### PR TITLE
declare modelbased dependency in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,8 @@ Imports:
     tidyselect,
     evaluate,
     rlang,
-    chk (>= 0.7.0)
+    chk (>= 0.7.0),
+    modelbased
 Suggests:
     rstan,
     knitr,


### PR DESCRIPTION
nsec_fct imports modelbased::zero_crossings (in NAMESPACE) but modelbased was never added to Imports, causing R CMD check to ERROR at the dependency stage on all CI runs.

# Declare `modelbased` dependency in DESCRIPTION

**Branch:** `fix_modelbased_dependency` → **base:** `dev`

## Summary

R CMD check is failing on **all** CI runs at the dependency stage:

```
* checking package dependencies ... ERROR
Error: Namespace dependency missing from DESCRIPTION Imports/Depends entries: ‘modelbased’
```

`R/nsec.R` uses `modelbased::zero_crossings` (`nsec_fct`, via
`#' @importFrom modelbased zero_crossings`), so `modelbased` is in `NAMESPACE`,
but it was never added to `DESCRIPTION`. This is a hard ERROR that aborts the
check before tests run, which is why every platform/run is red.

## Change

Add `modelbased` to `DESCRIPTION` Imports (one line). Verified that this is the
only `importFrom` package missing from DESCRIPTION, so it fully resolves the
dependency ERROR.

## Notes / follow-ups

- This declares the dependency as-is to unblock CI without changing any behaviour.
- There is a separate, pre-existing test failure (`test-check_priors.R`, ggplot2 4.0
  S7 class change) handled in branch `fix_ggplot_class_tests`; both are needed for a
  green run.
- While confirming the dependency, we found that `modelbased::zero_crossings()` can
  silently miss closely-spaced / narrow zero crossings (it samples a fixed 100-point
  grid), which can cause `nsec` to overestimate the first crossing. This is being
  raised separately as a methods follow-up (reprex prepared) — not addressed here.
