### PR TITLE
fix rhat generic-method conflict

### DIFF
--- a/R/rhat.R
+++ b/R/rhat.R
@@ -8,7 +8,7 @@
 #' @name rhat
 #' @order 1
 #'
-#' @param object An object of class \code{\link{bayesnecfit}} or
+#' @param x An object of class \code{\link{bayesnecfit}} or
 #' \code{\link{bayesmanecfit}}.
 #' @param rhat_cutoff A \code{\link[base]{numeric}} vector indicating the Rhat
 #' cut-off used to test for model convergence.
@@ -38,14 +38,14 @@ NULL
 #' @importFrom chk chk_numeric
 #'
 #' @export
-rhat.bayesnecfit <- function(object, rhat_cutoff = 1.05, ...) {
+rhat.bayesnecfit <- function(x, rhat_cutoff = 1.05, ...) {
   chk_numeric(rhat_cutoff)
-  rhat_vals <- pull_brmsfit(object) |>
+  rhat_vals <- pull_brmsfit(x) |>
     rhat() |>
     clean_rhat_names()
   failed <- any(rhat_vals > rhat_cutoff)
   out <- list(list(rhat_vals = rhat_vals, failed = failed))
-  names(out) <- object$model
+  names(out) <- x$model
   out
 }
 
@@ -59,12 +59,12 @@ rhat.bayesnecfit <- function(object, rhat_cutoff = 1.05, ...) {
 #' @importFrom brms rhat
 #'
 #' @export
-rhat.bayesmanecfit <- function(object, rhat_cutoff = 1.05, ...) {
-  out <- sapply(object$success_models, function(x, object, ...) {
-    pull_out(object, model = x) |>
+rhat.bayesmanecfit <- function(x, rhat_cutoff = 1.05, ...) {
+  out <- sapply(x$success_models, function(y, x, ...) {
+    pull_out(x, model = y) |>
       suppressMessages() |>
       rhat(...)
-  }, object = object, rhat_cutoff = rhat_cutoff, USE.NAMES = FALSE)
+  }, x = x, rhat_cutoff = rhat_cutoff, USE.NAMES = FALSE)
   failed <- sapply(out, "[[", "failed")
   if (all(failed)) {
     message("All models failed the rhat_cutoff of ", rhat_cutoff)

--- a/man/rhat.Rd
+++ b/man/rhat.Rd
@@ -6,12 +6,12 @@
 \alias{rhat.bayesmanecfit}
 \title{Extract Diagnostic Quantities of 'brms' Models}
 \usage{
-\method{rhat}{bayesnecfit}(object, rhat_cutoff = 1.05, ...)
+\method{rhat}{bayesnecfit}(x, rhat_cutoff = 1.05, ...)
 
-\method{rhat}{bayesmanecfit}(object, rhat_cutoff = 1.05, ...)
+\method{rhat}{bayesmanecfit}(x, rhat_cutoff = 1.05, ...)
 }
 \arguments{
-\item{object}{An object of class \code{\link{bayesnecfit}} or
+\item{x}{An object of class \code{\link{bayesnecfit}} or
 \code{\link{bayesmanecfit}}.}
 
 \item{rhat_cutoff}{A \code{\link[base]{numeric}} vector indicating the Rhat


### PR DESCRIPTION
This PR fixes an R check warning that will occur once brms 2.19 is on CRAN, which will tentatively happen in the next few days.