### PR TITLE
fix check_priors test for ggplot2 4.0 S7 classes

### DIFF
--- a/tests/testthat/test-check_priors.R
+++ b/tests/testthat/test-check_priors.R
@@ -5,7 +5,10 @@ test_that("returns ggplot for bayesnecfit objects", {
   p <- check_priors(nec4param)
   expect_error(print(p), NA)
   expect_silent(check_priors(nec4param))
-  expect_equal(class(p), c("gg", "ggplot"))
+  # Check inheritance rather than the exact class vector: ggplot2 >= 4.0 builds
+  # plots as S7 objects, so class(p) gained extra entries ("ggplot2::ggplot",
+  # "S7_object", ...) and an exact-equality test breaks across versions.
+  expect_s3_class(p, "ggplot")
 })
 
 test_that("returns pdf for bayesmanecfit objects", {


### PR DESCRIPTION
Use expect_s3_class() inheritance check instead of exact class() equality, which broke under ggplot2 >= 4.0 where plots became S7 objects.

# Fix `check_priors` test for ggplot2 4.0 (S7) class change

**Branch:** `fix_ggplot_class_tests` → **base:** `dev`

## Summary

`tests/testthat/test-check_priors.R` asserted the exact class vector of a ggplot
object:

```r
expect_equal(class(p), c("gg", "ggplot"))
```

As of **ggplot2 4.0**, plots are built as **S7** objects, so `class(p)` now returns
`c("ggplot2::ggplot", "ggplot", "ggplot2::gg", "S7_object", "gg")`. The exact-equality
test therefore fails on any machine with ggplot2 >= 4.0 — including GitHub Actions —
while still passing on older ggplot2. This is the (or a) cause of the current CI red,
and is unrelated to the package's own code.

## Change

Single line in `tests/testthat/test-check_priors.R`: replace the exact class-vector
comparison with an inheritance check that is stable across ggplot2 versions:

```r
expect_s3_class(p, "ggplot")
```

## Why this is the right fix

- `inherits(p, "ggplot")` is `TRUE` under both old (S3) and new (S7) ggplot2, so the
  test now passes regardless of ggplot2 version.
- This was the **only** brittle ggplot class assertion in the suite — a grep of all
  `expect_equal(class(...))` / `expect_identical(class(...))` calls confirms every other
  one targets `matrix`/`array`/`list`/`brmsfit`/`data.frame`/summary classes, none of
  which are affected by the S7 change. There are no dedicated plot/autoplot test files
  with similar assertions.

## Verification

Ran the affected test against the working tree with `NOT_CRAN=true` (so the
`skip_on_cran()` guard does not skip it) under ggplot2 4.0.3 — passes.

## Scope

Test-only change. No package code, docs, or NAMESPACE touched. Independent of the
`fix_priors` and `fix_ecnsec` PRs.
