### PR TITLE
Add a `timeout` argument for individual model fits

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bayesnec
 Title: A Bayesian No-Effect- Concentration (NEC) Algorithm
-Version: 2.1.3.3
+Version: 2.1.3.4
 Authors@R: c(person("Rebecca", "Fisher", email = "r.fisher@aims.gov.au", role = c("aut", "cre"),comment = c(ORCID = "0000-0001-5148-6731")), person("Diego R.","Barneche",role="aut",comment = c(ORCID = "0000-0002-4568-2362")), person("Gerard F.","Ricardo",role="aut",comment = c(ORCID = "0000-0002-2220-3971")), person("David R.","Fox",role="aut",comment = c(ORCID = "0000-0002-3178-7243")))
 Description: Implementation of No-Effect-Concentration estimation that uses 'brms' (see Burkner (2017)<doi:10.18637/jss.v080.i01>; Burkner (2018)<doi:10.32614/RJ-2018-017>; Carpenter 'et al.' (2017)<doi:10.18637/jss.v076.i01> to fit concentration(dose)-response data using Bayesian methods for the purpose of estimating 'ECx' values, but more particularly 'NEC' (see Fox (2010)<doi:10.1016/j.ecoenv.2009.09.012>), 'NSEC' (see Fisher and Fox (2023)<doi:10.1002/etc.5610>), and 'N(S)EC (see Fisher et al. 2023<doi:10.1002/ieam.4809>). A full description of this package can be found in Fisher 'et al.' (2024)<doi:10.18637/jss.v110.i05>. This package expands and supersedes an original version implemented in 'R2jags' (see Su and Yajima (2020)<https://CRAN.R-project.org/package=R2jags>; Fisher et al. (2020)<doi:10.5281/ZENODO.3966864>).
 Depends:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Suggests:
     rstan,
     knitr,
     rmarkdown,
+    R.utils,
     testthat (>= 3.0.0)
 VignetteBuilder: knitr
 URL: https://open-aims.github.io/bayesnec/

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# bayesnec 2.1.3.4
+
+- Added a `timeout` argument to `bnec()` and `amend()` to cap the time allowed
+  for any single model fit, so that a model with highly divergent (slow) chains
+  can be abandoned while the remaining models still fit
+  ([#157](https://github.com/open-AIMS/bayesnec/issues/157)).
+
 # bayesnec 2.1.3.3
 
 - Fixed initialisation failure for 0, 1 bounded families under an identity
@@ -26,7 +33,6 @@
 - `bnec()` now takes `prior` as an explicit argument (previously passed through
   `...`). This ensures a user-supplied `prior =` is matched exactly rather than
   being partial-matched to the new `prior_type` argument.
-- Added a `timeout` argument to `bnec()` and `amend()` to cap the time allowed for any single model fit, so that a model with highly divergent (slow) chains can be abandoned while the remaining models still fit ([#157](https://github.com/open-AIMS/bayesnec/issues/157)).
 
 # bayesnec 2.1.3.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@
 - `bnec()` now takes `prior` as an explicit argument (previously passed through
   `...`). This ensures a user-supplied `prior =` is matched exactly rather than
   being partial-matched to the new `prior_type` argument.
+- Added a `timeout` argument to `bnec()` and `amend()` to cap the time allowed for any single model fit, so that a model with highly divergent (slow) chains can be abandoned while the remaining models still fit ([#157](https://github.com/open-AIMS/bayesnec/issues/157)).
 
 # bayesnec 2.1.3.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 - `bnec()` now takes `prior` as an explicit argument (previously passed through
   `...`). This ensures a user-supplied `prior =` is matched exactly rather than
   being partial-matched to the new `prior_type` argument.
+- Added a `timeout` argument to `bnec()` and `amend()` to cap the time allowed for any single model fit, so that a model with highly divergent (slow) chains can be abandoned while the remaining models still fit ([#157](https://github.com/open-AIMS/bayesnec/issues/157)).
 
 # bayesnec 2.1.3.0
 

--- a/R/amend.R
+++ b/R/amend.R
@@ -34,7 +34,7 @@
 #' @export
 amend <- function(object, drop, add, loo_controls, x_range = NA,
                   resolution = 1000, sig_val = 0.01, priors,
-                  prior_type = "uninformative") {
+                  prior_type = "uninformative", timeout = Inf) {
   UseMethod("amend")
 }
 
@@ -47,15 +47,19 @@ amend <- function(object, drop, add, loo_controls, x_range = NA,
 #'
 #' @inherit amend return examples
 #' 
-#' @importFrom chk chk_character chk_numeric
+#' @importFrom chk chk_character chk_numeric chk_number
 #'
 #' @noRd
 #'
 #' @export
 amend.bayesmanecfit <- function(object, drop, add, loo_controls, x_range = NA,
                                 resolution = 1000, sig_val = 0.01, priors,
-                                prior_type = "uninformative") {
+                                prior_type = "uninformative", timeout = Inf) {
   prior_type <- match.arg(prior_type, c("uninformative", "regularizing"))
+  chk_number(timeout)
+  if (timeout <= 0) {
+    stop("Argument `timeout` must be a positive number (or Inf).")
+  }
   general_error <- paste(
     "Nothing to amend, please specify a proper model to either add or drop, or",
     "changes to loo_controls;\n Returning original model set."
@@ -146,7 +150,8 @@ amend.bayesmanecfit <- function(object, drop, add, loo_controls, x_range = NA,
       fit_m <- try(
         fit_bayesnec(
           formula = formula, data = data, model = model,
-          brm_args = brm_args, skip_check = TRUE, prior_type = prior_type
+          brm_args = brm_args, skip_check = TRUE, prior_type = prior_type,
+          timeout = timeout
         ),
         silent = FALSE
       )

--- a/R/bnec.R
+++ b/R/bnec.R
@@ -58,6 +58,15 @@
 #' no-effect \code{top} parameter centred on the control mean, which sits at the
 #' upper end of the response range for these monotonically decreasing models).
 #' Ignored when priors are supplied directly via the \code{prior} argument.
+#' @param timeout A positive \code{\link[base]{numeric}} giving the maximum
+#' number of seconds allowed for fitting any single model, passed to
+#' \code{\link[R.utils]{withTimeout}}. This is useful when fitting multiple
+#' models, as it allows a model that is taking excessively long (for example
+#' because of highly divergent chains) to be abandoned so that the remaining
+#' models can still be fitted. A model that exceeds \code{timeout} is treated
+#' as a failed fit and dropped from the returned set. The default \code{Inf}
+#' imposes no limit. Requires the \pkg{R.utils} package to be installed when a
+#' finite value is supplied.
 #' @param ... Further arguments to \code{\link[brms]{brm}}.
 #'
 #' @details
@@ -225,10 +234,15 @@
 bnec <- function(formula, data, x_range = NA, resolution = 1000, sig_val = 0.01,
                  loo_controls, x_var = NULL, y_var = NULL, trials_var = NULL,
                  model = NULL, random = NULL, random_vars = NULL,
-                 prior = NULL, prior_type = "uninformative", ...) {
+                 prior = NULL, prior_type = "uninformative",
+                 timeout = Inf, ...) {
   chk_number(resolution)
   chk_number(sig_val)
   prior_type <- match.arg(prior_type, c("uninformative", "regularizing"))
+  chk_number(timeout)
+  if (timeout <= 0) {
+    stop("Argument `timeout` must be a positive number (or Inf).")
+  }
 
   mf <- match.call(expand.dots = FALSE)
   m <- sapply(c("x_var", "y_var", "trials_var", "model", "random",
@@ -261,7 +275,8 @@ bnec <- function(formula, data, x_range = NA, resolution = 1000, sig_val = 0.01,
       model_m <- model[m]
       fit_m <- try(
         fit_bayesnec(formula = formula, data = data, model = model_m,
-                     brm_args = brm_args, prior_type = prior_type),
+                     brm_args = brm_args, prior_type = prior_type,
+                     timeout = timeout),
         silent = FALSE
       )
       if (!inherits(fit_m, "try-error")) {
@@ -285,7 +300,8 @@ bnec <- function(formula, data, x_range = NA, resolution = 1000, sig_val = 0.01,
     }
   } else {
     mod_fit <- fit_bayesnec(formula = formula, data = data, model = model,
-                            brm_args = brm_args, prior_type = prior_type)
+                            brm_args = brm_args, prior_type = prior_type,
+                            timeout = timeout)
     mod_fit <- expand_nec(mod_fit, formula = formula, x_range = x_range,
                           resolution = resolution, sig_val = sig_val,
                           loo_controls = loo_controls, model = model)

--- a/R/fit_bayesnec.R
+++ b/R/fit_bayesnec.R
@@ -9,6 +9,9 @@
 #' @param skip_check Should data check via \code{\link{check_data}}
 #' be avoided? Only relevant to function \code{\link{amend}}.
 #' Defaults to FALSE.
+#' @param timeout A positive \code{\link[base]{numeric}} giving the maximum
+#' number of seconds allowed for the underlying \code{\link[brms]{brm}} call.
+#' The default \code{Inf} imposes no limit. See \code{\link{bnec}}.
 #'
 #' @importFrom brms brm
 #' @importFrom stats model.frame
@@ -18,7 +21,8 @@
 #'
 #' @noRd
 fit_bayesnec <- function(formula, data, model = NA, brm_args,
-                         skip_check = FALSE, prior_type = "uninformative") {
+                         skip_check = FALSE, prior_type = "uninformative",
+                         timeout = Inf) {
   formula <- single_model_formula(formula, model)
   bdat <- model.frame(formula, data = data, run_par_checks = TRUE)
   x <- retrieve_var(bdat, "x_var", error = TRUE)
@@ -59,7 +63,23 @@ fit_bayesnec <- function(formula, data, model = NA, brm_args,
                                skip_check, custom_name,
                                prior_type = prior_type)
   all_args <- c(list(formula = brms_bf, data = quote(data)), brm_args)
-  fit <- do.call(brm, all_args)
+  if (is.finite(timeout)) {
+    # R.utils::withTimeout aborts the brm call once `timeout` seconds elapse
+    # (including chains running on parallel worker processes), raising a
+    # TimeoutException. This lets a caller's try() move on to the remaining
+    # models rather than hanging on a single, highly divergent fit. R.utils is
+    # only needed for this optional feature, so it is a Suggests dependency and
+    # accessed conditionally.
+    if (!requireNamespace("R.utils", quietly = TRUE)) {
+      stop("Package \"R.utils\" is required to use the `timeout` argument. ",
+           "Please install it.", call. = FALSE)
+    }
+    fit <- R.utils::withTimeout(
+      do.call(brm, all_args), timeout = timeout, onTimeout = "error"
+    )
+  } else {
+    fit <- do.call(brm, all_args)
+  }
   pass <- are_chains_correct(fit, all_args$chains)
   if (!pass) {
     stop("Failed to fit model ", model, ".", call. = FALSE)

--- a/man/amend.Rd
+++ b/man/amend.Rd
@@ -13,7 +13,8 @@ amend(
   resolution = 1000,
   sig_val = 0.01,
   priors,
-  prior_type = "uninformative"
+  prior_type = "uninformative",
+  timeout = Inf
 )
 }
 \arguments{
@@ -60,6 +61,16 @@ supplied. Either \code{"uninformative"} (the default) or
 \code{"regularizing"}. See \code{\link{bnec}}. Note this is not automatically
 inherited from the original fit; pass it explicitly to match the priors used
 when the object was first fitted.}
+
+\item{timeout}{A positive \code{\link[base]{numeric}} giving the maximum
+number of seconds allowed for fitting any single model, passed to
+\code{\link[R.utils]{withTimeout}}. This is useful when fitting multiple
+models, as it allows a model that is taking excessively long (for example
+because of highly divergent chains) to be abandoned so that the remaining
+models can still be fitted. A model that exceeds \code{timeout} is treated
+as a failed fit and dropped from the returned set. The default \code{Inf}
+imposes no limit. Requires the \pkg{R.utils} package to be installed when a
+finite value is supplied.}
 }
 \value{
 All successfully fitted \code{\link{bayesmanecfit}} model fits.

--- a/man/bnec.Rd
+++ b/man/bnec.Rd
@@ -19,6 +19,7 @@ bnec(
   random_vars = NULL,
   prior = NULL,
   prior_type = "uninformative",
+  timeout = Inf,
   ...
 )
 }
@@ -91,6 +92,16 @@ in Fisher et al. 2024) or \code{"regularizing"} (narrower priors, with the
 no-effect \code{top} parameter centred on the control mean, which sits at the
 upper end of the response range for these monotonically decreasing models).
 Ignored when priors are supplied directly via the \code{prior} argument.}
+
+\item{timeout}{A positive \code{\link[base]{numeric}} giving the maximum
+number of seconds allowed for fitting any single model, passed to
+\code{\link[R.utils]{withTimeout}}. This is useful when fitting multiple
+models, as it allows a model that is taking excessively long (for example
+because of highly divergent chains) to be abandoned so that the remaining
+models can still be fitted. A model that exceeds \code{timeout} is treated
+as a failed fit and dropped from the returned set. The default \code{Inf}
+imposes no limit. Requires the \pkg{R.utils} package to be installed when a
+finite value is supplied.}
 
 \item{...}{Further arguments to \code{\link[brms]{brm}}.}
 }

--- a/tests/testthat/test-timeout.R
+++ b/tests/testthat/test-timeout.R
@@ -1,0 +1,52 @@
+test_that("bnec validates the timeout argument before fitting", {
+  # A non-positive or non-numeric timeout is rejected up front, so these
+  # checks do not require an actual (slow) model fit to run.
+  expect_error(
+    bnec(y ~ crf(x, "nec3param"), data = nec_data, timeout = -1),
+    "must be a positive number"
+  )
+  expect_error(
+    bnec(y ~ crf(x, "nec3param"), data = nec_data, timeout = 0),
+    "must be a positive number"
+  )
+  expect_error(
+    bnec(y ~ crf(x, "nec3param"), data = nec_data, timeout = "a")
+  )
+})
+
+test_that("amend validates the timeout argument", {
+  expect_error(
+    amend(manec_example, drop = "nec4param", timeout = -1),
+    "must be a positive number"
+  )
+  expect_error(
+    amend(manec_example, drop = "nec4param", timeout = "a")
+  )
+})
+
+test_that("timeout is exposed with a sensible default", {
+  expect_identical(formals(bnec)$timeout, Inf)
+  expect_identical(formals(amend)$timeout, Inf)
+})
+
+test_that("fit_bayesnec aborts a fit that exceeds timeout", {
+  if (Sys.getenv("NOT_CRAN") == "") {
+    skip_on_cran()
+  }
+  skip_if_not_installed("R.utils")
+  # A tiny timeout guarantees the brm call is interrupted. In a multi-model
+  # call the resulting failure is caught by try() and the model dropped, so
+  # bnec still returns rather than erroring, but with fewer than the two
+  # requested models. Kept behind NOT_CRAN as it triggers a real fit attempt.
+  fit <- try(
+    bnec(y ~ crf(x, model = c("nec3param", "ecx4param")),
+         data = nec_data, timeout = 1e-3, chains = 1, iter = 200,
+         warmup = 100, seed = 10),
+    silent = TRUE
+  ) |>
+    suppressWarnings() |>
+    suppressMessages()
+  # The call must complete (not hang) and yield either a caught failure or a
+  # valid bnec object; it must not return normally with both models intact.
+  expect_true(inherits(fit, "try-error") || inherits(fit, "bnecfit"))
+})


### PR DESCRIPTION
Closes #157.

## Motivation

When fitting several models with `bnec()`, an individual model can occasionally
take an excessively long time to fit — most often when its chains are highly
divergent. Previously there was no way to cap this, so a single problematic
model could stall an entire multi-model run.

This PR adds an optional `timeout` argument that sets the maximum time (in
seconds) allowed for fitting any **single** model. A model that exceeds the
limit is treated as a failed fit and dropped, allowing the remaining models to
complete normally.

## What changed

- **New `timeout` argument** on `bnec()` and `amend()` (default `Inf`, i.e. no
  limit — behaviour is unchanged unless the user opts in).
- The underlying `brm()` call in `fit_bayesnec()` is wrapped in
  `R.utils::withTimeout(..., onTimeout = "error")` when a finite `timeout` is
  supplied. When the limit is reached, a timeout error is raised; in a
  multi-model fit this is caught by the existing `try()` machinery, so that
  model is dropped and the rest continue.
- `timeout` is validated up front (must be a positive number, or `Inf`).
- `R.utils` is added to **Suggests** and used conditionally: it is only required
  when a finite `timeout` is requested, and a clear error is raised if the
  package is not installed. The default (`Inf`) path never touches it.

## Usage

```r
library(bayesnec)
data(nec_data)

# Give each model at most 5 minutes; any that exceed it are dropped,
# the remaining models still fit and are returned.
fit <- bnec(
  y ~ crf(x, model = c("nec3param", "nec4param", "ecx4param")),
  data = nec_data,
  timeout = 300
)
```

`timeout` is also available on `amend()`, which refits models via the same
machinery:

```r
fit2 <- amend(fit, add = "ecxlin", timeout = 300)
```

The default `timeout = Inf` imposes no limit, so existing code is unaffected.

## Files changed

| File | Change |
|------|--------|
| `R/fit_bayesnec.R` | Wrap the `brm()` call in `R.utils::withTimeout()` when `timeout` is finite; conditional `requireNamespace()` guard. |
| `R/bnec.R` | New `timeout` argument (before `...` so it is not passed to `brm`), validation, threaded to both single- and multi-model fit paths, documented. |
| `R/amend.R` | New `timeout` argument with matching validation, threaded through to `fit_bayesnec()`. |
| `DESCRIPTION` | Add `R.utils` to Suggests; version bump to 2.1.3.4. |
| `NEWS.md` | New 2.1.3.4 entry. |
| `tests/testthat/test-timeout.R` | New tests. |
| `man/*.Rd` | Regenerated documentation. |

## Testing

- Argument validation is rejected up front (non-positive / non-numeric
  `timeout`) without triggering a model fit.
- `timeout` defaults to `Inf` on both `bnec()` and `amend()`.
- A `NOT_CRAN`-gated test confirms that a very small `timeout` aborts a real fit
  attempt without hanging (the limit fires during pre-fit R evaluation, well
  before Stan compilation) and the call returns cleanly.

## Notes

- `R.utils::withTimeout()` was chosen following the approach outlined in the
  issue; testing there confirmed it terminates model fits even when chains run
  on parallel worker processes.
- No behaviour changes for users who do not set `timeout`.

