### PR TITLE
Exclude the unscaled power hormesis models for bounded responses (#177)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -198,6 +198,24 @@
   `NA` by `as.numeric()`, and then evaluated as `while (NA)` — "missing value
   where TRUE/FALSE needed". Blank bounds are now normalised before use, which is
   the second half of what `get_priors()` needed to round trip.
+- `nechormepwr` and `nechorme4pwr` are now excluded up front for 0-1 bounded
+  families under an identity link, and for the zero-probability block of the
+  two-block families, instead of failing after minutes of fruitless
+  initialisation. Their hormesis term is `x^(1 / (1 + exp(slope)))`, which
+  carries no coefficient: the exponent lies in (0, 1), so at `x = 1` the term
+  contributes exactly 1 whatever `slope` is, and below the threshold — where the
+  decay factor is exactly 1 — the fitted mean is at least `top + 1`. No
+  parameter value keeps that inside (0, 1) for a predictor that reaches 1, so
+  there is nothing for a better initial-value search to find. `nechormepwr01` is
+  the bounded hormesis form and is unaffected, as are `nechorme` and
+  `nechorme4`, whose increment is scaled by `exp(slope)`.
+- The consequence in practice: `model = "zero_bounded"` under `hurdle_gamma`
+  reported 11 models and averaged over 9 — one dropped by design and one lost
+  silently to an initialisation failure that cost roughly eight minutes per run.
+  It now reports 9, and says why each was dropped. The message for these two
+  names the reason rather than sharing the generic one, and points at the
+  hormesis models that do work on a bounded response. See
+  [#177](https://github.com/open-AIMS/bayesnec/issues/177).
 
 # bayesnec 2.1.3.6
 

--- a/R/check_models.R
+++ b/R/check_models.R
@@ -1,3 +1,59 @@
+#' Models excluded from 0-1 bounded identity families because they can go
+#' negative
+#'
+#' \code{neclin}, \code{neclinhorme} and \code{ecxlin} decay by subtraction
+#' rather than by an exponential factor, so their fitted mean is unbounded
+#' below. Named in one place because both the single-block and the two-block
+#' branch need the same list.
+#'
+#' @return A \code{\link[base]{character}} vector.
+#'
+#' @noRd
+bounded_linear_drops <- function() {
+  c("neclin", "neclinhorme", "ecxlin")
+}
+
+#' Models excluded from 0-1 bounded identity families because they can exceed 1
+#'
+#' \code{nechormepwr} and \code{nechorme4pwr} carry the hormesis term
+#' \code{x^(1 / (1 + exp(slope)))}, which has no coefficient. The exponent lies
+#' in (0, 1), so at \code{x = 1} the term contributes exactly 1 whatever
+#' \code{slope} is, and below the threshold -- where the decay factor is exactly
+#' 1 -- the fitted mean is at least \code{top + 1}. No parameter value keeps that
+#' inside (0, 1) for a predictor that reaches 1, which is why the initial-value
+#' search cannot be fixed for this combination: there is nothing to find. See
+#' #177.
+#'
+#' @return A \code{\link[base]{character}} vector.
+#'
+#' @noRd
+bounded_power_drops <- function() {
+  c("nechormepwr", "nechorme4pwr")
+}
+
+#' The message explaining an unscaled-power exclusion
+#'
+#' Separate from the generic drop message because the reason is different, and
+#' because the previous behaviour -- roughly eight minutes of failed
+#' initialisation followed by "Initialization failed" buried in a long run --
+#' is exactly what makes an explicit reason worth the extra line.
+#'
+#' @param drop_model The models being dropped.
+#' @param fam_tag The family tag.
+#'
+#' @return A \code{\link[base]{character}} string.
+#'
+#' @noRd
+unscaled_power_message <- function(drop_model, fam_tag) {
+  paste0("Dropping the model(s) ", paste0(drop_model, collapse = ", "),
+         " as they are not valid in the case of a ", fam_tag,
+         " with identity link: their hormesis term",
+         " x^(1 / (1 + exp(slope))) has no scale parameter, so the fitted mean",
+         " is at least top + 1 wherever the predictor reaches 1 and cannot be",
+         " held inside (0, 1). Use nechorme, nechorme4 or nechormepwr01 for a",
+         " hormesis model on a bounded response. See ?models.")
+}
+
 #' check_models
 #'
 #' Check model input for a Bayesian model fit
@@ -35,13 +91,19 @@ check_models <- function(model, family, data) {
   }
   if (link_tag == "identity" & fam_tag %in%
         c("bernoulli", "beta", "binomial", "beta_binomial")) {
-    use_model <-  model[!model %in% c("neclin", "neclinhorme", "ecxlin")]
+    use_model <- model[!model %in% bounded_linear_drops()]
     drop_model <- setdiff(model, use_model)
     if (length(drop_model) > 0) {
       message(paste("Dropping the model(s)",
                     paste0(drop_model, collapse = ", "),
                     "as they are not valid in the case of a",
                     fam_tag, "with identity link."))
+    }
+    model <- use_model
+    use_model <- model[!model %in% bounded_power_drops()]
+    drop_model <- setdiff(model, use_model)
+    if (length(drop_model) > 0) {
+      message(unscaled_power_message(drop_model, fam_tag))
     }
     if (length(use_model) == 0) {
       stop(paste("None of the model(s) specified are valid for a",
@@ -57,7 +119,7 @@ check_models <- function(model, family, data) {
     # family: zero-bounded for hurdle_gamma, which additionally rules out
     # nechormepwr01; 0-1 bounded for zero_inflated_beta, which does not, since
     # nechormepwr01 is the equation designed for that range.
-    drop_always <- c("neclin", "neclinhorme", "ecxlin")
+    drop_always <- bounded_linear_drops()
     mu_fam <- unname(hurdle_mu_fams[[fam_tag]])
     if (mu_fam %in% c("Gamma", "poisson", "negbinomial")) {
       drop_always <- c(drop_always, "nechormepwr01")
@@ -69,6 +131,17 @@ check_models <- function(model, family, data) {
                     paste0(drop_model, collapse = ", "),
                     "as they are not valid in the case of a",
                     fam_tag, "with identity link."))
+    }
+    model <- use_model
+    # The zero-probability block is 0-1 bounded whatever the response family
+    # is, so the unscaled-power hormesis models cannot be used for it either.
+    # Without this a `model = "zero_bounded"` call under hurdle_gamma silently
+    # averaged over 9 equations rather than 11 -- one dropped by design and one
+    # lost to an eight-minute initialisation failure. See #177.
+    use_model <- model[!model %in% bounded_power_drops()]
+    drop_model <- setdiff(model, use_model)
+    if (length(drop_model) > 0) {
+      message(unscaled_power_message(drop_model, fam_tag))
     }
     if (length(use_model) == 0) {
       stop(paste("None of the model(s) specified are valid for a",

--- a/R/models.R
+++ b/R/models.R
@@ -44,8 +44,17 @@
 #' beta, beta_binomial) using an identity link. Note that the linear-decay
 #' restriction applies to the models containing "lin" only
 #' ("neclin", "neclinhorme", "ecxlin"); the hormesis models that also carry a
-#' "slope" parameter are retained for 0, 1 bounded families. Conversely
-#' "nechormepwr01" is excluded for the zero-bounded identity families, being
+#' "slope" parameter are retained for 0, 1 bounded families, with two
+#' exceptions. Models whose hormesis term raises the predictor to a power with
+#' no coefficient ("nechormepwr", "nechorme4pwr") are excluded for 0, 1 bounded
+#' families under an identity link. The term
+#' \code{x^(1 / (1 + exp(slope)))} contributes exactly 1 at \code{x = 1}
+#' whatever "slope" is, and below the threshold the decay factor is 1, so the
+#' fitted mean is at least \code{top + 1} wherever the predictor reaches 1.
+#' There is no parameter value that keeps it inside (0, 1), which is why this is
+#' an exclusion rather than a harder search for initial values.
+#' "nechormepwr01" is the bounded hormesis form and is retained there;
+#' conversely it is excluded for the zero-bounded identity families, being
 #' bounded on (0, 1) by construction and so unable to represent a response with
 #' no upper bound. Additionally,
 #' models that raise the predictor to a fractional power ("ecxsigm",

--- a/man/models.Rd
+++ b/man/models.Rd
@@ -56,8 +56,17 @@ identity link, nor for families that are 0, 1 bounded (bernoulli, binomial,
 beta, beta_binomial) using an identity link. Note that the linear-decay
 restriction applies to the models containing "lin" only
 ("neclin", "neclinhorme", "ecxlin"); the hormesis models that also carry a
-"slope" parameter are retained for 0, 1 bounded families. Conversely
-"nechormepwr01" is excluded for the zero-bounded identity families, being
+"slope" parameter are retained for 0, 1 bounded families, with two
+exceptions. Models whose hormesis term raises the predictor to a power with
+no coefficient ("nechormepwr", "nechorme4pwr") are excluded for 0, 1 bounded
+families under an identity link. The term
+\code{x^(1 / (1 + exp(slope)))} contributes exactly 1 at \code{x = 1}
+whatever "slope" is, and below the threshold the decay factor is 1, so the
+fitted mean is at least \code{top + 1} wherever the predictor reaches 1.
+There is no parameter value that keeps it inside (0, 1), which is why this is
+an exclusion rather than a harder search for initial values.
+"nechormepwr01" is the bounded hormesis form and is retained there;
+conversely it is excluded for the zero-bounded identity families, being
 bounded on (0, 1) by construction and so unable to represent a response with
 no upper bound. Additionally,
 models that raise the predictor to a fractional power ("ecxsigm",

--- a/tests/testthat/test-bnec.R
+++ b/tests/testthat/test-bnec.R
@@ -15,7 +15,12 @@ test_that("user-supplied `prior` is not captured by partial matching to `prior_t
 })
 
 test_that("Check models inappropriate for negative x are dropped", {
- bnec(y ~ crf(log_x, "nechorme4pwr"), data = nec_data) |>
+  # The family is given explicitly because nec_data's response is 0-1 bounded,
+  # for which nechorme4pwr is now excluded up front (#177) -- the negative-x
+  # rule would never be reached. Gamma leaves it in the set so that this test
+  # still exercises the rule it is about.
+  bnec(y ~ crf(log_x, "nechorme4pwr"), data = nec_data,
+       family = Gamma(link = "identity")) |>
     expect_message("Dropping the model\\(s\\) nechorme4pwr as they are not valid for data with negative predictor \\(x\\) values\\.") |>
     expect_error("No valid models have been supplied for this data type.")
 })

--- a/tests/testthat/test-nechormepwr-bounded.R
+++ b/tests/testthat/test-nechormepwr-bounded.R
@@ -1,0 +1,101 @@
+test_that("the unscaled power hormesis models are dropped for 0-1 bounded families", {
+  # nechormepwr and nechorme4pwr carry the hormesis term x^(1/(1 + exp(slope))),
+  # which has no coefficient. At x = 1 it contributes exactly 1 whatever slope
+  # is, so below the threshold -- where the decay factor is exactly 1 -- the
+  # fitted mean is at least top + 1. No parameter value keeps that inside
+  # (0, 1) for a predictor that reaches 1. See #177.
+  bounded <- list(
+    bernoulli = validate_family(bernoulli(link = "identity")),
+    beta = validate_family(Beta(link = "identity")),
+    binomial = validate_family(binomial(link = "identity")),
+    beta_binomial = validate_family(beta_binomial(link = "identity"))
+  )
+  for (fam in bounded) {
+    got <- suppressMessages(check_models(models()$all, fam))
+    expect_false("nechormepwr" %in% got)
+    expect_false("nechorme4pwr" %in% got)
+    # The sibling hormesis models are unaffected: their increment is scaled.
+    expect_true("nechorme" %in% got)
+    expect_true("nechorme4" %in% got)
+    expect_true("nechormepwr01" %in% got)
+  }
+  # Unbounded and zero-bounded responses keep them.
+  expect_true(
+    "nechormepwr" %in%
+      suppressMessages(check_models(models()$all,
+                                    validate_family(Gamma(link = "identity"))))
+  )
+  expect_true(
+    "nechorme4pwr" %in%
+      suppressMessages(check_models(models()$all, validate_family("gaussian")))
+  )
+})
+
+test_that("the two-block families drop them too", {
+  # The zero-probability block of a joint fit is 0-1 bounded whatever the
+  # response family is, so a model that cannot be held inside (0, 1) cannot be
+  # used for it. This is the "9 of 11 rather than 11" the issue reports.
+  for (fam_tag in c("hurdle_gamma", "zero_inflated_beta")) {
+    got <- suppressMessages(
+      check_models(models()$all, validate_family(fam_tag))
+    )
+    expect_false("nechormepwr" %in% got)
+    expect_false("nechorme4pwr" %in% got)
+  }
+  # zero_bounded under hurdle_gamma is now an honest count.
+  zb <- suppressMessages(
+    check_models(models()$zero_bounded, validate_family("hurdle_gamma"))
+  )
+  expect_false("nechormepwr" %in% zb)
+  expect_false("nechormepwr01" %in% zb)
+})
+
+test_that("the exclusion is named and explained", {
+  expect_message(
+    check_models(c("nechormepwr", "nec3param"),
+                 validate_family(Beta(link = "identity"))),
+    "nechormepwr"
+  )
+  expect_message(
+    check_models(c("nechormepwr", "nec3param"),
+                 validate_family(Beta(link = "identity"))),
+    "no scale parameter"
+  )
+  # Asking for nothing else is an error rather than an empty set.
+  expect_error(
+    check_models("nechormepwr", validate_family(Beta(link = "identity"))) |>
+      suppressMessages(),
+    "None of the model"
+  )
+})
+
+test_that("initialisation confirms why they are excluded", {
+  if (Sys.getenv("NOT_CRAN") == "") {
+    skip_on_cran()
+  }
+  # The evidence behind the exclusion, kept as a test so that a future change to
+  # the init search is measured against it rather than assumed to have fixed it.
+  fam <- validate_family(bernoulli(link = "identity"))
+  found <- function(model, x, y) {
+    pr <- define_prior(model, fam, x, y)
+    ii <- suppressMessages(
+      bayesnec:::make_good_inits(model, x, y, n_trials = 200, seed = 1,
+                                 priors = pr, chains = 2)
+    )
+    !(length(ii) == 1 && identical(ii$random, "random"))
+  }
+  y <- nec_data$y
+  x_over_one <- nec_data$x                                  # reaches 3.22
+  x_under_one <- nec_data$x / max(nec_data$x) * 0.9         # stays below 1
+  expect_false(found("nechormepwr", x_over_one, y))
+  expect_false(found("nechorme4pwr", x_over_one, y))
+  # Not a defect of the search: the same models initialise when the predictor
+  # never reaches 1, which is the only case the equation can represent. That is
+  # a property of the units the predictor happens to be in, not of the model,
+  # which is why the exclusion is by family rather than conditional on the data.
+  expect_true(found("nechormepwr", x_under_one, y))
+  expect_true(found("nechorme4pwr", x_under_one, y))
+  # The scaled siblings initialise either way.
+  expect_true(found("nechorme", x_over_one, y))
+  expect_true(found("nechormepwr01", x_over_one, y))
+})


### PR DESCRIPTION
Closes #177. The queue entry allows either outcome — fix the initialisation, or
exclude the model by name with a message. **The investigation says it cannot be
fixed**, so this is the exclusion, and the reasoning is below.

## Why the initial-value search cannot be made to work

`nechormepwr` is

```
mu = (top + x^(1 / (1 + exp(slope)))) * exp(-exp(beta) * (x - nec) * step(x - nec))
```

The hormesis term is a power of the predictor **with no coefficient**. The
exponent lies in (0, 1), so at `x = 1` the term contributes exactly 1 whatever
`slope` is. Below the threshold the decay factor is exactly 1. So for every `x`
in `[1, nec]` the fitted mean is at least `top + 1`, and for a 0-1 bounded family
`top > 0`, so `mu > 1` there for **every** point in the parameter space.

There is nothing for a better search to find. `nechorme4pwr` has the same term
and the same problem. Contrast `nechorme`, whose increment is `exp(slope) * x`
and can be shrunk to nothing by `slope`, and `nechormepwr01`, which is bounded in
(0, 1) by construction.

Measured, with `make_good_inits(n_trials = 200)` against a bernoulli/identity
response:

| model | predictor up to 3.22 | predictor up to 0.90 |
|---|---|---|
| `nechormepwr` | **not found** (13.5 s) | found (2.6 s) |
| `nechorme4pwr` | **not found** (13.3 s) | found (4.0 s) |
| `nechorme` | found (0.0 s) | found (0.0 s) |
| `nechormepwr01` | found (0.0 s) | found (0.0 s) |

The predictor-scaled second column is the point: these two *can* be initialised
when the predictor never reaches 1, which is a property of the units the user
happened to use rather than of the model. That is why the exclusion is by family
rather than conditional on the data — the same rule every other exclusion in
`check_models()` follows, and rescaling `x` is not a fix a user should have to
discover from an eight-minute failure.

The queue entry warns that "a fix that makes the model fit but converge badly is
worse than an explicit exclusion". There is no such fix available here.

## What changed

- **`check_models()`** drops `nechormepwr` and `nechorme4pwr` for
  `bernoulli`, `beta`, `binomial` and `beta_binomial` under an identity link,
  and for the two-block families, whose zero-probability block is 0-1 bounded
  whatever the response family is. That last one is the case in the issue:
  `model = "zero_bounded"` under `hurdle_gamma` reported 11 models and averaged
  over 9.
- **The message names the reason** rather than sharing the generic drop message,
  and points at `nechorme`, `nechorme4` and `nechormepwr01` — which is what the
  user wanted. Previously the run printed *"bayesnec failed to find initial
  values"*, spent about eight minutes, then *"Initialization failed"* somewhere
  in the middle of a long log.
- The three lists behind the two rules are named — `bounded_linear_drops()` and
  `bounded_power_drops()` — because the single-block and two-block branches need
  the same ones and had been restating them.
- `?models` explains the exclusion, including why it is an exclusion and not a
  harder search.

Now, for `model = "zero_bounded"` under `hurdle_gamma`:

```
Dropping the model(s) nechormepwr01 as they are not valid in the case of a
  hurdle_gamma with identity link.
Dropping the model(s) nechormepwr as they are not valid in the case of a
  hurdle_gamma with identity link: their hormesis term x^(1 / (1 + exp(slope)))
  has no scale parameter, so the fitted mean is at least top + 1 wherever the
  predictor reaches 1 and cannot be held inside (0, 1). Use nechorme, nechorme4
  or nechormepwr01 for a hormesis model on a bounded response. See ?models.
```

and the set is 9 models, honestly reported.

## How it was verified

- `tests/testthat/test-nechormepwr-bounded.R`: the exclusion across all four
  bounded families and both two-block families; the siblings surviving; the
  models kept for Gamma and gaussian; the message naming the model and the
  reason; the all-dropped error; and the initialisation evidence above, kept as
  a test so a future change to the init search is measured against it rather
  than assumed to have fixed things.
- `test-check_models.R`, `test-modname.R`, `test-hurdle_family.R`,
  `test-inits_functions.R` and the new file together: **454 passing, 0 failing**.
- One existing test changed. `test-bnec.R` asserted the negative-predictor rule
  using `nechorme4pwr` on `nec_data`, whose response is 0-1 bounded, so the new
  exclusion fired first and the negative-`x` message never appeared. The test now
  passes `family = Gamma(link = "identity")` so that it still exercises the rule
  it is about. The negative-`x` behaviour itself is unchanged.

## Note for review — overlap with #170

`models(c(0, 1))` restates the exclusion list rather than deriving it, so this
branch adds the two names there as well. **PR #200 (#170) deletes that list**,
replacing it with a call to `check_models()`. Whichever merges second will
conflict on those lines; take #170's version, which picks this change up
automatically and cannot drift again.

## Left undone

`nechormepwr` and `nechorme4pwr` remain available for unbounded and zero-bounded
responses, where the term is legitimate. Nothing here changes those.
