### PR TITLE
Allow a cens() aterm in bnec_hurdle() (#188)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -113,6 +113,32 @@
   nothing to return. Both methods now share one implementation, so the single-
   and multi-model paths cannot drift apart. See
   [#176](https://github.com/open-AIMS/bayesnec/issues/176).
+- `bnec_hurdle()` now accepts a `cens()` aterm on the response, which unblocks
+  the combination the censoring work was raised for: a growth endpoint that is
+  both zero-bounded with structural zeros (deaths) and left-censored at the
+  recording resolution (survivors measured below the limit). Only a two-part
+  model with a censored response component can tell those two zeros apart. The
+  guard was stricter than the constraint it protected — `hurdle_response_var()`
+  required the whole left-hand side to deparse to a bare name, when what the
+  zero-as-death convention needs is a bare *response*; an aterm alongside it
+  does not threaten that.
+- The declaration is routed rather than merely allowed. It is passed to the
+  growth component, where the censoring indicator travels as an ordinary data
+  column and is subset with everything else, and dropped from the survival
+  component, whose alive/dead response is observed exactly. That was already the
+  behaviour of `swap_response()`, incidentally; it is now deliberate and tested.
+- A row that is both zero and censored is refused. A structural zero and a
+  censored observation are the two things a hurdle model exists to separate, and
+  accepting a row claiming to be both would reproduce the confusion
+  `vignette("example6")` warns about. Under a Gamma growth component the
+  censoring bound cannot be `0` — `bnec()` already rejects that — so the
+  encoding is "at most the smallest resolvable value", which `?bnec_hurdle` now
+  says.
+- Other aterms keep erroring, but by name and with the reason. `trials()` has no
+  meaning for either component; `weights()` is refused because whether a weight
+  applies to the growth component, the survival component or both is a modelling
+  decision `bnec_hurdle()` will not make on the user's behalf. See
+  [#188](https://github.com/open-AIMS/bayesnec/issues/188).
 
 # bayesnec 2.1.3.6
 

--- a/R/bayesnechurdlefit-methods.R
+++ b/R/bayesnechurdlefit-methods.R
@@ -578,7 +578,9 @@ amend.bayesnechurdlefit <- function(object, drop, add, loo_controls,
 #' @param object An object of class \code{\link{bayesnechurdlefit}}.
 #' @param newdata Optional new data. Split into the two component datasets the
 #' same way \code{\link{bnec_hurdle}} does, so zeros continue to denote the
-#' hurdle rather than being modelled as small responses.
+#' hurdle rather than being modelled as small responses, and checked the same
+#' way: a row that is both zero and censored is refused here as it is at
+#' construction.
 #'
 #' @return An object of class \code{\link{bayesnechurdlefit}}.
 #'
@@ -597,6 +599,13 @@ update.bayesnechurdlefit <- function(object, newdata = NULL, ...) {
     stop("\"newdata\" must contain the response column \"", object$y_var,
          "\".", call. = FALSE)
   }
+  # The zero-vs-censored invariant belongs to the data, not to the fit, so it
+  # has to be re-checked against newdata. Without this a row that is both zero
+  # and censored is dropped from the growth refit and coded as a death in the
+  # survival refit, silently -- the confusion the construction-time check in
+  # bnec_hurdle() exists to prevent.
+  check_hurdle_cens(check_hurdle_aterms(object$formula), newdata, y,
+                    object$y_var)
   surv_data <- newdata
   surv_data[[".alive"]] <- as.integer(y > 0)
   out <- hurdle_rewrap(

--- a/R/bnec_hurdle.R
+++ b/R/bnec_hurdle.R
@@ -77,8 +77,12 @@
 #'
 #' \bold{Censoring, and which aterms are allowed}
 #'
-#' \code{cens()} is the one \pkg{brms} aterm accepted on the response, because
-#' it is the one a hurdle model needs. A growth endpoint can be both
+#' \code{cens()} is the one aterm accepted on the response. \code{\link{bnec}}
+#' itself carries three -- \code{trials()}, \code{weights()} and
+#' \code{cens()} -- and of those \code{cens()} is the only one whose meaning
+#' stays unambiguous once the response is split across two models. It is also
+#' the one with a use here that nothing else covers. A growth endpoint can be
+#' both
 #' zero-bounded with structural zeros and left-censored at the recording
 #' resolution, and only a two-part model with a censored response component can
 #' tell the two apart: a death is a structural zero belonging to the Bernoulli
@@ -97,12 +101,14 @@
 #' limit, so the encoding is "at most the smallest resolvable value" rather than
 #' "at most zero".
 #'
-#' Other aterms are refused by name, with the reason. \code{trials()} has no
+#' The other two are refused by name, with the reason. \code{trials()} has no
 #' meaning for either component, and \code{weights()} is a modelling decision --
 #' whether a weight applies to the growth component, the survival component or
-#' both -- that this function will not make on the user's behalf. Making the two
-#' \code{\link{bnec}} calls directly remains available for anything outside this
-#' set.
+#' both -- that this function will not make on the user's behalf. Aterms beyond
+#' those three are refused here as well, though they would not reach \pkg{brms}
+#' in any case: \code{\link{model.frame}} drops them for an ordinary
+#' \code{\link{bnec}} fit too. Making the two \code{\link{bnec}} calls directly
+#' remains available for anything outside this set.
 #'
 #' @return An object of class \code{\link{bayesnechurdlefit}}.
 #'
@@ -268,8 +274,12 @@ hurdle_lhs_parts <- function(lhs_call) {
 #'
 #' @param formula An object of class \code{\link{bayesnecformula}}.
 #'
-#' @details Only \code{cens()} is accepted. A censored response is the case
-#' \code{bnec_hurdle} needs it for: a growth endpoint can be both zero-bounded
+#' @details Only \code{cens()} is accepted. The candidate set is the three
+#' aterms \code{bnec} supports at all -- \code{trials()}, \code{weights()} and
+#' \code{cens()} -- since \code{model.frame} drops the rest before they reach
+#' brms; \code{cens()} is the one of the three that survives the split. A
+#' censored response is also the case \code{bnec_hurdle} needs it for: a growth
+#' endpoint can be both zero-bounded
 #' with structural zeros and left-censored at the recording resolution, and only
 #' a two-part model with a censored response component can tell a death from a
 #' survivor measured below the limit.

--- a/R/bnec_hurdle.R
+++ b/R/bnec_hurdle.R
@@ -254,7 +254,12 @@ hurdle_lhs_parts <- function(lhs_call) {
   }
   out[[length(out) + 1]] <- aterm_call
   names(out) <- vapply(out, function(tt) {
-    if (is.call(tt)) deparse1(tt[[1]]) else deparse1(tt)
+    nm <- if (is.call(tt)) deparse1(tt[[1]]) else deparse1(tt)
+    # brms::cens() and cens() are the same aterm. Everything else in the
+    # package matches aterms on the bare name (split_calls() greps for
+    # "cens("), so strip any namespace qualifier here too rather than let
+    # check_hurdle_aterms() refuse the qualified form as unrecognised.
+    sub("^.*:::?", "", nm)
   }, character(1))
   list(response = lhs_call[[2]], aterms = rev(out))
 }
@@ -339,7 +344,18 @@ check_hurdle_cens <- function(aterms, data, y, y_var) {
   if (!"cens" %in% names(aterms)) {
     return(invisible(NULL))
   }
-  cens_arg <- as.list(aterms[["cens"]])[-1][[1]]
+  cens_args <- as.list(aterms[["cens"]])[-1]
+  if (length(cens_args) == 0) {
+    stop("cens() was supplied with no arguments, so there is no censoring",
+         " indicator to check the zeros against. Pass the column holding the",
+         " censoring codes, e.g. \"", y_var, " | cens(censored) ~ ...\".",
+         call. = FALSE)
+  }
+  # The first argument positionally, matching how split_calls() reads the same
+  # term downstream. Resolving named arguments properly here would be more
+  # correct in isolation but would make this check disagree with the term brms
+  # is actually given, which is worse than agreeing and being wrong together.
+  cens_arg <- cens_args[[1]]
   cens_vals <- if (length(all.vars(cens_arg)) == 0) {
     # A literal, e.g. cens("left"), which brms recycles over every row.
     # check_formula() already warns about this; here it still has to be checked

--- a/R/bnec_hurdle.R
+++ b/R/bnec_hurdle.R
@@ -28,7 +28,9 @@
 #' @param formula Either a \code{\link[base]{character}} string defining an
 #' R formula or an actual \code{\link[stats]{formula}} object. See
 #' \code{\link{bayesnecformula}}. The response must be untransformed, and zero
-#' values in it are taken to mean the individual did not survive.
+#' values in it are taken to mean the individual did not survive. A
+#' \code{cens()} aterm is allowed alongside it; other aterms are refused, see
+#' Details.
 #' @param data A \code{\link[base]{data.frame}} containing the data to use with
 #' the \code{formula}. Every unit that entered the experiment must be present,
 #' with \code{0} recorded for those that gave no response. Rows omitted rather
@@ -73,6 +75,35 @@
 #' a measurement. Where mortality is instead recorded by omitting rows, those
 #' rows must be reinstated as zeros before calling this function.
 #'
+#' \bold{Censoring, and which aterms are allowed}
+#'
+#' \code{cens()} is the one \pkg{brms} aterm accepted on the response, because
+#' it is the one a hurdle model needs. A growth endpoint can be both
+#' zero-bounded with structural zeros and left-censored at the recording
+#' resolution, and only a two-part model with a censored response component can
+#' tell the two apart: a death is a structural zero belonging to the Bernoulli
+#' component, while a survivor measured below the limit is a real observation of
+#' the growth component whose value is known only to lie at or below a bound.
+#'
+#' The declaration is routed accordingly. It is passed through to the growth
+#' component, where the censoring indicator travels as an ordinary data column
+#' and is subset along with everything else, and it is dropped from the survival
+#' component, whose alive/dead response is observed exactly. A row that is both
+#' zero and censored is refused rather than assigned to one of them.
+#'
+#' Under a Gamma growth component the censoring bound cannot be \code{0} --
+#' \code{\link{bnec}} rejects that, correctly, because the censored likelihood
+#' contribution there is \code{F(0) = 0}. The bound has to be the resolution
+#' limit, so the encoding is "at most the smallest resolvable value" rather than
+#' "at most zero".
+#'
+#' Other aterms are refused by name, with the reason. \code{trials()} has no
+#' meaning for either component, and \code{weights()} is a modelling decision --
+#' whether a weight applies to the growth component, the survival component or
+#' both -- that this function will not make on the user's behalf. Making the two
+#' \code{\link{bnec}} calls directly remains available for anything outside this
+#' set.
+#'
 #' @return An object of class \code{\link{bayesnechurdlefit}}.
 #'
 #' @seealso \code{\link{bnec}} for the equivalent joint fit via
@@ -95,6 +126,7 @@ bnec_hurdle <- function(formula, data, model_survival = NULL,
                         family_growth = NULL, ...) {
   formula <- bayesnecformula(formula)
   y_var <- hurdle_response_var(formula)
+  aterms <- check_hurdle_aterms(formula)
   if (!y_var %in% names(data)) {
     stop("The response variable \"", y_var, "\" is not a column in \"data\".",
          call. = FALSE)
@@ -125,10 +157,17 @@ bnec_hurdle <- function(formula, data, model_survival = NULL,
   if (n_dead == length(y)) {
     stop("Every value of \"", y_var, "\" is zero.", call. = FALSE)
   }
+  check_hurdle_cens(aterms, data, y, y_var)
 
   # Survival component: one Bernoulli trial per individual, 1 = survived. The
   # curve therefore declines with concentration, matching the sign convention
   # of every bayesnec equation, and hu = 1 - fitted survival.
+  #
+  # swap_response() rebuilds the formula from rhs() alone, so any aterm on the
+  # response is dropped here rather than carried over. That is deliberate for
+  # cens(): the Bernoulli response is alive/dead, which is observed exactly, so
+  # there is nothing for a censoring declaration to bound. The censoring
+  # indicator stays in surv_data as an ordinary unused column.
   surv_data <- data
   surv_data[[".alive"]] <- as.integer(y > 0)
   surv_formula <- swap_response(formula, ".alive")
@@ -146,6 +185,10 @@ bnec_hurdle <- function(formula, data, model_survival = NULL,
   }
   message("Fitting the growth component (", sum(y > 0), " survivors of ",
           length(y), ") with a ", family_growth$family, " distribution.")
+  # The formula is passed through unchanged, aterms included: a censoring
+  # indicator is an ordinary data column, so the subset carries it along and the
+  # declaration reaches the block it belongs to. A survivor measured below the
+  # recording limit is an observation of *this* component, not a structural zero.
   growth_fit <- bnec(formula, data = data[y > 0, , drop = FALSE],
                      family = family_growth, ...)
   message("Fitting the survival component (", n_dead, " deaths of ",
@@ -161,8 +204,11 @@ bnec_hurdle <- function(formula, data, model_survival = NULL,
 
 #' Extract the response variable name from a hurdle formula
 #'
-#' Errors informatively if the response is transformed or carries aterms, both
-#' of which make the zero-as-death convention ambiguous.
+#' Errors informatively if the response itself is transformed, which makes the
+#' zero-as-death convention ambiguous. Aterms alongside the response are left
+#' alone here and validated by \code{\link{check_hurdle_aterms}}: what
+#' \code{bnec_hurdle} needs is a bare response variable, not a bare left-hand
+#' side.
 #'
 #' @param formula An object of class \code{\link{bayesnecformula}}.
 #'
@@ -173,15 +219,150 @@ bnec_hurdle <- function(formula, data, model_survival = NULL,
 #'
 #' @noRd
 hurdle_response_var <- function(formula) {
-  lhs_call <- lhs(formula)
-  y_var <- all.vars(lhs_call)
-  if (length(y_var) != 1 || !identical(deparse1(lhs_call), y_var)) {
+  resp_call <- hurdle_lhs_parts(lhs(formula))$response
+  y_var <- all.vars(resp_call)
+  if (length(y_var) != 1 || !identical(deparse1(resp_call), y_var)) {
     stop("bnec_hurdle requires a plain, untransformed response on the left",
          " of the formula, because zero values in it are used to identify",
-         " deaths. You supplied \"", deparse1(lhs_call), "\".",
+         " deaths. You supplied \"", deparse1(resp_call), "\".",
          call. = FALSE)
   }
   y_var
+}
+
+#' Split a formula's left-hand side into the response and its aterms
+#'
+#' @param lhs_call The left-hand side of a formula, as a call.
+#'
+#' @return A \code{\link[base]{list}} with elements \code{response} (a call) and
+#' \code{aterms} (a possibly empty \code{\link[base]{list}} of calls).
+#'
+#' @noRd
+hurdle_lhs_parts <- function(lhs_call) {
+  if (!(length(lhs_call) == 3 && identical(lhs_call[[1]], quote(`|`)))) {
+    return(list(response = lhs_call, aterms = list()))
+  }
+  # aterms are joined by "+", so peel the chain apart from the right. The `+`
+  # test matters for the same reason it does in split_calls(): without it a
+  # two-argument aterm such as cens(indicator, upper_bound) is itself length 3
+  # and would be destructured as though it were a chain.
+  aterm_call <- lhs_call[[3]]
+  out <- list()
+  while (length(aterm_call) == 3 && identical(aterm_call[[1]], quote(`+`))) {
+    out[[length(out) + 1]] <- aterm_call[[3]]
+    aterm_call <- aterm_call[[2]]
+  }
+  out[[length(out) + 1]] <- aterm_call
+  names(out) <- vapply(out, function(tt) {
+    if (is.call(tt)) deparse1(tt[[1]]) else deparse1(tt)
+  }, character(1))
+  list(response = lhs_call[[2]], aterms = rev(out))
+}
+
+#' Validate the aterms on a hurdle formula's response
+#'
+#' @param formula An object of class \code{\link{bayesnecformula}}.
+#'
+#' @details Only \code{cens()} is accepted. A censored response is the case
+#' \code{bnec_hurdle} needs it for: a growth endpoint can be both zero-bounded
+#' with structural zeros and left-censored at the recording resolution, and only
+#' a two-part model with a censored response component can tell a death from a
+#' survivor measured below the limit.
+#'
+#' Every other aterm is refused by name. \code{trials()} has no meaning for
+#' either component -- the growth component is continuous and the survival
+#' component is one Bernoulli trial per individual -- and an aggregated count
+#' could not be split into survivors and deaths row by row anyway.
+#' \code{weights()} is refused because whether a weight belongs to the growth
+#' component, the survival component or both is a modelling decision, and
+#' guessing it would silently change the model; a user who knows which they want
+#' can make the two \code{\link{bnec}} calls directly.
+#'
+#' @return A \code{\link[base]{list}} of the accepted aterm calls, named by
+#' function.
+#'
+#' @importFrom formula.tools lhs
+#'
+#' @noRd
+check_hurdle_aterms <- function(formula) {
+  aterms <- hurdle_lhs_parts(lhs(formula))$aterms
+  if (length(aterms) == 0) {
+    return(aterms)
+  }
+  reasons <- c(
+    trials = paste("neither component takes a trial count: the growth",
+                   "component is continuous, and the survival component is one",
+                   "Bernoulli trial per individual. An aggregated count cannot",
+                   "be split into survivors and deaths row by row"),
+    weights = paste("whether a weight applies to the growth component, the",
+                    "survival component or both is a modelling decision that",
+                    "bnec_hurdle will not make for you. Make the two bnec()",
+                    "calls directly if you need it")
+  )
+  bad <- setdiff(names(aterms), "cens")
+  if (length(bad) > 0) {
+    detail <- vapply(bad, function(nm) {
+      why <- if (nm %in% names(reasons)) {
+        reasons[[nm]]
+      } else {
+        paste("it has no validated behaviour in a two-block fit, where the",
+              "response is split across two models")
+      }
+      paste0("\"", nm, "()\": ", why)
+    }, character(1))
+    stop("bnec_hurdle accepts only the cens() aterm on the response.",
+         " Rejected: ", paste0(detail, collapse = "; "), ".", call. = FALSE)
+  }
+  aterms
+}
+
+#' Check that no structural zero is also declared censored
+#'
+#' @param aterms The accepted aterms, as returned by
+#' \code{\link{check_hurdle_aterms}}.
+#' @param data The user's \code{\link[base]{data.frame}}.
+#' @param y The response vector.
+#' @param y_var The response variable name.
+#'
+#' @details The two kinds of zero a hurdle model exists to separate must stay
+#' separate in the input. A \code{0} response is a structural zero belonging to
+#' the Bernoulli component; a left-censored row is an observation of the growth
+#' component whose value is known only to be at or below a bound. A row claiming
+#' to be both is not a model this function can fit, and accepting it silently
+#' would reproduce exactly the confusion \code{vignette("example6")} warns
+#' about.
+#'
+#' @return \code{invisible(NULL)}, called for its side effect.
+#'
+#' @noRd
+check_hurdle_cens <- function(aterms, data, y, y_var) {
+  if (!"cens" %in% names(aterms)) {
+    return(invisible(NULL))
+  }
+  cens_arg <- as.list(aterms[["cens"]])[-1][[1]]
+  cens_vals <- if (length(all.vars(cens_arg)) == 0) {
+    # A literal, e.g. cens("left"), which brms recycles over every row.
+    # check_formula() already warns about this; here it still has to be checked
+    # against the zeros, because recycled over a response containing zeros it
+    # declares those zeros censored.
+    eval(cens_arg)
+  } else {
+    data[[all.vars(cens_arg)[1]]]
+  }
+  cens <- normalise_cens(cens_vals)
+  bad <- which(y == 0 & is_censored(cens))
+  if (length(bad) > 0) {
+    stop("Row(s) ",
+         paste0(bad[seq_len(min(10, length(bad)))], collapse = ", "),
+         if (length(bad) > 10) ", ..." else "",
+         " of \"", y_var, "\" are zero and also carry a censoring code other",
+         " than \"none\". A structural zero and a censored observation are the",
+         " two things a hurdle model exists to separate: a zero means the",
+         " individual gave no response at all, while a censored row is a real",
+         " observation known only to lie at or below a bound. Recode each row",
+         " as one or the other.", call. = FALSE)
+  }
+  invisible(NULL)
 }
 
 #' Replace the response of a bayesnecformula, keeping the right-hand side

--- a/man/bnec_hurdle.Rd
+++ b/man/bnec_hurdle.Rd
@@ -91,8 +91,12 @@ rows must be reinstated as zeros before calling this function.
 
 \bold{Censoring, and which aterms are allowed}
 
-\code{cens()} is the one \pkg{brms} aterm accepted on the response, because
-it is the one a hurdle model needs. A growth endpoint can be both
+\code{cens()} is the one aterm accepted on the response. \code{\link{bnec}}
+itself carries three -- \code{trials()}, \code{weights()} and
+\code{cens()} -- and of those \code{cens()} is the only one whose meaning
+stays unambiguous once the response is split across two models. It is also
+the one with a use here that nothing else covers. A growth endpoint can be
+both
 zero-bounded with structural zeros and left-censored at the recording
 resolution, and only a two-part model with a censored response component can
 tell the two apart: a death is a structural zero belonging to the Bernoulli
@@ -111,12 +115,14 @@ contribution there is \code{F(0) = 0}. The bound has to be the resolution
 limit, so the encoding is "at most the smallest resolvable value" rather than
 "at most zero".
 
-Other aterms are refused by name, with the reason. \code{trials()} has no
+The other two are refused by name, with the reason. \code{trials()} has no
 meaning for either component, and \code{weights()} is a modelling decision --
 whether a weight applies to the growth component, the survival component or
-both -- that this function will not make on the user's behalf. Making the two
-\code{\link{bnec}} calls directly remains available for anything outside this
-set.
+both -- that this function will not make on the user's behalf. Aterms beyond
+those three are refused here as well, though they would not reach \pkg{brms}
+in any case: \code{\link{model.frame}} drops them for an ordinary
+\code{\link{bnec}} fit too. Making the two \code{\link{bnec}} calls directly
+remains available for anything outside this set.
 }
 \examples{
 \dontrun{

--- a/man/bnec_hurdle.Rd
+++ b/man/bnec_hurdle.Rd
@@ -10,7 +10,9 @@ bnec_hurdle(formula, data, model_survival = NULL, family_growth = NULL, ...)
 \item{formula}{Either a \code{\link[base]{character}} string defining an
 R formula or an actual \code{\link[stats]{formula}} object. See
 \code{\link{bayesnecformula}}. The response must be untransformed, and zero
-values in it are taken to mean the individual did not survive.}
+values in it are taken to mean the individual did not survive. A
+\code{cens()} aterm is allowed alongside it; other aterms are refused, see
+Details.}
 
 \item{data}{A \code{\link[base]{data.frame}} containing the data to use with
 the \code{formula}. Every unit that entered the experiment must be present,
@@ -86,6 +88,35 @@ within each component independently.
 A \code{0} response means the individual did not survive; it is a label, not
 a measurement. Where mortality is instead recorded by omitting rows, those
 rows must be reinstated as zeros before calling this function.
+
+\bold{Censoring, and which aterms are allowed}
+
+\code{cens()} is the one \pkg{brms} aterm accepted on the response, because
+it is the one a hurdle model needs. A growth endpoint can be both
+zero-bounded with structural zeros and left-censored at the recording
+resolution, and only a two-part model with a censored response component can
+tell the two apart: a death is a structural zero belonging to the Bernoulli
+component, while a survivor measured below the limit is a real observation of
+the growth component whose value is known only to lie at or below a bound.
+
+The declaration is routed accordingly. It is passed through to the growth
+component, where the censoring indicator travels as an ordinary data column
+and is subset along with everything else, and it is dropped from the survival
+component, whose alive/dead response is observed exactly. A row that is both
+zero and censored is refused rather than assigned to one of them.
+
+Under a Gamma growth component the censoring bound cannot be \code{0} --
+\code{\link{bnec}} rejects that, correctly, because the censored likelihood
+contribution there is \code{F(0) = 0}. The bound has to be the resolution
+limit, so the encoding is "at most the smallest resolvable value" rather than
+"at most zero".
+
+Other aterms are refused by name, with the reason. \code{trials()} has no
+meaning for either component, and \code{weights()} is a modelling decision --
+whether a weight applies to the growth component, the survival component or
+both -- that this function will not make on the user's behalf. Making the two
+\code{\link{bnec}} calls directly remains available for anything outside this
+set.
 }
 \examples{
 \dontrun{

--- a/man/update.bayesnechurdlefit.Rd
+++ b/man/update.bayesnechurdlefit.Rd
@@ -11,7 +11,9 @@
 
 \item{newdata}{Optional new data. Split into the two component datasets the
 same way \code{\link{bnec_hurdle}} does, so zeros continue to denote the
-hurdle rather than being modelled as small responses.}
+hurdle rather than being modelled as small responses, and checked the same
+way: a row that is both zero and censored is refused here as it is at
+construction.}
 
 \item{...}{Further arguments to \code{\link[brms]{brm}}.}
 }

--- a/tests/testthat/test-bayesnechurdlefit-methods.R
+++ b/tests/testthat/test-bayesnechurdlefit-methods.R
@@ -81,6 +81,25 @@ test_that("update() requires the response column in newdata", {
                "must contain the response column")
 })
 
+test_that("update() re-checks the zero-vs-censored invariant on newdata", {
+  # The invariant is a property of the data, so a refit has to re-check it.
+  # Otherwise a row that is both zero and censored is dropped from the growth
+  # refit and coded as a death in the survival refit, with no message.
+  o <- mock_hurdle()
+  o$formula <- bnf(y | cens(cens) ~ crf(x, "nec3param"))
+  bad <- data.frame(x = 1:6, y = c(5, 4, 3, 0, 0, 0),
+                    cens = c(rep("none", 5), "left"))
+  expect_error(update(o, newdata = bad),
+               "zero and also carry a censoring code")
+  # A censored survivor is a growth observation and must still get past the
+  # check. The mock has no real component fit, so update() fails regardless --
+  # the point is only that it does not fail on the invariant.
+  ok <- bad
+  ok$cens <- c("left", rep("none", 5))
+  msg <- tryCatch(update(o, newdata = ok), error = conditionMessage)
+  expect_false(grepl("zero and also carry", msg))
+})
+
 test_that("summary carries its own class and print method", {
   expect_true(!is.null(getS3method("print", "hurdlesummary", optional = TRUE)))
   expect_true(!is.null(getS3method("summary", "bayesnechurdlefit", optional = TRUE)))

--- a/tests/testthat/test-bnec_hurdle.R
+++ b/tests/testthat/test-bnec_hurdle.R
@@ -80,6 +80,21 @@ test_that("check_hurdle_aterms accepts cens and rejects everything else", {
     ),
     "\"weights\\(\\)\""
   )
+  # A namespace-qualified aterm is the same aterm. The rest of the package
+  # matches on the bare name, so accepting brms::cens() keeps bnec_hurdle in
+  # step with what bnec() already takes.
+  expect_named(
+    bayesnec:::check_hurdle_aterms(
+      bnf(y | brms::cens(cens) ~ crf(x, "nec3param"))
+    ),
+    "cens"
+  )
+  expect_error(
+    bayesnec:::check_hurdle_aterms(
+      bnf(y | brms::weights(w) ~ crf(x, "nec3param"))
+    ),
+    "\"weights\\(\\)\".*modelling decision"
+  )
 })
 
 test_that("check_hurdle_cens separates structural from censored zeros", {
@@ -113,6 +128,15 @@ test_that("check_hurdle_cens separates structural from censored zeros", {
   # No cens() term at all is a no-op.
   expect_null(
     bayesnec:::check_hurdle_cens(list(), dat, dat$y, "y")
+  )
+  # An empty cens() has no indicator to check against, and should say so
+  # rather than fall over indexing an empty argument list.
+  empty <- bayesnec:::check_hurdle_aterms(
+    bnf(y | cens() ~ crf(x, "nec3param"))
+  )
+  expect_error(
+    bayesnec:::check_hurdle_cens(empty, dat, dat$y, "y"),
+    "cens\\(\\) was supplied with no arguments"
   )
 })
 

--- a/tests/testthat/test-bnec_hurdle.R
+++ b/tests/testthat/test-bnec_hurdle.R
@@ -17,6 +17,161 @@ test_that("hurdle_response_var rejects a transformed response", {
   )
 })
 
+test_that("hurdle_response_var reads the response past an aterm", {
+  # What bnec_hurdle needs is a bare *response*, not a bare left-hand side: an
+  # aterm alongside it does not make the zero-as-death convention ambiguous.
+  expect_equal(
+    bayesnec:::hurdle_response_var(bnf(y | cens(cens) ~ crf(x, "nec3param"))),
+    "y"
+  )
+  expect_equal(
+    bayesnec:::hurdle_response_var(
+      bnf(y | cens(cens, ub) ~ crf(x, "nec3param"))
+    ),
+    "y"
+  )
+  expect_equal(
+    bayesnec:::hurdle_response_var(
+      bnf(y | trials(n) + cens(cens) ~ crf(x, "nec3param"))
+    ),
+    "y"
+  )
+  # A transformed response is still rejected, and the message names the
+  # response rather than the whole left-hand side.
+  expect_error(
+    bayesnec:::hurdle_response_var(bnf(log(y) | cens(cens) ~ crf(x, "n"))),
+    "You supplied \"log\\(y\\)\""
+  )
+})
+
+test_that("check_hurdle_aterms accepts cens and rejects everything else", {
+  expect_length(
+    bayesnec:::check_hurdle_aterms(bnf(y ~ crf(x, "nec3param"))), 0
+  )
+  expect_named(
+    bayesnec:::check_hurdle_aterms(bnf(y | cens(cens) ~ crf(x, "nec3param"))),
+    "cens"
+  )
+  expect_named(
+    bayesnec:::check_hurdle_aterms(
+      bnf(y | cens(cens, ub) ~ crf(x, "nec3param"))
+    ),
+    "cens"
+  )
+  # Each rejected aterm is named, with the reason it cannot apply.
+  expect_error(
+    bayesnec:::check_hurdle_aterms(bnf(y | weights(w) ~ crf(x, "nec3param"))),
+    "\"weights\\(\\)\".*modelling decision"
+  )
+  expect_error(
+    bayesnec:::check_hurdle_aterms(bnf(y | trials(n) ~ crf(x, "nec3param"))),
+    "\"trials\\(\\)\".*Bernoulli trial per individual"
+  )
+  # An unrecognised aterm still gets named rather than falling through.
+  expect_error(
+    bayesnec:::check_hurdle_aterms(bnf(y | se(sigma) ~ crf(x, "nec3param"))),
+    "\"se\\(\\)\""
+  ) |>
+    suppressMessages()
+  # Rejected alongside an accepted one.
+  expect_error(
+    bayesnec:::check_hurdle_aterms(
+      bnf(y | cens(cens) + weights(w) ~ crf(x, "nec3param"))
+    ),
+    "\"weights\\(\\)\""
+  )
+})
+
+test_that("check_hurdle_cens separates structural from censored zeros", {
+  dat <- data.frame(x = rep(1:4, each = 5), y = c(rep(2, 15), rep(0, 5)))
+  dat$cens <- "none"
+  aterms <- bayesnec:::check_hurdle_aterms(
+    bnf(y | cens(cens) ~ crf(x, "nec3param"))
+  )
+  # A left-censored survivor is fine: it is an observation of the growth
+  # component, known only to lie at or below a bound.
+  ok <- dat
+  ok$y[1:2] <- 0.05
+  ok$cens[1:2] <- "left"
+  expect_null(bayesnec:::check_hurdle_cens(aterms, ok, ok$y, "y"))
+  # A row that is both zero and censored is refused: it claims to be both kinds
+  # of zero at once, which is what the hurdle exists to tell apart.
+  bad <- dat
+  bad$cens[bad$y == 0][1:2] <- "left"
+  expect_error(
+    bayesnec:::check_hurdle_cens(aterms, bad, bad$y, "y"),
+    "zero and also carry a censoring code"
+  )
+  # A recycled literal declares every row censored, zeros included.
+  lit <- bayesnec:::check_hurdle_aterms(
+    bnf(y | cens("left") ~ crf(x, "nec3param"))
+  )
+  expect_error(
+    bayesnec:::check_hurdle_cens(lit, dat, dat$y, "y"),
+    "zero and also carry a censoring code"
+  )
+  # No cens() term at all is a no-op.
+  expect_null(
+    bayesnec:::check_hurdle_cens(list(), dat, dat$y, "y")
+  )
+})
+
+test_that("bnec_hurdle rejects a censored structural zero", {
+  dat <- data.frame(x = rep(1:4, each = 5), y = c(rep(2, 15), rep(0, 5)),
+                    cens = "none")
+  dat$cens[dat$y == 0][1] <- "left"
+  expect_error(
+    bnec_hurdle(y | cens(cens) ~ crf(x, "nec3param"), data = dat),
+    "zero and also carry a censoring code"
+  )
+  expect_error(
+    bnec_hurdle(y | weights(x) ~ crf(x, "nec3param"), data = dat),
+    "only the cens\\(\\) aterm"
+  )
+})
+
+test_that("bnec_hurdle fits a censored response and routes it correctly", {
+  if (Sys.getenv("NOT_CRAN") == "") {
+    skip_on_cran()
+  }
+  set.seed(17)
+  dat <- nec_data
+  dat$y[dat$x > 2.5] <- 0
+  dat$cens <- "none"
+  # Left-censored *survivors*: real observations of the growth component, known
+  # only to lie at or below the recording limit. They must not be routed to the
+  # hurdle block.
+  lod <- unname(quantile(dat$y[dat$y > 0], 0.15))
+  is_lo <- dat$y > 0 & dat$y < lod
+  dat$y[is_lo] <- lod
+  dat$cens[is_lo] <- "left"
+  expect_gt(sum(is_lo), 0)
+  fit <- bnec_hurdle(y | cens(cens) ~ crf(x, "nec3param"), data = dat,
+                     iter = 400, warmup = 200, chains = 2, seed = 17,
+                     refresh = 0, open_progress = FALSE) |>
+    suppressMessages() |>
+    suppressWarnings()
+  expect_s3_class(fit, "bayesnechurdlefit")
+  # Every survivor, censored or not, is in the growth component.
+  expect_equal(nrow(fit$growth$fit$data), sum(dat$y > 0))
+  expect_equal(sum(fit$survival$fit$data$.alive), sum(dat$y > 0))
+  # The declaration reached the growth block and only the growth block.
+  expect_true("cens" %in% names(fit$growth$fit$data))
+  expect_false(is.null(standata(fit$growth$fit)$cens))
+  expect_true(is.null(standata(fit$survival$fit)$cens))
+})
+
+test_that("swap_response drops an aterm from the survival component", {
+  # The Bernoulli response is alive/dead, observed exactly, so there is nothing
+  # for a censoring declaration to bound. Incidental in the original
+  # implementation; asserted here so it stays deliberate.
+  out <- bayesnec:::swap_response(
+    bnf(y | cens(cens) ~ crf(x, "nec3param")), ".alive"
+  )
+  expect_false(grepl("cens(", deparse1(out), fixed = TRUE))
+  expect_equal(bayesnec:::hurdle_response_var(out), ".alive")
+})
+
 test_that("swap_response replaces the lhs and keeps the rhs", {
   out <- bayesnec:::swap_response(bnf(y ~ crf(x, "nec3param")), ".alive")
   expect_s3_class(out, "bayesnecformula")


### PR DESCRIPTION
Closes #188.

## What changed

`bnec_hurdle()` accepts a `cens()` aterm on the response. Everything else on the
left of the formula keeps erroring, but now by name and with the reason.

- **`hurdle_response_var()` validates the response, not the whole left-hand
  side.** It previously required the entire LHS to deparse to a bare name, which
  is stricter than the constraint it protects: what the zero-as-death convention
  needs is that the *response variable* be a bare, untransformed name, and an
  aterm alongside it does not threaten that. A new `hurdle_lhs_parts()` splits
  the LHS into response and aterms; a transformed response is still rejected,
  and the message now names the response rather than the whole LHS.
- **`check_hurdle_aterms()`** accepts `cens()` and refuses the rest by name.
  `trials()` — neither component takes a trial count, and an aggregated count
  could not be split into survivors and deaths row by row. `weights()` — whether
  a weight applies to the growth component, the survival component or both is a
  modelling decision, and guessing it would silently change the model. Anything
  unrecognised gets a generic reason but is still named.
- **Routing.** The growth component gets the formula unchanged, aterms included:
  the censoring indicator is an ordinary data column, so the existing
  `data[y > 0, , drop = FALSE]` subset carries it along. The survival component
  drops it, because the alive/dead response is observed exactly. That was
  already what `swap_response()` did by rebuilding from `rhs()` alone; it is now
  deliberate, commented and tested rather than incidental.
- **`check_hurdle_cens()`** refuses any row that is both zero and censored. A
  structural zero and a censored observation are the two things a hurdle model
  exists to separate, and a row claiming to be both cannot be assigned to either
  block. The recycled-literal form `cens("left")` is caught by the same check.
- `?bnec_hurdle` gains a *Censoring, and which aterms are allowed* section,
  including the caveat that under a Gamma growth component the censoring bound
  cannot be `0` (`bnec()` already rejects that, correctly) — the bound has to be
  the resolution limit, so the encoding is "at most the smallest resolvable
  value" rather than "at most zero".

## How it was verified

**The issue's reprex fits.** It returns a `bayesnechurdlefit`.

**Simulated data where the answer is known** — 150 individuals, `nec3param`
growth with `top = 10`, `nec = 2`, `beta = log(0.6)`, mortality rising with
concentration, and survivors below a recording limit of 1.5 recoded as
left-censored at that limit:

```
survivors in data: 130   rows in growth fit: 130
alive coded in survival fit: 130
cens column present in growth data: TRUE
growth formula:   y | cens(cens) ~ top * exp(-exp(beta) * (x - nec) * step(x - nec))
survival formula: .alive ~ top * exp(-exp(beta) * (x - nec) * step(x - nec))
cens reached Stan (growth):   TRUE
cens reached Stan (survival): FALSE

growth parameters (truth: top 10, nec 2, beta log(0.6) = -0.51)
                 Estimate    Q2.5   Q97.5
top_Intercept      10.062   9.518  10.724
beta_Intercept     -0.516  -0.604  -0.417
nec_Intercept       1.985   1.787   2.199
```

This is the hazard the queue entry names: a left-censored survivor is an
observation of the growth component, not a structural zero. All 130 survivors
are in the growth fit and all 130 are coded alive in the survival fit, so no
censored survivor was routed to the hurdle block. The censoring declaration
reaches Stan for the growth block and not for the survival block.

**Tests.** `devtools::test()` on `test-bnec_hurdle.R`: 53 passing; on
`test-cens.R`, `test-bayesnechurdlefit-methods.R`, `test-bayesnecformula.R`,
`test-check_formula.R`, `test-make_brmsformula.R` together: 148 passing.
New tests cover the accepted case (`cens()` alone, with an interval upper bound,
and reading the response past an aterm), the rejected cases (`weights()`,
`trials()`, an unrecognised aterm, and a rejected aterm alongside an accepted
one), both directions of the zero-versus-censored check, that `swap_response()`
drops the aterm, and an end-to-end fit asserting the routing above.

## Observed while verifying, not fixed here

The reprex takes several minutes before it starts sampling, all of it in
`make_good_inits()`. Its growth data has three distinct response values across
30 rows, no candidate draw satisfies `check_init_predictions()`, and the search
runs its full `n_trials = 1e4` — about 5 minutes at ~30 ms a trial — before
falling back to Stan's random initialisation. Nothing to do with this change;
it is the same failure mode as #177, which is next in the queue, and worth
noting there that the cost is paid in full even when the search is hopeless.
