### PR TITLE
fix test setup to work with the latest brms

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -21,6 +21,10 @@ nec_data$count <- as.integer(round(nec_data$y * 20))
 nec_data$trials <- as.integer(20)
 nec_data$log_x <- log(nec_data$x)
 
+# ensure that the 'step' can be found during formula evaluation
+env <- environment(manec_example$mod_fits$nec4param$fit$formula$formula)
+assign("step", value = function(x) ifelse(x > 0, 1, 0), pos = env)
+
 data(manec_example)
 nec4param <- pull_out(manec_example, model = "nec4param") |>
   suppressMessages() |>


### PR DESCRIPTION
In the current brms github version (soon to be on CRAN), your test setup fails because it uses the internal `step` function of brms in one of its formulas. Due to a change in how non-linear formulas search for their variables, `brms:::step` is no longer in the search path and I have yet to find a good and safe approach to include it there. 

This PR provides a little fix for the resulting problem in your test setup.