### PR TITLE
Fix `beta_binomial(link = "identity")` init failure

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ cache/
 
 tests/*.rds
 tests/*.rda
+# Written by plotting tests when a device is opened without one being requested.
+tests/testthat/Rplots.pdf
 
 # package development
 bayesnec.Rcheck/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bayesnec
 Title: A Bayesian No-Effect- Concentration (NEC) Algorithm
-Version: 2.1.3.2
+Version: 2.1.3.3
 Authors@R: c(person("Rebecca", "Fisher", email = "r.fisher@aims.gov.au", role = c("aut", "cre"),comment = c(ORCID = "0000-0001-5148-6731")), person("Diego R.","Barneche",role="aut",comment = c(ORCID = "0000-0002-4568-2362")), person("Gerard F.","Ricardo",role="aut",comment = c(ORCID = "0000-0002-2220-3971")), person("David R.","Fox",role="aut",comment = c(ORCID = "0000-0002-3178-7243")))
 Description: Implementation of No-Effect-Concentration estimation that uses 'brms' (see Burkner (2017)<doi:10.18637/jss.v080.i01>; Burkner (2018)<doi:10.32614/RJ-2018-017>; Carpenter 'et al.' (2017)<doi:10.18637/jss.v076.i01> to fit concentration(dose)-response data using Bayesian methods for the purpose of estimating 'ECx' values, but more particularly 'NEC' (see Fox (2010)<doi:10.1016/j.ecoenv.2009.09.012>), 'NSEC' (see Fisher and Fox (2023)<doi:10.1002/etc.5610>), and 'N(S)EC (see Fisher et al. 2023<doi:10.1002/ieam.4809>). A full description of this package can be found in Fisher 'et al.' (2024)<doi:10.18637/jss.v110.i05>. This package expands and supersedes an original version implemented in 'R2jags' (see Su and Yajima (2020)<https://CRAN.R-project.org/package=R2jags>; Fisher et al. (2020)<doi:10.5281/ZENODO.3966864>).
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,20 @@
+# bayesnec 2.1.3.3
+
+- Fixed initialisation failure for 0, 1 bounded families under an identity
+  link. `response_link_scale()` handled only the `logit` and `log` links, so
+  under `link = "identity"` the response was returned unchanged — exact `0`s
+  and `1`s included. Those bounds propagated into the init-finder's range
+  check, which a decaying curve can essentially never satisfy, and into the
+  likelihood itself, where a `beta_binomial` mean of exactly `0` gives an
+  infinite log-probability. Every initialisation attempt was rejected. The
+  identity link now applies the same clamping the `logit` branch already did.
+  See [#162](https://github.com/open-AIMS/bayesnec/issues/162).
+- `make_good_inits()` gains a rescue step. When a full random draw falls
+  outside the valid response range, individual parameters are re-drawn from
+  their own priors while the rest are held fixed, rather than the whole trial
+  being counted as a loss. Models that previously fell back to Stan's random
+  initialisation — `nechorme` among them — are now reliably initialised.
+
 # bayesnec 2.1.3.2
 
 - Added a `prior_type` argument to `bnec()` and `amend()` for selecting the set

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -82,8 +82,10 @@ extract_waic_estimate <- function(x) {
 
 #' @noRd
 w_nec_calc <- function(index, mod_fits, sample_size, mod_stats) {
-  sample(mod_fits[[index]]$ne_posterior,
-         as.integer(round(sample_size * mod_stats[index, "wi"])))
+  sample(
+    mod_fits[[index]]$ne_posterior,
+    as.integer(round(sample_size * mod_stats[index, "wi"]))
+  )
 }
 
 #' @noRd
@@ -137,14 +139,18 @@ handle_set <- function(x, add, drop) {
     }
     tmp <- setdiff(tmp, y)
     if (length(tmp) == 0) {
-      stop("All models removed, nothing to return;\n",
-           "Perhaps try calling function bnec with another ",
-           "model set.")
+      stop(
+        "All models removed, nothing to return;\n",
+        "Perhaps try calling function bnec with another ",
+        "model set."
+      )
     }
   }
   if (identical(sort(x), sort(tmp))) {
-    message("Nothing to amend, please specify a model to ",
-            "either add or drop that differs from the original set.")
+    message(
+      "Nothing to amend, please specify a model to ",
+      "either add or drop that differs from the original set."
+    )
     "wrong_model_output"
   } else {
     tmp
@@ -199,13 +205,13 @@ get_init_predictions <- function(y, x, fct, .args) {
 
 #' @noRd
 check_init_predictions <- function(x, limits) {
-    min(x) > min(limits) & 
+  min(x) > min(limits) &
     max(x) < max(limits) &
     !any(is.na(x)) &
-    !any(is.infinite(x)) & 
-    !any(is.nan(x)) & 
-    x[1]>x[length(x)] &
-    length(unique(x))>3 
+    !any(is.infinite(x)) &
+    !any(is.nan(x)) &
+    x[1] > x[length(x)] &
+    length(unique(x)) > 3
 }
 
 #' @noRd
@@ -266,7 +272,7 @@ print_mat <- function(x, digits = 2) {
 
 #' @noRd
 clean_mod_weights <- function(x) {
-  a <- x$mod_stats[, !sapply(x$mod_stats, function(z)all(is.na(z)))]
+  a <- x$mod_stats[, !sapply(x$mod_stats, function(z) all(is.na(z)))]
   as.matrix(a[, -1])
 }
 
@@ -318,7 +324,7 @@ contains_negative <- function(x) {
 response_link_scale <- function(response, family) {
   link_tag <- family$link
   min_z_val <- min(response[which(response > 0)]) / 100
-  if (link_tag == "logit") {  
+  if (link_tag == "logit") {
     max_o_val <- max(response[which(response < 1)]) +
       (1 - max(response[which(response < 1)])) * 0.99
   }
@@ -338,6 +344,21 @@ response_link_scale <- function(response, family) {
         response <- lr(response, r_out = c(min_z_val, max(response)))
       }
       response <- family$linkfun(response)
+    }
+  } else if (
+    link_tag == "identity" &&
+      family$family %in% c("bernoulli", "binomial", "beta_binomial", "beta")
+  ) {
+    # For identity-link bounded families, mu must be strictly in (0, 1).
+    # Clamp response away from the boundaries so that initial values
+    # derived from it stay within the valid support.
+    if (contains_zero(response)) {
+      response <- lr(response, r_out = c(min_z_val, max(response)))
+    }
+    if (contains_one(response)) {
+      max_o_val <- max(response[which(response < 1)]) +
+        (1 - max(response[which(response < 1)])) * 0.99
+      response <- lr(response, r_out = c(min(response), max_o_val))
     }
   }
   response
@@ -400,7 +421,9 @@ summarise_posterior <- function(mat, x_vec) {
 
 #' @noRd
 is_character <- function(x) {
-  if (is.na(x)) x <- as.character(x)
+  if (is.na(x)) {
+    x <- as.character(x)
+  }
   is.character(x)
 }
 
@@ -448,28 +471,40 @@ retrieve_var <- function(data, var, error = FALSE) {
   out <- try(data[[v_pos]], silent = TRUE)
   if (inherits(out, "try-error")) {
     if (error) {
-      stop("The input variable \"", bnec_vars[[var]],
-           "\" was not properly specified in formula. See ?bayesnecformula")
+      stop(
+        "The input variable \"",
+        bnec_vars[[var]],
+        "\" was not properly specified in formula. See ?bayesnecformula"
+      )
     }
     NULL
   } else if (is.numeric(out)) {
     if (!is.vector(out)) {
-      message("You most likely provided a function to transform your \"",
-              bnec_vars[[var]], "\" that does not return a vector. This is",
-              " likely to cause issues with sampling in Stan. ",
-              " Forcing it to be a vector...")
+      message(
+        "You most likely provided a function to transform your \"",
+        bnec_vars[[var]],
+        "\" that does not return a vector. This is",
+        " likely to cause issues with sampling in Stan. ",
+        " Forcing it to be a vector..."
+      )
     }
     as.vector(out)
   } else {
-    stop("The input variable \"", bnec_vars[[var]],
-         "\" is not numeric.")
+    stop("The input variable \"", bnec_vars[[var]], "\" is not numeric.")
   }
 }
 
 #' @noRd
-add_brm_defaults <- function(brm_args, model, family, predictor, response,
-                             skip_check, custom_name,
-                             prior_type = "uninformative") {
+add_brm_defaults <- function(
+  brm_args,
+  model,
+  family,
+  predictor,
+  response,
+  skip_check,
+  custom_name,
+  prior_type = "uninformative"
+) {
   if (!("chains" %in% names(brm_args))) {
     brm_args$chains <- 4
   }
@@ -484,24 +519,39 @@ add_brm_defaults <- function(brm_args, model, family, predictor, response,
   }
   priors <- try(validate_priors(brm_args$prior, model), silent = TRUE)
   if (inherits(priors, "try-error")) {
-    brm_args$prior <- define_prior(model, family, predictor, response,
-                                   prior_type = prior_type)
+    brm_args$prior <- define_prior(
+      model,
+      family,
+      predictor,
+      response,
+      prior_type = prior_type
+    )
   } else {
     brm_args$prior <- priors
   }
   if (!("init" %in% names(brm_args)) || skip_check) {
     msg_tag <- family$family
-    message(paste0("Finding initial values which allow the response to be",
-                   " fitted using a ", model, " model and a ", msg_tag,
-                   " distribution."))
+    message(paste0(
+      "Finding initial values which allow the response to be",
+      " fitted using a ",
+      model,
+      " model and a ",
+      msg_tag,
+      " distribution."
+    ))
     response_link <- response_link_scale(response, family)
     init_seed <- NULL
     if ("seed" %in% names(brm_args)) {
       init_seed <- brm_args$seed
     }
-    inits <- make_good_inits(model, predictor, response_link,
-                             priors = brm_args$prior, chains = brm_args$chains,
-                             seed = init_seed)
+    inits <- make_good_inits(
+      model,
+      predictor,
+      response_link,
+      priors = brm_args$prior,
+      chains = brm_args$chains,
+      seed = init_seed
+    )
     if (length(inits) == 1 && "random" %in% names(inits)) {
       inits <- inits$random
     }
@@ -532,8 +582,12 @@ has_family_changed <- function(x, data, ...) {
     model <- check_models(model, family, bdat)
     checked_df <- check_data(data = bdat, family = family, model = model)
   }
-  out <- all.equal(checked_df$family, x[[1]]$fit$family,
-                   check.attributes = FALSE, check.environment = FALSE)
+  out <- all.equal(
+    checked_df$family,
+    x[[1]]$fit$family,
+    check.attributes = FALSE,
+    check.environment = FALSE
+  )
   if (is.logical(out)) {
     FALSE
   } else {
@@ -568,7 +622,9 @@ find_transformations <- function(data) {
 cleaned_brms_summary <- function(brmsfit) {
   brmssummary <- summary(brmsfit, robust = TRUE)
   rownames(brmssummary$fixed) <- gsub(
-    "\\_Intercept$", "", rownames(brmssummary$fixed)
+    "\\_Intercept$",
+    "",
+    rownames(brmssummary$fixed)
   )
   brmssummary
 }
@@ -589,8 +645,10 @@ check_data_equality <- function(mod_fits) {
     Reduce(f = identical_value) |>
     is.matrix()
   if (!data_are_equal) {
-    stop("Dataset values differ across fits. Datasets need to be identical ",
-         "across the multiple fits.")
+    stop(
+      "Dataset values differ across fits. Datasets need to be identical ",
+      "across the multiple fits."
+    )
   }
   # this second check is needed for cases where a function is passed onto
   # one of the model variables via the formula, e.g. crf(log(x), ...)
@@ -604,8 +662,10 @@ check_data_equality <- function(mod_fits) {
     Reduce(f = identical_value) |>
     is.character()
   if (!cols_are_equal) {
-    stop("Dataset column names differ across fits. Datasets need to be ",
-         "identical across the multiple fits.")
+    stop(
+      "Dataset column names differ across fits. Datasets need to be ",
+      "identical across the multiple fits."
+    )
   }
 }
 
@@ -615,7 +675,7 @@ check_args_newdata <- function(resolution, x_range) {
   chk_numeric(resolution)
   if (!is.na(x_range[1])) {
     chk_numeric(x_range)
-  }  
+  }
 }
 
 #' @noRd
@@ -634,8 +694,14 @@ newdata_eval <- function(object, resolution, x_range) {
 }
 
 #' @noRd
-newdata_eval_fitted <- function(object, resolution, x_range, make_newdata,
-                                fct_eval, ...) {
+newdata_eval_fitted <- function(
+  object,
+  resolution,
+  x_range,
+  make_newdata,
+  fct_eval,
+  ...
+) {
   # Just need one model to extract and generate data
   # since all models are considered to have the exact same raw data.
   if (inherits(object, "bayesmanecfit")) {
@@ -646,17 +712,26 @@ newdata_eval_fitted <- function(object, resolution, x_range, make_newdata,
   bnec_pop_vars <- attr(data, "bnec_pop")
   dot_list <- list(...)
   if ("newdata" %in% names(dot_list) && make_newdata) {
-    stop("You cannot provide a \"newdata\" argument and set",
-         " make_newdata = TRUE at the same time. Please use one or another.",
-         " See details in help file ?", fct_eval)
+    stop(
+      "You cannot provide a \"newdata\" argument and set",
+      " make_newdata = TRUE at the same time. Please use one or another.",
+      " See details in help file ?",
+      fct_eval
+    )
   }
   if (!("newdata" %in% names(dot_list))) {
     if (make_newdata) {
-      newdata <- bnec_newdata(object, resolution = resolution, x_range = x_range)
+      newdata <- bnec_newdata(
+        object,
+        resolution = resolution,
+        x_range = x_range
+      )
       x_vec <- newdata[[bnec_pop_vars[["x_var"]]]]
       if ("re_formula" %in% names(dot_list)) {
-        message("Argument \"re_formula\" ignored and set to NA because",
-                " function bnec_newdata cannot guess random effect structure.")
+        message(
+          "Argument \"re_formula\" ignored and set to NA because",
+          " function bnec_newdata cannot guess random effect structure."
+        )
       }
       re_formula <- NA
     } else {
@@ -679,8 +754,12 @@ newdata_eval_fitted <- function(object, resolution, x_range, make_newdata,
       re_formula <- dot_list$re_formula
     }
   }
-  list(newdata = newdata, x_vec = x_vec, resolution = resolution,
-       re_formula = re_formula)
+  list(
+    newdata = newdata,
+    x_vec = x_vec,
+    resolution = resolution,
+    re_formula = re_formula
+  )
 }
 
 #' step

--- a/R/inits_functions.R
+++ b/R/inits_functions.R
@@ -79,6 +79,70 @@ make_inits <- function(model, fct_args, priors, chains) {
   out
 }
 
+#' refine_inits
+#'
+#' For a single chain's init list that fails prediction checks, attempt to
+#' fix it by re-drawing one parameter at a time while holding the others
+#' fixed.  Targets \code{slope}, \code{d} and \code{beta} -- the parameters
+#' most likely to push hormesis / sigmoidal predictions out of range.
+#'
+#' @param init A named \code{\link[base]{list}} of init values for one chain.
+#' @param x Sorted predictor values.
+#' @param pred_fct The prediction function for the model.
+#' @param fct_args Parameter names expected by the prediction function.
+#' @param limits A length-2 \code{\link[base]{numeric}} vector (response range).
+#' @param priors A \code{\link[base]{data.frame}} of priors (already filtered
+#'   to non-empty rows).
+#' @param n_sub Maximum number of single-parameter re-draws per parameter.
+#'
+#' @return The (possibly improved) init list.
+#' @noRd
+refine_inits <- function(init, x, pred_fct, fct_args, limits,
+                         priors, n_sub = 500) {
+  fcts <- c(gamma = rgamma,
+            normal = rnorm,
+            beta = rbeta,
+            uniform = runif)
+  preds <- get_init_predictions(init, x, pred_fct, fct_args)
+  if (check_init_predictions(preds, limits)) {
+    return(init)
+  }
+  # refine_inits nudges a finite-but-out-of-range curve back into range by
+  # re-drawing slope/d/beta. Non-finite predictions signal a structural
+  # problem instead -- e.g. models that raise the predictor to a fractional
+  # power (nechormepwr, nechorme4pwr, ecxsigm) return NaN wherever x < 0, for
+  # every parameter draw. No re-draw fixes that, so bail early rather than
+  # burn the full n_sub search on a hopeless case.
+  if (!all(is.finite(preds))) {
+    return(init)
+  }
+  # Identify tunable parameters (slope, d, beta -- those most likely
+  # to push predictions out of range in hormesis / sigmoidal models).
+  tunable <- intersect(names(init), c("b_slope", "b_d", "b_beta"))
+  for (par in tunable) {
+    pr_row <- which(priors$nlpar == gsub("^b_", "", par))
+    if (length(pr_row) != 1) next
+    bits <- gsub("\\(|\\)", ",", priors$prior[pr_row])
+    bits <- strsplit(bits, ",", fixed = TRUE)[[1]]
+    fct_i <- bits[1]
+    v1 <- as.numeric(bits[2])
+    v2 <- as.numeric(bits[3])
+    for (k in seq_len(n_sub)) {
+      candidate <- init
+      new_val <- fcts[[fct_i]](1, v1, v2)
+      if (priors$class[pr_row] == "b") {
+        dim(new_val) <- 1
+      }
+      candidate[[par]] <- new_val
+      preds <- get_init_predictions(candidate, x, pred_fct, fct_args)
+      if (check_init_predictions(preds, limits)) {
+        return(candidate)
+      }
+    }
+  }
+  init
+}
+
 #' make_good_inits
 #'
 #' Creates list of initialisation values that generate
@@ -103,16 +167,27 @@ make_good_inits <- function(model, x, y, n_trials = 1e4, seed = NULL, ...) {
   pred_fct <- get(paste0("pred_", model))
   fct_args <- names(unlist(as.list(args(pred_fct))))
   fct_args <- setdiff(fct_args, "x")
+  dots <- list(...)
+  priors_df <- as.data.frame(dots$priors)
+  priors_df <- priors_df[priors_df$prior != "", ]
   set.seed(seed)
   inits <- make_inits(model, fct_args, ...)
   init_ranges <- lapply(inits, get_init_predictions, sort(x), pred_fct, fct_args)
   are_good <- all(sapply(init_ranges, check_init_predictions, limits))
   n_t <- 1
   while (!are_good && n_t <= n_trials) {
-    #if (!is.null(seed)) {set.seed(seed + n_t)}
     inits <- make_inits(model, fct_args, ...)
     init_ranges <- lapply(inits, get_init_predictions, sort(x), pred_fct, fct_args)
     are_good <- all(sapply(init_ranges, check_init_predictions, limits))
+    # If the full draw failed, try to fix each chain by re-drawing
+    # one problematic parameter at a time (slope, d, beta).
+    if (!are_good) {
+      inits <- lapply(inits, refine_inits, sort(x), pred_fct, fct_args,
+                      limits, priors_df)
+      init_ranges <- lapply(inits, get_init_predictions, sort(x),
+                            pred_fct, fct_args)
+      are_good <- all(sapply(init_ranges, check_init_predictions, limits))
+    }
     n_t <- n_t + 1
   }
   if (!are_good) {

--- a/R/inits_functions.R
+++ b/R/inits_functions.R
@@ -108,12 +108,14 @@ refine_inits <- function(init, x, pred_fct, fct_args, limits,
     return(init)
   }
   # refine_inits nudges a finite-but-out-of-range curve back into range by
-  # re-drawing slope/d/beta. Non-finite predictions signal a structural
-  # problem instead -- e.g. models that raise the predictor to a fractional
-  # power (nechormepwr, nechorme4pwr, ecxsigm) return NaN wherever x < 0, for
-  # every parameter draw. No re-draw fixes that, so bail early rather than
-  # burn the full n_sub search on a hopeless case.
-  if (!all(is.finite(preds))) {
+  # re-drawing slope/d/beta. NaN predictions signal a structural problem
+  # instead -- e.g. models that raise the predictor to a fractional power
+  # (nechormepwr, nechorme4pwr, ecxsigm) return NaN wherever x < 0, for every
+  # parameter draw. No re-draw fixes that, so bail early rather than burn the
+  # full n_sub search on a hopeless case. We test NaN specifically rather than
+  # all non-finite values: Inf from numerical overflow can sometimes be cured
+  # by re-drawing a parameter smaller, so those are left for the search below.
+  if (any(is.nan(preds))) {
     return(init)
   }
   # Identify tunable parameters (slope, d, beta -- those most likely

--- a/tests/testthat/test-inits_functions.R
+++ b/tests/testthat/test-inits_functions.R
@@ -134,19 +134,35 @@ get_pred_fct_args <- function(model) {
 # -- make_good_inits across models and prior types ---------------------------
 # Models valid for beta_binomial + identity (excludes neclin, neclinhorme,
 # ecxlin which are dropped by check_models for this family/link combo).
+#
+# Some model/prior combos cannot find good inits within the default 10k
+# trials for this particular dataset --- their prediction curves exceed
+# the (0, 1) bounds due to hormesis slopes or sigmoidal shapes. These
+# are pre-existing limitations, not caused by the identity-link fix.
+# We split models into those expected to succeed and those that may
+# fall back to Stan's random initialisation.
 
-bb_identity_models <- c(
+# Models that reliably find good inits for both prior types
+bb_models_expected_pass <- c(
   "nec3param", "nec4param",
-  "nechorme", "nechorme4", "necsigm",
-  "nechormepwr", "nechorme4pwr", "nechormepwr01",
-  "ecxexp", "ecxsigm",
+  "nechorme4", "necsigm",
+  "nechormepwr01",
+  "ecxexp",
   "ecx4param", "ecxwb1", "ecxwb2",
   "ecxwb1p3", "ecxwb2p3",
   "ecxll5", "ecxll4", "ecxll3",
   "ecxhormebc4", "ecxhormebc5"
 )
 
-for (mod in bb_identity_models) {
+# Models whose prediction curves regularly exceed (0, 1) for this dataset,
+# making it very hard or impossible to find valid inits within 10k trials.
+# These fall back to Stan's default random initialisation. This is
+# pre-existing behaviour, not a regression from the identity-link fix.
+bb_models_may_fail <- c(
+  "nechorme", "nechormepwr", "nechorme4pwr", "ecxsigm"
+)
+
+for (mod in bb_models_expected_pass) {
   for (pt in c("uninformative", "regularizing")) {
     test_that(
       paste0("make_good_inits succeeds for ", mod,
@@ -175,6 +191,38 @@ for (mod in bb_identity_models) {
           info = paste("Chain", i, "predictions out of (0,1) for",
                        mod, pt)
         )
+      }
+    })
+  }
+}
+
+# Models that may fall back to random: just verify they don't error and
+# that when inits ARE found, predictions stay in (0, 1)
+for (mod in bb_models_may_fail) {
+  for (pt in c("uninformative", "regularizing")) {
+    test_that(
+      paste0("make_good_inits does not error for ", mod,
+             " with ", pt, " priors (issue #162 data)"), {
+      inits <- run_init_test(mod, prior_type = pt)
+
+      # May be random or valid inits --- either is acceptable
+      expect_type(inits, "list")
+
+      # If inits were found, predictions must be in (0, 1)
+      if (!identical(inits, list(random = "random"))) {
+        pred_fct <- get(paste0("pred_", mod),
+                        envir = asNamespace("bayesnec"))
+        fct_args <- get_pred_fct_args(mod)
+        for (i in seq_along(inits)) {
+          preds <- bayesnec:::get_init_predictions(
+            inits[[i]], sort(bb_predictor), pred_fct, fct_args
+          )
+          expect_true(
+            all(preds > 0 & preds < 1),
+            info = paste("Chain", i, "predictions out of (0,1) for",
+                         mod, pt)
+          )
+        }
       }
     })
   }

--- a/tests/testthat/test-inits_functions.R
+++ b/tests/testthat/test-inits_functions.R
@@ -157,16 +157,16 @@ bb_models_expected_pass <- c(
   "ecxhormebc4", "ecxhormebc5"
 )
 
-# Models that cannot find valid inits for this dataset and fall back to Stan's
-# default random initialisation. This is a structural incompatibility, not a
-# regression from the identity-link fix, and refine_inits() cannot rescue it:
-# these models raise the predictor x to a fractional power (nechormepwr and
-# nechorme4pwr use x^(1/(1+exp(b_slope))); ecxsigm uses x^exp(b_d)). The
-# predictor here is log(mgL + 0.1), which is negative for low concentrations,
-# and a negative base with a non-integer exponent is NaN in R for every
-# parameter draw. No init re-draw changes the predictor, so these always fall
-# back to random.
-bb_models_may_fail <- c(
+# Models that are structurally invalid for this dataset: they raise the
+# predictor x to a fractional power (nechormepwr and nechorme4pwr use
+# x^(1/(1+exp(b_slope))); ecxsigm uses x^exp(b_d)). The predictor here is
+# log(mgL + 0.1), which is negative for low concentrations, and a negative
+# base with a non-integer exponent is NaN in R for every parameter draw --- no
+# init could fix this because the same term is evaluated in Stan. bnec() never
+# reaches init-finding for them: check_models() drops them upstream whenever
+# the predictor contains negative values. The test below asserts that
+# behaviour rather than exercising make_good_inits() on a path bnec() prevents.
+bb_models_negative_x <- c(
   "nechormepwr", "nechorme4pwr", "ecxsigm"
 )
 
@@ -204,34 +204,22 @@ for (mod in bb_models_expected_pass) {
   }
 }
 
-# Models that may fall back to random: just verify they don't error and
-# that when inits ARE found, predictions stay in (0, 1)
-for (mod in bb_models_may_fail) {
-  for (pt in c("uninformative", "regularizing")) {
-    test_that(
-      paste0("make_good_inits does not error for ", mod,
-             " with ", pt, " priors (issue #162 data)"), {
-      inits <- run_init_test(mod, prior_type = pt)
+# The fractional-power models never reach init-finding for this dataset:
+# check_models() drops them upstream because the predictor contains negative
+# values. Assert that upstream guard directly (this is the behaviour that
+# protects make_good_inits() from ever seeing them via bnec()).
+test_that("check_models drops fractional-power models for negative predictors", {
+  form <- bnf(y | trials(trials) ~ crf(log.x, "nec3param"))
+  bdat <- model.frame(form, dat_real)
 
-      # May be random or valid inits --- either is acceptable
-      expect_type(inits, "list")
+  requested <- c(bb_models_negative_x, "nec3param", "ecxexp")
+  kept <- suppressMessages(
+    bayesnec:::check_models(requested, bb_family, bdat)
+  )
 
-      # If inits were found, predictions must be in (0, 1)
-      if (!identical(inits, list(random = "random"))) {
-        pred_fct <- get(paste0("pred_", mod),
-                        envir = asNamespace("bayesnec"))
-        fct_args <- get_pred_fct_args(mod)
-        for (i in seq_along(inits)) {
-          preds <- bayesnec:::get_init_predictions(
-            inits[[i]], sort(bb_predictor), pred_fct, fct_args
-          )
-          expect_true(
-            all(preds > 0 & preds < 1),
-            info = paste("Chain", i, "predictions out of (0,1) for",
-                         mod, pt)
-          )
-        }
-      }
-    })
-  }
-}
+  # The three fractional-power models are dropped ...
+  expect_false(any(bb_models_negative_x %in% kept),
+               info = "fractional-power models must be dropped for negative x")
+  # ... while models valid for negative predictors are retained.
+  expect_true(all(c("nec3param", "ecxexp") %in% kept))
+})

--- a/tests/testthat/test-inits_functions.R
+++ b/tests/testthat/test-inits_functions.R
@@ -1,0 +1,181 @@
+# Regression tests for GitHub issue #162
+# beta_binomial + identity link: initial values must stay within (0, 1)
+
+# -- Shared test data (issue #162 reprex) ------------------------------------
+
+dat_real <- structure(
+  list(
+    mgL = c(
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      4.094250037, 4.094250037, 4.094250037, 4.094250037, 4.094250037,
+      6.896245775, 6.896245775, 6.896245775, 6.896245775, 6.896245775,
+      12.75631805, 12.75631805, 12.75631805, 12.75631805, 12.75631805,
+      23.23869006, 23.23869006, 23.23869006, 23.23869006, 23.23869006,
+      35.13868903, 35.13868903, 35.13868903, 35.13868903, 35.13868903,
+      57.21608294, 57.21608294, 57.21608294, 57.21608294, 57.21608294,
+      80.27771977, 80.27771977, 80.27771977, 80.27771977, 80.27771977,
+      153.6317617, 153.6317617, 153.6317617, 153.6317617, 153.6317617,
+      232.3389074, 232.3389074, 232.3389074, 232.3389074, 232.3389074,
+      311.490013,  311.490013,  311.490013,  311.490013,  311.490013
+    ),
+    prop = c(
+      0.911, 0.948, 0.967, 0.99, 0.953,
+      0.913, 0.879, 0.926, 0.969, 0.927,
+      0.973, 0.927, 0.957, 0.936, 0.97,
+      0.946, 0.906, 0.927, 0.919, 0.829,
+      0.964, 0.95,  0.918, 0.907, 0.971,
+      0.933, 0.943, 0.971, 0.943, 0.934,
+      0.831, 0.96,  0.935, 0.926, 0.844,
+      0.968, 0.982, 0.945, 0.939, 0.964,
+      0.856, 0.901, 0.851, 0.747, 0.917,
+      0.626, 0.678, 0.832, 0.83,  0.596,
+      0,     0.059, 0.064, 0,     0.056,
+      0.011, 0,     0.011, 0,     0
+    ),
+    trials = c(
+      90L, 96L, 91L, 105L, 86L, 103L, 99L, 95L, 98L, 110L,
+      113L, 96L, 92L, 78L, 99L, 93L, 96L, 96L, 86L, 82L,
+      111L, 101L, 85L, 118L, 102L, 104L, 105L, 105L, 106L, 91L,
+      83L, 101L, 93L, 95L, 90L, 95L, 109L, 110L, 114L, 112L,
+      90L, 91L, 101L, 95L, 96L, 91L, 90L, 95L, 106L, 94L,
+      94L, 68L, 94L, 94L, 107L, 94L, 93L, 89L, 105L, 99L
+    )
+  ),
+  class = "data.frame",
+  row.names = c(NA, -60L)
+)
+dat_real$y <- as.integer(round(dat_real$prop * dat_real$trials))
+dat_real$log.x <- log(dat_real$mgL + 0.1)
+
+bb_family    <- beta_binomial(link = "identity")
+bb_response  <- dat_real$y / dat_real$trials
+bb_predictor <- dat_real$log.x
+
+# -- response_link_scale unit tests ------------------------------------------
+
+test_that("response_link_scale clamps identity-link beta_binomial away from 0 and 1", {
+  response <- c(0, 0, 0.05, 0.5, 0.9, 0.95, 0.97, 1.0)
+  family <- beta_binomial(link = "identity")
+  result <- bayesnec:::response_link_scale(response, family)
+
+  expect_true(all(result > 0),
+              info = "All values should be strictly > 0 after clamping")
+  expect_true(all(result < 1),
+              info = "All values should be strictly < 1 after clamping")
+})
+
+test_that("response_link_scale clamps identity-link binomial away from 0 and 1", {
+  response <- c(0, 0.1, 0.5, 0.9, 1.0)
+  family <- binomial(link = "identity")
+  result <- bayesnec:::response_link_scale(response, family)
+
+  expect_true(all(result > 0))
+  expect_true(all(result < 1))
+})
+
+test_that("response_link_scale clamps identity-link beta away from 0 and 1", {
+  response <- c(0, 0.3, 0.7, 1.0)
+  family <- Beta(link = "identity")
+  result <- bayesnec:::response_link_scale(response, family)
+
+  expect_true(all(result > 0))
+  expect_true(all(result < 1))
+})
+
+test_that("response_link_scale is identity for identity-link families without boundary values", {
+  response <- c(0.2, 0.4, 0.6, 0.8)
+  family <- beta_binomial(link = "identity")
+  result <- bayesnec:::response_link_scale(response, family)
+
+  expect_equal(result, response,
+               info = "No clamping needed when response is already in (0, 1)")
+})
+
+test_that("response_link_scale only-zeros edge case stays in (0, 1)", {
+  response <- c(0, 0, 0, 0.01, 0.02)
+  family <- beta_binomial(link = "identity")
+  result <- bayesnec:::response_link_scale(response, family)
+
+  expect_true(all(result > 0))
+  expect_true(all(result < 1))
+})
+
+test_that("response_link_scale only-ones edge case stays in (0, 1)", {
+  response <- c(0.98, 0.99, 1.0, 1.0)
+  family <- beta_binomial(link = "identity")
+  result <- bayesnec:::response_link_scale(response, family)
+
+  expect_true(all(result > 0))
+  expect_true(all(result < 1))
+})
+
+# -- Helper to run the make_good_inits pipeline for a given model/prior ------
+
+run_init_test <- function(model, prior_type = "uninformative") {
+  response_link <- bayesnec:::response_link_scale(bb_response, bb_family)
+  priors <- bayesnec:::define_prior(model, bb_family, bb_predictor,
+                                    response_link,
+                                    prior_type = prior_type)
+  set.seed(42)
+  inits <- bayesnec:::make_good_inits(
+    model, bb_predictor, response_link,
+    priors = priors, chains = 4, seed = 42
+  )
+  inits
+}
+
+get_pred_fct_args <- function(model) {
+  pred_fct <- get(paste0("pred_", model),
+                  envir = asNamespace("bayesnec"))
+  fct_args <- names(unlist(as.list(args(pred_fct))))
+  setdiff(fct_args, "x")
+}
+
+# -- make_good_inits across models and prior types ---------------------------
+# Models valid for beta_binomial + identity (excludes neclin, neclinhorme,
+# ecxlin which are dropped by check_models for this family/link combo).
+
+bb_identity_models <- c(
+  "nec3param", "nec4param",
+  "nechorme", "nechorme4", "necsigm",
+  "nechormepwr", "nechorme4pwr", "nechormepwr01",
+  "ecxexp", "ecxsigm",
+  "ecx4param", "ecxwb1", "ecxwb2",
+  "ecxwb1p3", "ecxwb2p3",
+  "ecxll5", "ecxll4", "ecxll3",
+  "ecxhormebc4", "ecxhormebc5"
+)
+
+for (mod in bb_identity_models) {
+  for (pt in c("uninformative", "regularizing")) {
+    test_that(
+      paste0("make_good_inits succeeds for ", mod,
+             " with ", pt, " priors (issue #162 data)"), {
+      inits <- run_init_test(mod, prior_type = pt)
+
+      # Should NOT fall back to random init
+      expect_false(
+        identical(inits, list(random = "random")),
+        info = paste("make_good_inits should find valid inits for",
+                     mod, "with", pt, "priors")
+      )
+      expect_type(inits, "list")
+      expect_length(inits, 4)
+
+      # Each chain's init predictions should be in (0, 1)
+      pred_fct <- get(paste0("pred_", mod),
+                      envir = asNamespace("bayesnec"))
+      fct_args <- get_pred_fct_args(mod)
+      for (i in seq_along(inits)) {
+        preds <- bayesnec:::get_init_predictions(
+          inits[[i]], sort(bb_predictor), pred_fct, fct_args
+        )
+        expect_true(
+          all(preds > 0 & preds < 1),
+          info = paste("Chain", i, "predictions out of (0,1) for",
+                       mod, pt)
+        )
+      }
+    })
+  }
+}

--- a/tests/testthat/test-inits_functions.R
+++ b/tests/testthat/test-inits_functions.R
@@ -142,10 +142,13 @@ get_pred_fct_args <- function(model) {
 # We split models into those expected to succeed and those that may
 # fall back to Stan's random initialisation.
 
-# Models that reliably find good inits for both prior types
+# Models that reliably find good inits for both prior types. nechorme is
+# rescued by refine_inits() (its hormesis slope term exp(b_slope) * x has no
+# fractional power, so re-drawing b_slope/b_beta can bring predictions into
+# range).
 bb_models_expected_pass <- c(
   "nec3param", "nec4param",
-  "nechorme4", "necsigm",
+  "nechorme", "nechorme4", "necsigm",
   "nechormepwr01",
   "ecxexp",
   "ecx4param", "ecxwb1", "ecxwb2",
@@ -154,12 +157,17 @@ bb_models_expected_pass <- c(
   "ecxhormebc4", "ecxhormebc5"
 )
 
-# Models whose prediction curves regularly exceed (0, 1) for this dataset,
-# making it very hard or impossible to find valid inits within 10k trials.
-# These fall back to Stan's default random initialisation. This is
-# pre-existing behaviour, not a regression from the identity-link fix.
+# Models that cannot find valid inits for this dataset and fall back to Stan's
+# default random initialisation. This is a structural incompatibility, not a
+# regression from the identity-link fix, and refine_inits() cannot rescue it:
+# these models raise the predictor x to a fractional power (nechormepwr and
+# nechorme4pwr use x^(1/(1+exp(b_slope))); ecxsigm uses x^exp(b_d)). The
+# predictor here is log(mgL + 0.1), which is negative for low concentrations,
+# and a negative base with a non-integer exponent is NaN in R for every
+# parameter draw. No init re-draw changes the predictor, so these always fall
+# back to random.
 bb_models_may_fail <- c(
-  "nechorme", "nechormepwr", "nechorme4pwr", "ecxsigm"
+  "nechormepwr", "nechorme4pwr", "ecxsigm"
 )
 
 for (mod in bb_models_expected_pass) {


### PR DESCRIPTION
**Closes:** #162

## Problem

Fitting a `nec3param` model with `beta_binomial(link = "identity")` fails with:

```
Chain 1: Initialization between (-2, 2) failed after 100 attempts.
```

### Root cause

`response_link_scale()` only handled `logit` and `log` links for bounded
families. When `link = "identity"`, the response was returned **unchanged** —
including exact `0` and `1` values from the raw proportions.

This caused two downstream failures:

1. **`make_good_inits()`** — the init-finder uses `limits <- range(y)` to
   validate candidate initial values via `check_init_predictions()`. With
   `min(limits) == 0`, the strict-inequality check `min(predictions) > 0` is
   nearly impossible to satisfy for NEC-type curves that decay toward zero at
   high concentrations.

2. **Stan** — even when initial values pass the R-side checks, the
   `beta_binomial` likelihood requires μ ∈ (0, 1) strictly. Init predictions
   that evaluate to exactly `0` (via floating-point underflow of
   `top * exp(-exp(beta) * ...)`) produce -∞ log-probability, causing Stan to
   reject every initialisation attempt.

## Changes

### `R/helpers.R` — `response_link_scale()`

Added an `else if` branch for `link == "identity"` when the family is
`bernoulli`, `binomial`, `beta_binomial`, or `beta`. It applies the same
`linear_rescale` clamping that already existed for the `logit` branch — pushing
exact `0`s slightly above zero and exact `1`s slightly below one — but
**without** applying a link transformation (since the link is identity).

This ensures that:

- `make_good_inits()` receives response values (and therefore `limits`) that
  are strictly within (0, 1), so the init-finder can reliably satisfy
  `check_init_predictions()`.
- The priors derived from the response range (via `define_prior()`) are
  computed on a valid scale.

> **Note on diff size:** most of the `helpers.R` diff is mechanical `air`
> reformatting (argument-per-line style, whitespace). The only behavioural
> change in this file is the new identity-link branch in
> `response_link_scale()`.

### `R/inits_functions.R` — new `refine_inits()` rescue step

Added `refine_inits()`, a rescue step used inside `make_good_inits()`. When a
full random init draw fails the `(0, 1)` prediction check, it re-draws one
parameter at a time (`b_slope`, `b_d`, `b_beta` — those most likely to push a
hormesis/sigmoidal curve out of range) while holding the rest fixed, and keeps
the first candidate whose predictions fall back into range.

`make_good_inits()` now:

- parses the supplied priors into a data frame (dropping empty rows) so that
  `refine_inits()` can re-draw individual parameters from their actual prior
  distributions (`gamma`, `normal`, `beta`, `uniform`); and
- calls `refine_inits()` on each chain after a failed full draw, before
  counting the trial as a loss.

`refine_inits()` bails out immediately when the failing predictions contain
`NaN` rather than merely being out of range. Its search only helps a
finite-but-out-of-range curve; `NaN` signals a structural problem no parameter
re-draw can fix (see the fractional-power models below), so skipping avoids
burning the full search on a hopeless case. The check is `any(is.nan(preds))`
specifically — not all non-finite values — because `Inf` from numerical
overflow can sometimes be cured by re-drawing a parameter smaller, so those
are left for the search. In practice this path is only reachable by calling
`make_good_inits()` directly; `bnec()` drops these models upstream (see
below).

A practical consequence: `nechorme`, which previously fell back to Stan's
random initialisation on the issue #162 data, is now reliably rescued by
`refine_inits()` for both prior types (its hormesis term `exp(b_slope) * x`
is finite everywhere, so re-drawing `b_slope`/`b_beta` can bring the curve
back into range).

### `tests/testthat/test-inits_functions.R` (new file)

**41 test blocks** across three sections, using the exact dataset from the
issue #162 reprex:

#### `response_link_scale` unit tests (6 tests)

| Test | What it checks |
|------|----------------|
| **beta_binomial + identity** | Exact `0` and `1` values clamped strictly into (0, 1) |
| **binomial + identity** | Same clamping for `binomial(link = "identity")` |
| **beta + identity** | Same clamping for `Beta(link = "identity")` |
| **No-op for interior values** | Response already in (0, 1) passes through unchanged |
| **Mostly-zeros edge case** | `c(0, 0, 0, 0.01, 0.02)` stays in (0, 1) |
| **Mostly-ones edge case** | `c(0.98, 0.99, 1.0, 1.0)` stays in (0, 1) |

#### `make_good_inits` across all models × both prior types (34 tests)

All 17 models that are valid for `beta_binomial(link = "identity")` *and*
structurally compatible with this dataset are tested with both
`"uninformative"` and `"regularizing"` prior types:

`nec3param`, `nec4param`, `nechorme`, `nechorme4`, `necsigm`,
`nechormepwr01`, `ecxexp`, `ecx4param`, `ecxwb1`, `ecxwb2`, `ecxwb1p3`,
`ecxwb2p3`, `ecxll5`, `ecxll4`, `ecxll3`, `ecxhormebc4`, `ecxhormebc5`.

For each combo the tests assert:

- `make_good_inits()` finds valid inits (no `"random"` fallback)
- 4 chains are produced
- All per-chain predictions fall strictly within (0, 1)

#### `check_models` drops fractional-power models for negative predictors (1 test)

`nechormepwr`, `nechorme4pwr`, and `ecxsigm` are **structurally incompatible**
with this dataset: all three raise the predictor `x` to a fractional power —
`nechormepwr`/`nechorme4pwr` use `x^(1/(1+exp(b_slope)))` and `ecxsigm` uses
`x^exp(b_d)`. The predictor here is `log(mgL + 0.1)`, which is **negative** at
low concentrations, and a negative base with a non-integer exponent is `NaN`
in R for *every* parameter draw — and the same term is evaluated in Stan, so
no init could fix it.

`bnec()` never reaches init-finding for them: `check_models()` drops them
upstream whenever the predictor contains negative values (via
`contains_negative()`). The test asserts that guard directly — the three are
dropped while models valid for negative predictors (`nec3param`, `ecxexp`)
are retained — rather than exercising `make_good_inits()` on a path `bnec()`
prevents.

## Verification

- `devtools::load_all()` + `testthat::test_file("test-inits_functions.R")`:
  **all 41 test blocks pass** (0 failures, 0 warnings, 0 skips).
- Full `devtools::test()`: exit 0, no failures (one pre-existing, unrelated
  warning in `test-define_prior.R:70`).
- Manual verification with the issue #162 reprex data confirms
  `make_good_inits()` now finds valid inits (including `nechorme` via
  `refine_inits()`), and that `check_models()` drops the three
  fractional-power models for this negative predictor.
