### PR TITLE
Require brms >= 2.23.0 and fix a doubled roxygen marker in ?nsec

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Authors@R: c(person("Rebecca", "Fisher", email = "r.fisher@aims.gov.au", role = 
 Description: Implementation of No-Effect-Concentration estimation that uses 'brms' (see Burkner (2017)<doi:10.18637/jss.v080.i01>; Burkner (2018)<doi:10.32614/RJ-2018-017>; Carpenter 'et al.' (2017)<doi:10.18637/jss.v076.i01> to fit concentration(dose)-response data using Bayesian methods for the purpose of estimating 'ECx' values, but more particularly 'NEC' (see Fox (2010)<doi:10.1016/j.ecoenv.2009.09.012>), 'NSEC' (see Fisher and Fox (2023)<doi:10.1002/etc.5610>), and 'N(S)EC (see Fisher et al. 2023<doi:10.1002/ieam.4809>). A full description of this package can be found in Fisher 'et al.' (2024)<doi:10.18637/jss.v110.i05>. This package expands and supersedes an original version implemented in 'R2jags' (see Su and Yajima (2020)<https://CRAN.R-project.org/package=R2jags>; Fisher et al. (2020)<doi:10.5281/ZENODO.3966864>).
 Depends:
     R (>= 4.1),
-    brms,
+    brms (>= 2.23.0),
     ggplot2
 License: GPL-2
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # bayesnec 2.1.3.7
 
+- `brms (>= 2.23.0)` is now required. Earlier versions generate the
+  `beta_binomial` likelihood by passing the whole `trials` array to
+  `beta_binomial_lpmf` instead of `trials[n]`, so each response is evaluated
+  against every trial count. With varying `trials` the density is `-Inf`
+  everywhere and the model cannot initialise; with constant `trials` it samples
+  on a likelihood inflated by a factor of `N`, which is silent and leaves
+  posteriors overconfident by roughly `sqrt(N)`. Fixed upstream in 2.23.0. See
+  `notes/beta_binomial_varying_trials.md`.
+- Fixed a doubled roxygen marker in the references section of `?nsec`, which
+  left a stray `#'` in the rendered help.
 - New `disp()` term in `bayesnecformula`, allowing a family's dispersion
   parameter to vary across the concentration-response curve instead of being
   held constant. Two forms. `disp(~x)` models dispersion on the **predictor** —

--- a/R/nsec.R
+++ b/R/nsec.R
@@ -68,7 +68,7 @@
 #' Fisher R, Fox DR (2023). Introducing the no significant effect concentration
 #' (NSEC).Environmental Toxicology and Chemistry, 42(9), 2019–2028.
 #' doi: 10.1002/etc.5610.
-#'#'
+#'
 #' @examples
 #' \donttest{
 #' library(bayesnec)

--- a/man/nsec.Rd
+++ b/man/nsec.Rd
@@ -106,7 +106,6 @@ nsec(manec_example)
 Fisher R, Fox DR (2023). Introducing the no significant effect concentration
 (NSEC).Environmental Toxicology and Chemistry, 42(9), 2019–2028.
 doi: 10.1002/etc.5610.
-#'
 }
 \seealso{
 \code{\link{bnec}}, \code{\link{bnec_hurdle}}, \code{\link{ecx}}


### PR DESCRIPTION
Two small, independent fixes found while working on #192.

## `brms (>= 2.23.0)`

`DESCRIPTION` listed `brms` with no version constraint. brms 2.22.0 generates
the `beta_binomial` likelihood as

```stan
target += beta_binomial_lpmf(Y[n] | trials, mu[n] * phi, (1 - mu[n]) * phi);
```

passing the whole `array[N] int trials` where it should pass `trials[n]`, so
Stan takes the vectorised signature and evaluates each scalar `Y[n]` against
*every* element of `trials`.

- **Varying `trials`** — each response is compared against the *smallest* trial
  count, so any observation above `min(trials)` makes a term `-Inf` at every
  parameter value. The model cannot initialise. This is what blocked `example1`.
- **Constant `trials`** — nothing is ever invalid, so it samples happily on a
  likelihood inflated by exactly `N`. Measured at a fixed parameter vector:
  correct log-likelihood -239.428 against -13407.956, ratio 56.0000 with N = 56.
  Posteriors are overconfident by roughly `sqrt(N)`, and nothing signals it.

The second is the more damaging case. Fixed upstream in brms 2.23.0, which
generates `beta_binomial_lpmf(Y | trials, mu .* phi, (1 - mu) .* phi)`.

Backend-independent — `rstan` and `cmdstanr` reject every initial value
identically, which is what ruled out a sampler regression. Scope was
`beta_binomial` alone; `binomial` and `zero_inflated_binomial` generate correct
code, so existing results for those families are unaffected.

Full write-up in `notes/beta_binomial_varying_trials.md`, added in #192.

## Doubled roxygen marker in `?nsec`

`R/nsec.R:71` had `#'#'` immediately after the references block, which reached
the rendered help:

```
42(9), 2019–2028. doi: 10.1002/etc.5610. #'
```

`man/nsec.Rd` regenerated with `roxygen2::roxygenise()`; no other Rd file
changed.

Credit to a parallel session for spotting this one independently.

## Note

No version bump — `DESCRIPTION` stays at 2.1.3.7, since this lands in the same
unreleased cycle as #192. Say if you would rather it moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
