### PR TITLE
Stop caching the posterior prediction matrix on fitted objects (#180)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -280,9 +280,10 @@
   `pred_vals$data`, the small summary that `plot()` and `autoplot()` use, is
   unchanged. See [#180](https://github.com/open-AIMS/bayesnec/issues/180).
 - The matrix had exactly one reader in the package, the model-averaging path in
-  `expand_manec()`, which now builds its own for the duration of that call and
-  discards it. The weighted draws are the same. Nothing else read it:
-  `predict()` did not, and the plot methods use the summary.
+  `expand_manec()`, which now builds each model's posterior itself and thins it
+  to the weighted draws one model at a time. The weighted draws are the same.
+  Nothing else read it: `predict()` did not, and the plot methods use the
+  summary.
 - This is a net saving in computation, not a trade. `expand_nec()` used to
   compute the matrix for every model whether or not anything needed it; it now
   computes it only where it does — for smooth (`ecx`-type) models, whose NSEC is
@@ -290,11 +291,32 @@
   on its own no longer computes it at all. The one place it is computed twice is
   a model set containing smooth models, at about 0.2 s per model against fitting
   times measured in minutes.
-- Objects saved before this change still carry the matrix and are unaffected;
-  every accessor works on both, which is tested. Two things that were not
-  touched and remain: a `bayesmanecfit` still stores `w_pred_vals$posterior`,
-  the single weighted matrix, and a two-block fit still stores its two component
-  curves in `hurdle$mu_pred` and `hurdle$hu_pred`.
+- **This is a breaking change for code that read the matrix off a fitted
+  object.** `x$pred_vals$posterior` now returns `NULL` rather than erroring, so
+  downstream code will fail a step later. Replace it with
+  `posterior_epred(x, newdata = bnec_newdata(x, resolution = 1000), re_formula = NA)`,
+  which returns the same thing computed on demand. Objects saved before this
+  change still carry the matrix and are unaffected; every accessor works on
+  both, which is tested.
+- A `bayesmanecfit` no longer stores `w_pred_vals$posterior` either, the single
+  `sample_size x resolution` matrix of model-weighted draws. Once the per-model
+  matrices were gone this was 77% of what remained — 7.65 MB of a 9.90 MB
+  five-model set, and roughly 64 MB on its own at the package defaults. Nothing
+  in the package read it. `w_pred_vals$data` is unchanged, and the same
+  `posterior_epred()` call above reproduces the draws, sampling the component
+  models in the same weighted proportions. See
+  [#213](https://github.com/open-AIMS/bayesnec/issues/213).
+- A two-block fit no longer stores `hurdle$mu_pred` and `hurdle$hu_pred`, the
+  two component curves. They were written on every hurdle fit and never read
+  anywhere, so they are no longer computed at all — removing two
+  `posterior_epred()` calls per two-block fit, and four per `bnec_hurdle()`
+  pair. See [#214](https://github.com/open-AIMS/bayesnec/issues/214).
+- The prediction grid is now built in exactly one place. `bnec_newdata()`,
+  `expand_nec()` and the internal `posterior_on_grid()` had three separate
+  copies of the same code, which disagreed on a partially specified `x_range`:
+  `bnec_newdata()` silently ignored it, the other two produced `seq(NA, NA)`.
+  A partially specified `x_range` is now rejected with a clear error. See
+  [#211](https://github.com/open-AIMS/bayesnec/issues/211).
 
 # bayesnec 2.1.3.6
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -243,6 +243,30 @@
   parameter", which would be wrong for `zero_inflated_negbinomial`.
 - Neither family is selected automatically. A count response is still read as
   `poisson`; the zero-inflated forms have to be asked for.
+- A fitted object no longer stores `pred_vals$posterior`, the
+  `n_draws x resolution` matrix of posterior predictions over the plotting grid.
+  It dominated the size of every fit — **31.8 MB against a 1.2 MB `brmsfit`** at
+  the package defaults, 96% of the object — and the cost multiplied with the
+  model set and with `iter`: `model = "all"` retained roughly 1.5 GB in a single
+  `bnec()` call. The measured reproducer from the issue now returns **1.28 MB**.
+  `pred_vals$data`, the small summary that `plot()` and `autoplot()` use, is
+  unchanged. See [#180](https://github.com/open-AIMS/bayesnec/issues/180).
+- The matrix had exactly one reader in the package, the model-averaging path in
+  `expand_manec()`, which now builds its own for the duration of that call and
+  discards it. The weighted draws are the same. Nothing else read it:
+  `predict()` did not, and the plot methods use the summary.
+- This is a net saving in computation, not a trade. `expand_nec()` used to
+  compute the matrix for every model whether or not anything needed it; it now
+  computes it only where it does — for smooth (`ecx`-type) models, whose NSEC is
+  read off the curve, and for the two-block families. A threshold model fitted
+  on its own no longer computes it at all. The one place it is computed twice is
+  a model set containing smooth models, at about 0.2 s per model against fitting
+  times measured in minutes.
+- Objects saved before this change still carry the matrix and are unaffected;
+  every accessor works on both, which is tested. Two things that were not
+  touched and remain: a `bayesmanecfit` still stores `w_pred_vals$posterior`,
+  the single weighted matrix, and a two-block fit still stores its two component
+  curves in `hurdle$mu_pred` and `hurdle$hu_pred`.
 
 # bayesnec 2.1.3.6
 

--- a/R/bayesmanecfit-class.R
+++ b/R/bayesmanecfit-class.R
@@ -30,9 +30,17 @@
 #' data.
 #' @slot w_residuals Model-weighted residual values
 #' (i.e. observed - w_predicted_y).
-#' @slot w_pred_vals A \code{\link[base]{list}} containing model-weighted
-#' posterior predicted values based on the supplied \code{resolution} and
-#' \code{x_range}.
+#' @slot w_pred_vals A \code{\link[base]{list}} with a single element
+#' \code{data}, a \code{\link[base]{data.frame}} of summary model-weighted
+#' posterior predicted values over a grid set by \code{resolution} and
+#' \code{x_range}. Up to and including version 2.1.3.6 it also held
+#' \code{posterior}, the full \code{sample_size x resolution} matrix of
+#' weighted draws those summaries came from. Once the per-model matrices were
+#' dropped that one matrix dominated what remained, so it is no longer stored.
+#' To obtain it directly, use \code{posterior_epred(x, newdata =
+#' bnec_newdata(x, resolution = 1000), re_formula = NA)}, which draws from the
+#' component models in the same weighted proportions. Objects saved before the
+#' change still carry it and are unaffected.
 #' @slot w_ne The summary stats (median and 95% credibility intervals) of
 #' w_ne_posterior.
 #' @slot ne_type A \code{\link[base]{character}} vector indicating the type of

--- a/R/bayesnecfit-class.R
+++ b/R/bayesnecfit-class.R
@@ -24,11 +24,13 @@
 #' @slot pred_vals A \code{\link[base]{list}} with a single element
 #' \code{data}, a \code{\link[base]{data.frame}} of summary posterior
 #' predicted values over a grid set by \code{resolution} and \code{x_range}.
-#' Up to version 2.1.3.7 it also held \code{posterior}, the full
+#' Up to and including version 2.1.3.6 it also held \code{posterior}, the full
 #' \code{n_draws x resolution} matrix those summaries came from. That matrix
 #' dominated the size of a fitted object and is no longer stored; it is
-#' recomputed from \code{fit} where it is needed. Objects saved before the
-#' change still carry it and are unaffected.
+#' recomputed from \code{fit} where it is needed. To obtain it directly, use
+#' \code{posterior_epred(x, newdata = bnec_newdata(x, resolution = 1000),
+#' re_formula = NA)}. Objects saved before the change still carry it and are
+#' unaffected.
 #' @slot top The estimate for parameter "top" in the fitted model.
 #' @slot beta The estimate for parameter "beta" in the fitted model.
 #' @slot ne The estimated NEC.

--- a/R/bayesnecfit-class.R
+++ b/R/bayesnecfit-class.R
@@ -21,10 +21,14 @@
 #' to fit the model.
 #' @slot bayesnecformula An object of class \code{\link{bayesnecformula}} and
 #' \code{\link[stats]{formula}}.
-#' @slot pred_vals A \code{\link[base]{list}} containing a
-#' \code{\link[base]{data.frame}} of summary posterior predicted values
-#' and a vector containing based on the supplied \code{resolution} and
-#' \code{x_range}.
+#' @slot pred_vals A \code{\link[base]{list}} with a single element
+#' \code{data}, a \code{\link[base]{data.frame}} of summary posterior
+#' predicted values over a grid set by \code{resolution} and \code{x_range}.
+#' Up to version 2.1.3.7 it also held \code{posterior}, the full
+#' \code{n_draws x resolution} matrix those summaries came from. That matrix
+#' dominated the size of a fitted object and is no longer stored; it is
+#' recomputed from \code{fit} where it is needed. Objects saved before the
+#' change still carry it and are unaffected.
 #' @slot top The estimate for parameter "top" in the fitted model.
 #' @slot beta The estimate for parameter "beta" in the fitted model.
 #' @slot ne The estimated NEC.

--- a/R/bnec_newdata.R
+++ b/R/bnec_newdata.R
@@ -40,24 +40,12 @@ bnec_newdata <- function(x, resolution = 100, x_range = NA) {
 #' @export
 bnec_newdata.bayesnecfit <- function(x, resolution = 100, x_range = NA) {
   check_args_newdata(resolution, x_range)
-  data <- model.frame(x$bayesnecformula, data = x$fit$data)
-  x_var <- attr(data, "bnec_pop")[["x_var"]]
-  fit <- x$fit
-  x_vec <- fit$data[[x_var]]
-  if (any(is.na(x_range))) {
-    x_seq <- seq(min(x_vec), max(x_vec), length = resolution)
-  } else {
-    x_seq <- seq(min(x_range), max(x_range), length = resolution)
-  }
-  newdata <- data.frame(x_seq)
-  names(newdata) <- x_var
-  fam_tag <- fit$family$family
-  custom_name <- check_custom_name(fit$family)
-  if (fam_tag == "binomial" || fam_tag == "beta_binomial") {
-    trials_var <- attr(data, "bnec_pop")[["trials_var"]]
-    newdata[[trials_var]] <- 1
-  }
-  newdata
+  # Delegates so this, expand_nec() and posterior_on_grid() cannot build
+  # different grids. This function used to test any(is.na(x_range)) while the
+  # other two tested is.na(x_range[1]); those disagreed for a partially
+  # specified range, which check_args_newdata() now rejects outright. See #211.
+  prediction_grid(x$fit, x$bayesnecformula, x_range = x_range,
+                  resolution = resolution)$newdata
 }
 
 #' bnec_newdata.bayesmanecfit

--- a/R/expand_classes.R
+++ b/R/expand_classes.R
@@ -44,7 +44,20 @@ expand_nec <- function(object, formula, x_range = NA, resolution = 1000,
     trials_col_name <- attr(mod_dat, "bnec_pop")[["trials_var"]]
     new_dat[[trials_col_name]] <- 1
   }
-  pred_posterior <- posterior_epred(fit, newdata = new_dat, re_formula = NA)
+  # Computed only where it is used, and never stored. The full n_draws x
+  # resolution matrix dominated the size of a fitted object -- 30.5 MB against a
+  # 1.2 MB brmsfit at the defaults -- and had exactly one reader, the
+  # model-averaging path in expand_manec(), which now builds its own. A
+  # threshold model with a single block needs it for nothing at all, so this is
+  # a saving rather than a trade. See #180.
+  pred_posterior <- NULL
+  get_pred_posterior <- function() {
+    if (is.null(pred_posterior)) {
+      pred_posterior <<- posterior_epred(fit, newdata = new_dat,
+                                         re_formula = NA)
+    }
+    pred_posterior
+  }
   y_pred_m <- fitted(fit, newdata = new_dat, robust = TRUE, re_formula = NA,
                      scale = "response")
   pred_data <- data.frame(x = x_seq, Estimate = y_pred_m[, "Estimate"],
@@ -70,12 +83,12 @@ expand_nec <- function(object, formula, x_range = NA, resolution = 1000,
     out
   }
   if (mod_class == "ecx") {
-    ne_posterior <- nsec_off_curve(pred_posterior)
+    ne_posterior <- nsec_off_curve(get_pred_posterior())
     extracted_params$ne <- estimates_summary(ne_posterior)
   } else {
     ne_posterior <- as_draws_df(fit)[["b_nec_Intercept"]]
   }
-  pred_vals <- list(data = pred_data, posterior = pred_posterior)
+  pred_vals <- list(data = pred_data)
   # Hurdle fits carry a second block. Keep its threshold and both component
   # curves alongside the combined ones, and make the *combined* threshold the
   # headline value -- posterior_epred() already returns mu * (1 - hu), so
@@ -108,7 +121,7 @@ expand_nec <- function(object, formula, x_range = NA, resolution = 1000,
       # curve itself rather than combined from the parts. When only one block
       # is smooth this is an N(S)EC in the sense of Fisher et al. (2023): a
       # threshold on one process and a significant-effect point on the other.
-      combined_ne <- nsec_off_curve(pred_posterior)
+      combined_ne <- nsec_off_curve(get_pred_posterior())
       ne_lab <- if (mod_class == "ecx" && hu_class == "ecx") {
         "NSEC"
       } else {
@@ -146,6 +159,42 @@ expand_nec <- function(object, formula, x_range = NA, resolution = 1000,
     out <- c(out, list(hurdle = hurdle_parts))
   }
   out
+}
+
+#' Posterior expectation over the prediction grid
+#'
+#' The grid \code{\link{expand_nec}} predicts over, and the posterior on it.
+#' Factored out because \code{\link{expand_manec}} needs the same matrix for
+#' the model-averaged draws and no longer finds it stored on the object.
+#'
+#' @param fit An object of class \code{\link[brms]{brmsfit}}.
+#' @param formula An object of class \code{\link{bayesnecformula}}.
+#'
+#' @inheritParams bnec
+#'
+#' @return A \code{\link[base]{matrix}} with draws as rows and grid points as
+#' columns.
+#'
+#' @importFrom brms posterior_epred
+#' @importFrom stats model.frame
+#'
+#' @noRd
+posterior_on_grid <- function(fit, formula, x_range = NA, resolution = 1000) {
+  mod_dat <- model.frame(formula, data = fit$data)
+  x_var <- attr(mod_dat, "bnec_pop")[["x_var"]]
+  x <- fit$data[[x_var]]
+  if (any(is.na(x_range[1]))) {
+    x_seq <- seq(min(x), max(x), length = resolution)
+  } else {
+    x_seq <- seq(min(x_range), max(x_range), length = resolution)
+  }
+  new_dat <- data.frame(x_seq)
+  names(new_dat) <- x_var
+  fam_tag <- fit$family$family
+  if (fam_tag == "binomial" || fam_tag == "beta_binomial") {
+    new_dat[[attr(mod_dat, "bnec_pop")[["trials_var"]]]] <- 1
+  }
+  posterior_epred(fit, newdata = new_dat, re_formula = NA)
 }
 
 #' Extracts a range of statistics from a list of \code{\link{prebayesnecfit}}
@@ -210,11 +259,20 @@ expand_manec <- function(object, formula, x_range = NA, resolution = 1000,
     loo_controls <- validate_loo_controls(loo_controls, fam_tag)
   }
   loo_w_controls <- loo_controls$weights
+  # The weighted draws below need each model's posterior over the prediction
+  # grid. It used to be read back off the objects, where expand_nec() had stored
+  # it; it is now held here for the duration of this call and discarded with the
+  # frame. Same computation, same result, nothing retained. See #180.
+  pred_list <- vector(mode = "list", length = length(object))
+  names(pred_list) <- success_models
   for (i in seq_along(object)) {
     object[[i]] <- expand_nec(object[[i]], formula = formula[[i]],
                               x_range = x_range, resolution = resolution,
                               sig_val = sig_val, loo_controls = loo_controls,
                               model = success_models[i])
+    pred_list[[i]] <- posterior_on_grid(object[[i]]$fit, formula[[i]],
+                                        x_range = x_range,
+                                        resolution = resolution)
   }
   mod_dat <- model.frame(formula[[1]], data = object[[1]]$fit$data)
   y_var <- attr(mod_dat, "bnec_pop")[["y_var"]]
@@ -232,8 +290,8 @@ expand_manec <- function(object, formula, x_range = NA, resolution = 1000,
                                  object, sample_size, mod_stats))
   y_pred <- rowSums(do_wrapper(success_models, w_pred_calc,
                                object, mod_stats))
-  post_pred <- do_wrapper(success_models, w_post_pred_calc,
-                          object, sample_size, mod_stats,
+  post_pred <- do_wrapper(success_models, w_pred_list_calc,
+                          pred_list, sample_size, mod_stats,
                           fct = "rbind")
   x <- object[[success_models[1]]]$pred_vals$data$x
   pred_data <- cbind(x = x,

--- a/R/expand_classes.R
+++ b/R/expand_classes.R
@@ -15,7 +15,7 @@
 #' @export
 expand_nec <- function(object, formula, x_range = NA, resolution = 1000,
                        sig_val = 0.01, loo_controls, ...) {
-  chk_numeric(resolution)
+  check_args_newdata(resolution, x_range)
   chk_numeric(sig_val)
   fam_tag <- object$fit$family$family
   if (missing(loo_controls)) {
@@ -29,21 +29,10 @@ expand_nec <- function(object, formula, x_range = NA, resolution = 1000,
                       "bot", "d", "slope", "ec50")
   extracted_params <- lapply(extract_params, extract_pars, fit)
   names(extracted_params) <- gsub("^nec$", "ne", extract_params)
-  mod_dat <- model.frame(formula, data = fit$data)
-  x_var <- attr(mod_dat, "bnec_pop")[["x_var"]]
-  x <- fit$data[[x_var]]
-  if (any(is.na(x_range[1]))) {
-    x_seq <- seq(min(x), max(x), length = resolution)
-  } else {
-    x_seq <- seq(min(x_range), max(x_range), length = resolution)
-  }
-  new_dat <- data.frame(x_seq)
-  names(new_dat) <- x_var
-  custom_name <- check_custom_name(fit$family)
-  if (fam_tag == "binomial" || fam_tag == "beta_binomial") {
-    trials_col_name <- attr(mod_dat, "bnec_pop")[["trials_var"]]
-    new_dat[[trials_col_name]] <- 1
-  }
+  grid <- prediction_grid(fit, formula, x_range = x_range,
+                          resolution = resolution)
+  new_dat <- grid$newdata
+  x_seq <- grid$x_seq
   # Computed only where it is used, and never stored. The full n_draws x
   # resolution matrix dominated the size of a fitted object -- 30.5 MB against a
   # 1.2 MB brmsfit at the defaults -- and had exactly one reader, the
@@ -89,20 +78,17 @@ expand_nec <- function(object, formula, x_range = NA, resolution = 1000,
     ne_posterior <- as_draws_df(fit)[["b_nec_Intercept"]]
   }
   pred_vals <- list(data = pred_data)
-  # Hurdle fits carry a second block. Keep its threshold and both component
-  # curves alongside the combined ones, and make the *combined* threshold the
-  # headline value -- posterior_epred() already returns mu * (1 - hu), so
-  # pred_vals and everything downstream of it describe the combined endpoint,
-  # and the NEC should describe the same curve.
+  # Hurdle fits carry a second block. Keep its threshold alongside the combined
+  # one, and make the *combined* threshold the headline value --
+  # posterior_epred() already returns mu * (1 - hu), so pred_vals and everything
+  # downstream of it describe the combined endpoint, and the NEC should describe
+  # the same curve. The two component curves used to be stored here as well;
+  # nothing ever read them, so they are no longer computed (#214).
   hurdle_parts <- NULL
   if (is_hurdle_family(fit$family)) {
     hu_dpar <- hurdle_dpar(fit$family)
     hu_params <- lapply(extract_params, extract_pars, fit, prefix = hu_dpar)
     names(hu_params) <- gsub("^nec$", "ne", extract_params)
-    mu_curve <- posterior_epred(fit, newdata = new_dat, re_formula = NA,
-                                dpar = "mu")
-    hu_curve <- posterior_epred(fit, newdata = new_dat, re_formula = NA,
-                                dpar = hu_dpar)
     hu_ne_posterior <- as_draws_df(fit)[[paste0("b_", hu_dpar,
                                                 "nec_Intercept")]]
     # The two blocks may carry different equations (see the model_survival
@@ -128,8 +114,7 @@ expand_nec <- function(object, formula, x_range = NA, resolution = 1000,
         "N(S)EC"
       }
     }
-    hurdle_parts <- list(mu_pred = mu_curve, hu_pred = hu_curve,
-                         mu_ne_posterior = ne_posterior,
+    hurdle_parts <- list(mu_ne_posterior = ne_posterior,
                          hu_ne_posterior = hu_ne_posterior,
                          hu_params = hu_params, hu_ne_type = hu_class,
                          ne_type = ne_lab)
@@ -161,39 +146,62 @@ expand_nec <- function(object, formula, x_range = NA, resolution = 1000,
   out
 }
 
-#' Posterior expectation over the prediction grid
+#' The grid predictions are made over
 #'
-#' The grid \code{\link{expand_nec}} predicts over, and the posterior on it.
-#' Factored out because \code{\link{expand_manec}} needs the same matrix for
-#' the model-averaged draws and no longer finds it stored on the object.
+#' The single definition of the prediction grid. \code{\link{expand_nec}},
+#' \code{posterior_on_grid} and the exported \code{\link{bnec_newdata}} all
+#' build the same grid from the same code, so they cannot drift apart. Takes a
+#' \code{\link[brms]{brmsfit}} and a formula rather than a
+#' \code{\link{bayesnecfit}} because inside \code{\link{expand_manec}} the
+#' object has not been given its class yet. See #211.
 #'
 #' @param fit An object of class \code{\link[brms]{brmsfit}}.
 #' @param formula An object of class \code{\link{bayesnecformula}}.
 #'
 #' @inheritParams bnec
 #'
-#' @return A \code{\link[base]{matrix}} with draws as rows and grid points as
-#' columns.
+#' @return A \code{\link[base]{list}} of \code{newdata}, the
+#' \code{\link[base]{data.frame}} to predict over; \code{x_seq}, the predictor
+#' values it spans; and \code{x_var}, the name of the predictor.
 #'
-#' @importFrom brms posterior_epred
 #' @importFrom stats model.frame
 #'
 #' @noRd
-posterior_on_grid <- function(fit, formula, x_range = NA, resolution = 1000) {
+prediction_grid <- function(fit, formula, x_range = NA, resolution = 1000) {
   mod_dat <- model.frame(formula, data = fit$data)
   x_var <- attr(mod_dat, "bnec_pop")[["x_var"]]
-  x <- fit$data[[x_var]]
-  if (any(is.na(x_range[1]))) {
+  if (is.na(x_range[1])) {
+    x <- fit$data[[x_var]]
     x_seq <- seq(min(x), max(x), length = resolution)
   } else {
     x_seq <- seq(min(x_range), max(x_range), length = resolution)
   }
-  new_dat <- data.frame(x_seq)
-  names(new_dat) <- x_var
+  newdata <- data.frame(x_seq)
+  names(newdata) <- x_var
   fam_tag <- fit$family$family
   if (fam_tag == "binomial" || fam_tag == "beta_binomial") {
-    new_dat[[attr(mod_dat, "bnec_pop")[["trials_var"]]]] <- 1
+    newdata[[attr(mod_dat, "bnec_pop")[["trials_var"]]]] <- 1
   }
+  list(newdata = newdata, x_seq = x_seq, x_var = x_var)
+}
+
+#' Posterior expectation over the prediction grid
+#'
+#' The posterior on the grid \code{\link{expand_nec}} predicts over. Factored
+#' out because \code{\link{expand_manec}} needs the same matrix for the
+#' model-averaged draws and no longer finds it stored on the object.
+#'
+#' @inheritParams prediction_grid
+#'
+#' @return A \code{\link[base]{matrix}} with draws as rows and grid points as
+#' columns.
+#'
+#' @importFrom brms posterior_epred
+#'
+#' @noRd
+posterior_on_grid <- function(fit, formula, x_range = NA, resolution = 1000) {
+  new_dat <- prediction_grid(fit, formula, x_range = x_range,
+                             resolution = resolution)$newdata
   posterior_epred(fit, newdata = new_dat, re_formula = NA)
 }
 
@@ -220,9 +228,8 @@ posterior_on_grid <- function(fit, formula, x_range = NA, resolution = 1000) {
 #' @export
 expand_manec <- function(object, formula, x_range = NA, resolution = 1000,
                          sig_val = 0.01, loo_controls) {
-  chk_numeric(resolution)
+  check_args_newdata(resolution, x_range)
   chk_numeric(sig_val)
-  if (!is.na(x_range[1])) {chk_numeric(x_range)}
   model_set <- names(object)
   success_models <- model_set[sapply(object, is_prebayesnecfit)]
   if (length(success_models) == 0) {
@@ -259,20 +266,11 @@ expand_manec <- function(object, formula, x_range = NA, resolution = 1000,
     loo_controls <- validate_loo_controls(loo_controls, fam_tag)
   }
   loo_w_controls <- loo_controls$weights
-  # The weighted draws below need each model's posterior over the prediction
-  # grid. It used to be read back off the objects, where expand_nec() had stored
-  # it; it is now held here for the duration of this call and discarded with the
-  # frame. Same computation, same result, nothing retained. See #180.
-  pred_list <- vector(mode = "list", length = length(object))
-  names(pred_list) <- success_models
   for (i in seq_along(object)) {
     object[[i]] <- expand_nec(object[[i]], formula = formula[[i]],
                               x_range = x_range, resolution = resolution,
                               sig_val = sig_val, loo_controls = loo_controls,
                               model = success_models[i])
-    pred_list[[i]] <- posterior_on_grid(object[[i]]$fit, formula[[i]],
-                                        x_range = x_range,
-                                        resolution = resolution)
   }
   mod_dat <- model.frame(formula[[1]], data = object[[1]]$fit$data)
   y_var <- attr(mod_dat, "bnec_pop")[["y_var"]]
@@ -290,18 +288,28 @@ expand_manec <- function(object, formula, x_range = NA, resolution = 1000,
                                  object, sample_size, mod_stats))
   y_pred <- rowSums(do_wrapper(success_models, w_pred_calc,
                                object, mod_stats))
-  post_pred <- do_wrapper(success_models, w_pred_list_calc,
-                          pred_list, sample_size, mod_stats,
+  # Each model's posterior over the prediction grid is computed here and
+  # immediately thinned to the round(sample_size * wi) rows the weighting keeps,
+  # one model at a time. Accumulating them into a list first would hold every
+  # model's full n_draws x resolution matrix at once -- the same peak #180 is
+  # about, merely not retained afterwards. The weights do not depend on the
+  # posteriors, so nothing forces them to be built together. See #180.
+  post_pred <- do_wrapper(success_models, w_grid_pred_calc, object, formula,
+                          x_range, resolution, sample_size, mod_stats,
                           fct = "rbind")
   x <- object[[success_models[1]]]$pred_vals$data$x
   pred_data <- cbind(x = x,
                      data.frame(t(apply(post_pred, 2,
                                         estimates_summary))))
   nec <- estimates_summary(ne_posterior)
+  # post_pred itself is not kept: it was w_pred_vals$posterior, which nothing in
+  # the package read and which became the dominant cost once the per-model
+  # matrices went. pred_data, the summary the plot methods use, is built from it
+  # here and is what survives. See #213.
   list(mod_fits = mod_fits, success_models = success_models,
        mod_stats = mod_stats, sample_size = sample_size,
        w_ne_posterior = ne_posterior, w_predicted_y = y_pred,
        w_residuals = mod_dat[[y_var]] - y_pred,
-       w_pred_vals = list(data = pred_data, posterior = post_pred),
+       w_pred_vals = list(data = pred_data),
        w_ne = nec, ne_type = ne_lab)
 }

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -105,6 +105,25 @@ w_pred_list_calc <- function(index, pred_list, sample_size, mod_stats) {
   pred_list[[index]][sample(x, size), ]
 }
 
+#' Compute one model's grid posterior and immediately thin it to its weight.
+#'
+#' Used by expand_manec(), where the posteriors are built rather than read off
+#' the objects. Computing and thinning in the same step means only one model's
+#' full matrix exists at a time; collecting them into a list first would hold
+#' every model's at once. Thins through w_pred_list_calc() rather than
+#' repeating the draw, so this and posterior_epred.bayesmanecfit() cannot
+#' sample differently. See #180.
+#'
+#' @noRd
+w_grid_pred_calc <- function(index, mod_fits, formulas, x_range, resolution,
+                             sample_size, mod_stats) {
+  pred_list <- list(posterior_on_grid(mod_fits[[index]]$fit, formulas[[index]],
+                                      x_range = x_range,
+                                      resolution = resolution))
+  names(pred_list) <- index
+  w_pred_list_calc(index, pred_list, sample_size, mod_stats)
+}
+
 #' @noRd
 do_wrapper <- function(..., fct = "cbind") {
   do.call(fct, lapply(...))
@@ -839,9 +858,21 @@ check_data_equality <- function(mod_fits) {
 #' @importFrom chk chk_numeric
 check_args_newdata <- function(resolution, x_range) {
   chk_numeric(resolution)
-  if (!is.na(x_range[1])) {
-    chk_numeric(x_range)
+  # The documented "not supplied" value, and the only NA accepted.
+  if (length(x_range) == 1 && is.na(x_range)) {
+    return(invisible(NULL))
   }
+  chk_numeric(x_range)
+  # A partially specified range used to be handled inconsistently, and
+  # differently depending on which end was missing -- bnec_newdata() ignored it
+  # silently, expand_nec() turned c(1, NA) into seq(NA, NA) but fell back to the
+  # observed range for c(NA, 4). It is not a meaningful request either way, so
+  # reject it rather than pick one. See #211.
+  if (any(is.na(x_range))) {
+    stop("x_range must be either NA or fully specified; ",
+         "it cannot contain NA alongside a value.", call. = FALSE)
+  }
+  invisible(NULL)
 }
 
 #' @noRd

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -99,13 +99,6 @@ w_pred_calc <- function(index, mod_fits, mod_stats) {
 }
 
 #' @noRd
-w_post_pred_calc <- function(index, mod_fits, sample_size, mod_stats) {
-  x <- seq_len(sample_size)
-  size <- round(sample_size * mod_stats[index, "wi"])
-  mod_fits[[index]]$pred_vals$posterior[sample(x, size), ]
-}
-
-#' @noRd
 w_pred_list_calc <- function(index, pred_list, sample_size, mod_stats) {
   x <- seq_len(sample_size)
   size <- round(sample_size * mod_stats[index, "wi"])

--- a/man/bayesmanecfit-class.Rd
+++ b/man/bayesmanecfit-class.Rd
@@ -43,9 +43,17 @@ data.}
 \item{\code{w_residuals}}{Model-weighted residual values
 (i.e. observed - w_predicted_y).}
 
-\item{\code{w_pred_vals}}{A \code{\link[base]{list}} containing model-weighted
-posterior predicted values based on the supplied \code{resolution} and
-\code{x_range}.}
+\item{\code{w_pred_vals}}{A \code{\link[base]{list}} with a single element
+\code{data}, a \code{\link[base]{data.frame}} of summary model-weighted
+posterior predicted values over a grid set by \code{resolution} and
+\code{x_range}. Up to and including version 2.1.3.6 it also held
+\code{posterior}, the full \code{sample_size x resolution} matrix of
+weighted draws those summaries came from. Once the per-model matrices were
+dropped that one matrix dominated what remained, so it is no longer stored.
+To obtain it directly, use \code{posterior_epred(x, newdata =
+bnec_newdata(x, resolution = 1000), re_formula = NA)}, which draws from the
+component models in the same weighted proportions. Objects saved before the
+change still carry it and are unaffected.}
 
 \item{\code{w_ne}}{The summary stats (median and 95\% credibility intervals) of
 w_ne_posterior.}

--- a/man/bayesnecfit-class.Rd
+++ b/man/bayesnecfit-class.Rd
@@ -31,10 +31,14 @@ to fit the model.}
 \item{\code{bayesnecformula}}{An object of class \code{\link{bayesnecformula}} and
 \code{\link[stats]{formula}}.}
 
-\item{\code{pred_vals}}{A \code{\link[base]{list}} containing a
-\code{\link[base]{data.frame}} of summary posterior predicted values
-and a vector containing based on the supplied \code{resolution} and
-\code{x_range}.}
+\item{\code{pred_vals}}{A \code{\link[base]{list}} with a single element
+\code{data}, a \code{\link[base]{data.frame}} of summary posterior
+predicted values over a grid set by \code{resolution} and \code{x_range}.
+Up to version 2.1.3.7 it also held \code{posterior}, the full
+\code{n_draws x resolution} matrix those summaries came from. That matrix
+dominated the size of a fitted object and is no longer stored; it is
+recomputed from \code{fit} where it is needed. Objects saved before the
+change still carry it and are unaffected.}
 
 \item{\code{top}}{The estimate for parameter "top" in the fitted model.}
 

--- a/man/bayesnecfit-class.Rd
+++ b/man/bayesnecfit-class.Rd
@@ -34,11 +34,13 @@ to fit the model.}
 \item{\code{pred_vals}}{A \code{\link[base]{list}} with a single element
 \code{data}, a \code{\link[base]{data.frame}} of summary posterior
 predicted values over a grid set by \code{resolution} and \code{x_range}.
-Up to version 2.1.3.7 it also held \code{posterior}, the full
+Up to and including version 2.1.3.6 it also held \code{posterior}, the full
 \code{n_draws x resolution} matrix those summaries came from. That matrix
 dominated the size of a fitted object and is no longer stored; it is
-recomputed from \code{fit} where it is needed. Objects saved before the
-change still carry it and are unaffected.}
+recomputed from \code{fit} where it is needed. To obtain it directly, use
+\code{posterior_epred(x, newdata = bnec_newdata(x, resolution = 1000),
+re_formula = NA)}. Objects saved before the change still carry it and are
+unaffected.}
 
 \item{\code{top}}{The estimate for parameter "top" in the fitted model.}
 

--- a/tests/testthat/test-expand_classes.R
+++ b/tests/testthat/test-expand_classes.R
@@ -14,7 +14,10 @@ test_that("expand_nec defaults work for nec model", {
                                  "residuals", "ne_posterior", "ne_type"))
   expect_equal(class(nec_fit$fit), "brmsfit")
   expect_equal(nec_fit$model, "nec4param")
-  expect_equal(dim(nec_fit$pred_vals$posterior), c(100, 1000))
+  # The n_draws x resolution matrix is no longer stored (#180); only the
+  # summary it was used to build.
+  expect_named(nec_fit$pred_vals, "data")
+  expect_null(nec_fit$pred_vals$posterior)
   expect_equal(dim(nec_fit$pred_vals$data), c(1000, 4))
   expect_equal(range(nec_fit$pred_vals$data$x), c(0.03234801, 3.22051966))
 })
@@ -33,7 +36,7 @@ test_that("expand_nec arguments work for nec model", {
                                  "residuals", "ne_posterior", "ne_type"))
   expect_equal(class(nec_fit$fit), "brmsfit")
   expect_equal(nec_fit$model, "nec4param")
-  expect_equal(dim(nec_fit$pred_vals$posterior), c(100, 20))
+  expect_named(nec_fit$pred_vals, "data")
   expect_equal(dim(nec_fit$pred_vals$data), c(20, 4))
   expect_equal(range(nec_fit$pred_vals$data$x), c(0.01, 4))
 })
@@ -51,7 +54,7 @@ test_that("expand_ecx defaults work for ecx model", {
                                  "residuals", "ne_posterior", "ne_type"))
   expect_equal(class(ecx_fit$fit), "brmsfit")
   expect_equal(ecx_fit$model, "ecx4param")
-  expect_equal(dim(ecx_fit$pred_vals$posterior), c(100, 1000))
+  expect_named(ecx_fit$pred_vals, "data")
   expect_equal(dim(ecx_fit$pred_vals$data), c(1000, 4))
   expect_equal(range(ecx_fit$pred_vals$data$x), c(0.03234801, 3.22051966))
 })
@@ -70,7 +73,7 @@ test_that("expand_ecx arguments work for ecx model", {
                                  "residuals", "ne_posterior", "ne_type"))
   expect_equal(class(ecx_fit$fit), "brmsfit")
   expect_equal(ecx_fit$model, "ecx4param")
-  expect_equal(dim(ecx_fit$pred_vals$posterior), c(100, 20))
+  expect_named(ecx_fit$pred_vals, "data")
   expect_equal(dim(ecx_fit$pred_vals$data), c(20, 4))
   expect_equal(range(ecx_fit$pred_vals$data$x), c(0.01, 4))
 })
@@ -152,4 +155,68 @@ test_that("new loo_controls are incorporated", {
     expect_equal("stacking") |>
     expect_message() |>
     suppressWarnings()
+})
+
+test_that("the model-averaged draws are unchanged by dropping the cache", {
+  if (Sys.getenv("NOT_CRAN") == "") {
+    skip_on_cran()
+  }
+  # expand_manec() used to read each model's posterior back off the object,
+  # where expand_nec() had stored it; it now builds the same matrices itself and
+  # discards them. The weighted draws must be the same in distribution, and are
+  # drawn in the same proportions. Compared against the priors-free arithmetic
+  # rather than against a stored constant, so this stays meaningful if the
+  # example object is ever refitted.
+  set.seed(180)
+  tt5 <- expand_manec(tt1, formulas) |>
+    suppressMessages() |>
+    suppressWarnings()
+  n <- tt5$sample_size
+  expected_rows <- sum(round(n * tt5$mod_stats$wi))
+  expect_equal(nrow(tt5$w_pred_vals$posterior), expected_rows)
+  expect_equal(ncol(tt5$w_pred_vals$posterior), 1000)
+  # Every draw came from one of the component posteriors, so the weighted set
+  # spans the same range as the models it was drawn from.
+  each <- lapply(tt5$mod_fits, function(z) {
+    bayesnec:::posterior_on_grid(z$fit, z$bayesnecformula, resolution = 1000)
+  })
+  expect_gte(min(tt5$w_pred_vals$posterior),
+             min(vapply(each, min, numeric(1))))
+  expect_lte(max(tt5$w_pred_vals$posterior),
+             max(vapply(each, max, numeric(1))))
+  # The summary the plot methods use is still built from those draws.
+  expect_equal(tt5$w_pred_vals$data$Estimate,
+               unname(apply(tt5$w_pred_vals$posterior, 2,
+                            bayesnec:::estimates_summary)["Estimate", ]))
+})
+
+test_that("an object saved with the old cache still works", {
+  if (Sys.getenv("NOT_CRAN") == "") {
+    skip_on_cran()
+  }
+  # Nothing reads pred_vals$posterior any more, but an object saved before this
+  # change still carries it. It must neither be needed nor get in the way.
+  new_style <- expand_nec(fit1, fit1$bayesnecformula, model = "nec4param") |>
+    suppressWarnings() |>
+    (\(z) bayesnec:::allot_class(z, c("bayesnecfit", "bnecfit")))()
+  expect_null(new_style$pred_vals$posterior)
+  old_style <- new_style
+  old_style$pred_vals$posterior <- bayesnec:::posterior_on_grid(
+    new_style$fit, new_style$bayesnecformula, resolution = 1000
+  )
+  expect_false(is.null(old_style$pred_vals$posterior))
+  for (obj in list(new_style, old_style)) {
+    expect_equal(nrow(predict(obj)), nrow(obj$fit$data))
+    expect_true(is.numeric(nec(obj)))
+    expect_error(suppressWarnings(summary(obj)), NA)
+    expect_error(suppressMessages(ecx(obj, ecx_val = 10)), NA)
+    expect_invisible(plot(obj))
+  }
+  # And an old-style object can still be combined into a model set, which is
+  # the one path that used to read the cache.
+  combined <- c(new_style, pull_out(manec_example, "ecx4param")) |>
+    suppressMessages() |>
+    suppressWarnings()
+  expect_s3_class(combined, "bayesmanecfit")
+  expect_null(combined$mod_fits$nec4param$pred_vals$posterior)
 })

--- a/tests/testthat/test-expand_classes.R
+++ b/tests/testthat/test-expand_classes.R
@@ -114,7 +114,10 @@ test_that("expand_manec defaults work correctly", {
   tt3 <- expand_manec(tt1, formulas) |>
     suppressMessages() |>
     suppressWarnings()
-  expect_equal(dim(tt3$w_pred_vals$posterior), c(100, 1000))
+  # The weighted n_draws x resolution matrix is no longer stored either (#213);
+  # only the summary built from it.
+  expect_named(tt3$w_pred_vals, "data")
+  expect_null(tt3$w_pred_vals$posterior)
   expect_equal(dim(tt3$w_pred_vals$data), c(1000, 4))
   expect_equal(range(tt3$w_pred_vals$data$x), c(0.03234801, 3.22051966))
 })
@@ -126,7 +129,7 @@ test_that("expand_manec defaults work correctly", {
   tt4 <- expand_manec(tt1, formulas, x_range = c(0.01, 4), resolution = 20) |>
     suppressMessages() |>
     suppressWarnings()
-  expect_equal(dim(tt4$w_pred_vals$posterior), c(100, 20))
+  expect_named(tt4$w_pred_vals, "data")
   expect_equal(dim(tt4$w_pred_vals$data), c(20, 4))
   expect_equal(range(tt4$w_pred_vals$data$x), c(0.01, 4))
 })
@@ -157,37 +160,81 @@ test_that("new loo_controls are incorporated", {
     suppressWarnings()
 })
 
-test_that("the model-averaged draws are unchanged by dropping the cache", {
+test_that("each model is thinned to exactly its share of the weighted draws", {
   if (Sys.getenv("NOT_CRAN") == "") {
     skip_on_cran()
   }
-  # expand_manec() used to read each model's posterior back off the object,
-  # where expand_nec() had stored it; it now builds the same matrices itself and
-  # discards them. The weighted draws must be the same in distribution, and are
-  # drawn in the same proportions. Compared against the priors-free arithmetic
-  # rather than against a stored constant, so this stays meaningful if the
-  # example object is ever refitted.
+  # expand_manec() used to read each model's posterior back off the object and
+  # thin it there; it now computes and thins one model at a time in
+  # w_grid_pred_calc(). "The weighted draws are the same" means two specific
+  # things, both asserted here rather than inferred from a range: each model
+  # contributes exactly round(sample_size * wi) rows, and every row it
+  # contributes is a row of that model's own posterior. Checked against the
+  # arithmetic of the weights rather than a stored constant, so this stays
+  # meaningful if the example objects are ever refitted.
   set.seed(180)
   tt5 <- expand_manec(tt1, formulas) |>
     suppressMessages() |>
     suppressWarnings()
+  expect_named(tt5$w_pred_vals, "data")
+  expect_null(tt5$w_pred_vals$posterior)
   n <- tt5$sample_size
-  expected_rows <- sum(round(n * tt5$mod_stats$wi))
-  expect_equal(nrow(tt5$w_pred_vals$posterior), expected_rows)
-  expect_equal(ncol(tt5$w_pred_vals$posterior), 1000)
-  # Every draw came from one of the component posteriors, so the weighted set
-  # spans the same range as the models it was drawn from.
-  each <- lapply(tt5$mod_fits, function(z) {
-    bayesnec:::posterior_on_grid(z$fit, z$bayesnecformula, resolution = 1000)
-  })
-  expect_gte(min(tt5$w_pred_vals$posterior),
-             min(vapply(each, min, numeric(1))))
-  expect_lte(max(tt5$w_pred_vals$posterior),
-             max(vapply(each, max, numeric(1))))
-  # The summary the plot methods use is still built from those draws.
-  expect_equal(tt5$w_pred_vals$data$Estimate,
-               unname(apply(tt5$w_pred_vals$posterior, 2,
-                            bayesnec:::estimates_summary)["Estimate", ]))
+  formulas_by_model <- lapply(tt5$mod_fits, `[[`, "bayesnecformula")
+  for (mod in tt5$success_models) {
+    full <- bayesnec:::posterior_on_grid(tt5$mod_fits[[mod]]$fit,
+                                         formulas_by_model[[mod]],
+                                         resolution = 1000)
+    drawn <- bayesnec:::w_grid_pred_calc(mod, tt5$mod_fits, formulas_by_model,
+                                         NA, 1000, n, tt5$mod_stats)
+    expect_equal(nrow(drawn), round(n * tt5$mod_stats[mod, "wi"]))
+    expect_equal(ncol(drawn), 1000)
+    # Row sums identify a row uniquely here because the values are copied, not
+    # recomputed, so they compare exactly.
+    expect_true(all(rowSums(drawn) %in% rowSums(full)))
+  }
+  # The rows contributed across all models account for the whole weighted set.
+  expect_equal(sum(round(n * tt5$mod_stats$wi)),
+               sum(vapply(tt5$success_models, function(mod) {
+                 as.integer(round(n * tt5$mod_stats[mod, "wi"]))
+               }, integer(1))))
+  # The summary the plot methods use spans the grid it is supposed to.
+  expect_equal(nrow(tt5$w_pred_vals$data), 1000)
+  expect_named(tt5$w_pred_vals$data, c("x", "Estimate", "Q2.5", "Q97.5"))
+})
+
+test_that("posterior_epred() reproduces the draws the cache used to hold", {
+  if (Sys.getenv("NOT_CRAN") == "") {
+    skip_on_cran()
+  }
+  # This is the migration path documented in NEWS and in both class docs for
+  # code that used to read pred_vals$posterior / w_pred_vals$posterior. It has
+  # to actually work, on both classes, at the documented grid.
+  single <- pull_out(manec_example, "nec4param") |>
+    suppressMessages() |>
+    suppressWarnings()
+  post_single <- posterior_epred(
+    single, newdata = bnec_newdata(single, resolution = 50), re_formula = NA
+  )
+  expect_true(is.matrix(post_single))
+  expect_equal(ncol(post_single), 50)
+  post_manec <- posterior_epred(
+    manec_example,
+    newdata = bnec_newdata(manec_example, resolution = 50), re_formula = NA
+  )
+  expect_true(is.matrix(post_manec))
+  expect_equal(ncol(post_manec), 50)
+})
+
+test_that("a partially specified x_range is rejected rather than guessed at", {
+  # bnec_newdata() used to ignore it silently while expand_nec() turned it into
+  # seq(NA, NA). Now one grid builder, one behaviour. See #211.
+  # Rejected whichever end is missing -- the two used to behave differently.
+  expect_error(bayesnec:::check_args_newdata(10, c(1, NA)), "fully specified")
+  expect_error(bayesnec:::check_args_newdata(10, c(NA_real_, 4)),
+               "fully specified")
+  # The documented "not supplied" value, and a proper range, both still pass.
+  expect_error(bayesnec:::check_args_newdata(10, NA), NA)
+  expect_error(bayesnec:::check_args_newdata(10, c(0, 4)), NA)
 })
 
 test_that("an object saved with the old cache still works", {
@@ -219,4 +266,36 @@ test_that("an object saved with the old cache still works", {
     suppressWarnings()
   expect_s3_class(combined, "bayesmanecfit")
   expect_null(combined$mod_fits$nec4param$pred_vals$posterior)
+  expect_null(combined$w_pred_vals$posterior)
+})
+
+test_that("a bayesmanecfit saved with the old weighted cache still works", {
+  if (Sys.getenv("NOT_CRAN") == "") {
+    skip_on_cran()
+  }
+  # Same again for w_pred_vals$posterior, dropped in #213. The shipped
+  # manec_example was built before that change, so it is a genuinely old
+  # serialised object rather than a synthesised one -- which is the case worth
+  # testing. Nothing needs the matrix and nothing should trip over it.
+  old_style <- manec_example
+  if (is.null(old_style$w_pred_vals$posterior)) {
+    # Only reached if the example data is ever regenerated under the new code;
+    # the fixture must not quietly stop testing anything at that point.
+    old_style$w_pred_vals$posterior <- posterior_epred(
+      manec_example, newdata = bnec_newdata(manec_example, resolution = 1000),
+      re_formula = NA
+    )
+  }
+  expect_false(is.null(old_style$w_pred_vals$posterior))
+  new_style <- old_style
+  new_style$w_pred_vals$posterior <- NULL
+  expect_named(new_style$w_pred_vals, "data")
+  for (obj in list(new_style, old_style)) {
+    expect_equal(nrow(predict(obj)), nrow(obj$mod_fits[[1]]$fit$data))
+    expect_true(is.numeric(obj$w_ne))
+    expect_error(suppressWarnings(summary(obj)), NA)
+    expect_error(suppressMessages(ecx(obj, ecx_val = 10)), NA)
+    expect_invisible(plot(obj))
+    expect_s3_class(autoplot(obj), "ggplot")
+  }
 })


### PR DESCRIPTION
Closes #180, #211, #213, #214. Implements **D2**: drop the cache, compute on demand.

## What changed

A fitted object no longer stores any of the `n_draws x resolution` posterior
matrices it used to keep. The small summaries the plot methods use are unchanged.

**`pred_vals$posterior` on every `bayesnecfit`** (#180). The one reader was the
model-averaging path in `expand_manec()`. Nothing else touched it: `predict()`
did not, and the plot methods use `pred_vals$data`.

**`w_pred_vals$posterior` on every `bayesmanecfit`** (#213). Once the per-model
matrices were gone this single weighted matrix was what remained — 77% of a
five-model set. Nothing in the package read it either. `w_pred_vals$data`, which
`plot()` and `autoplot()` do read, is unchanged.

**`hurdle$mu_pred` and `hurdle$hu_pred` on every two-block fit** (#214). Written
on every hurdle fit and never read anywhere — not by the plot methods, not by
`ecx()` / `nsec()`, not by the `bayesnechurdlefit` methods, not by the tests, and
not documented as slots. They are no longer computed at all, which removes two
`posterior_epred()` calls per two-block fit and four per `bnec_hurdle()` pair.

### How the model-averaged draws are built now

`expand_manec()` needs each model's posterior on the grid to assemble the
weighted draws. It computes each one and **immediately thins it** to the
`round(sample_size * wi)` rows the weighting keeps, one model at a time, in
`w_grid_pred_calc()`. Accumulating them into a list first would hold every
model's full matrix simultaneously — the same peak #180 is about, merely not
retained afterwards. The model weights do not depend on the posteriors, so
nothing forces them to be built together. Thinning goes through the existing
`w_pred_list_calc()`, so this and `posterior_epred.bayesmanecfit()` cannot
sample differently. The weighted draws are unchanged.

### One prediction grid (#211)

`bnec_newdata()`, `expand_nec()` and `posterior_on_grid()` each built the same
grid from their own copy of the same code. The copies had already diverged:
`bnec_newdata()` tested `any(is.na(x_range))` while the other two tested
`any(is.na(x_range[1]))`, so a partially specified range was silently ignored by
one and turned into `seq(NA, NA)` by the others — and even that differed by
which end was missing. There is now a single internal `prediction_grid()` that
all three delegate to, and `check_args_newdata()` rejects a partially specified
`x_range` with a clear error rather than guessing.

## What it cost

**It is a net saving in computation, not a trade.** `expand_nec()` used to
compute the matrix for every model whether anything needed it or not. Now:

| | before | after |
|---|---|---|
| single threshold model | 1 `posterior_epred` | **0** |
| single smooth model | 1 | 1 |
| single two-block fit | 3 | **0–1** |
| model set, per threshold model | 1 | 1 |
| model set, per smooth model | 1 | 2 |

Two-block fits gain the most: the two `dpar` calls that built the stored
component curves are gone, and the combined curve is computed only when at
least one block is smooth. The one case that pays is a smooth model inside a
model set, which computes the matrix twice — once in `expand_nec()` for its NSEC
and once in `expand_manec()` for the weighted draws:

```
posterior_on_grid at 100 draws x 1000 grid: 0.205 s (median of 5)
```

Against fitting times measured in minutes, that is not a trade worth avoiding.

## Measured

The reproducer from the issue — `nec3param`, Gamma, 140 observations,
`chains = 4, iter = 2000, warmup = 1000`, `resolution = 1000`:

```
                        issue     this branch
whole bayesnecfit      31.8 MB      1.28 MB
  $fit (brmsfit)        1.2 MB      1.20 MB
  $pred_vals           30.5 MB      0.03 MB
  pred_vals$posterior  present      absent
  pred_vals$data       1000 x 4     1000 x 4
```

96% of the object is gone. At `model = "all"` and the package defaults that is
roughly 1.5 GB per `bnec()` call that is no longer retained, and the transient
peak inside `expand_manec()` goes with it rather than merely not being kept.

On the shipped `manec_example`, which was built before this change and still
carries the weighted matrix, dropping it alone takes the object from **1.335 MB
to 0.535 MB — 60%**, on only 100 draws. The earlier five-model measurement
(`nec3param`, `nec4param`, `ecx4param`, `ecxwb1`, `ecxll4`; 2 chains, 999
retained draws, `resolution = 1000`) put `w_pred_vals` at 7.65 MB of a 9.90 MB
object; removing it leaves roughly 2.25 MB.

## Breaking change, and the migration path

`x$pred_vals$posterior` and `x$w_pred_vals$posterior` now return `NULL` rather
than erroring, so downstream code fails a step later with something unhelpful
like `NULL[i, ]`. NEWS and both class docs now name the replacement:

```r
posterior_epred(x, newdata = bnec_newdata(x, resolution = 1000), re_formula = NA)
```

which works on both classes and, for a model set, draws from the component
models in the same weighted proportions.

Objects saved before this change still carry the matrices. Nothing needs them
and nothing trips over them, which is tested on both classes — the
`bayesmanecfit` case uses the shipped `manec_example`, a genuinely old
serialised object rather than a synthesised one.

## Downstream impact

Checked because of the silent-`NULL` failure mode:

- **`toxval`** — unaffected. Every live path calls `posterior_epred(object,
  newdata = ...)` fresh; its only slot reads are `$pred_vals$data$x` and
  `$w_pred_vals$data$x`, both of which survive.
- **`msPAF`** — unaffected. No reads of any `pred_vals` / `posterior` slot; it
  uses `bnec_newdata()` + `posterior_epred()`.
- **Vignettes** — unaffected. The only slot access across all six is
  `example2.Rmd:284`, `exp_5_nec$w_pred_vals$data`. `example4` is built on
  `compare_posterior()`, which computes fresh via `compare_fitted()`.

## How it was verified

- `test-expand_classes.R`: assertions on `pred_vals$posterior` and
  `w_pred_vals$posterior` replaced by assertions that both hold `data` alone;
  the model-averaged draws now checked by **count and membership** — each model
  contributes exactly `round(sample_size * wi)` rows, and every row it
  contributes is a row of that model's own posterior — rather than by a range
  check that any subsetting would have passed; backward-compatibility tests for
  old-style objects of both classes; and a test that a partially specified
  `x_range` is rejected at either end.
- **525 assertions passing, 0 failing** across `test-expand_classes.R`,
  `test-bayesmanec_methods.R`, `test-bayesnec_methods.R`, `test-helpers.R`,
  `test-compare_fitted.R`, `test-compare_posterior.R`, `test-compare_estimates.R`,
  `test-ecx.R`, `test-nsec.R`, `test-ecnsec.R`, `test-nec.R`,
  `test-average_estimates.R`, `test-pull_out.R`, `test-amend.R`,
  `test-bayesnechurdlefit-methods.R`, `test-bnec_hurdle.R`,
  `test-hurdle_family.R`.
- `bnec_newdata()` and `prediction_grid()` verified to return `identical()`
  grids.
- Full suite and R CMD check run on CI.

## Left undone, deliberately

- **#212** — `ggbnec_data.bayesnecfit()` rebuilds the fitted curve via
  `conditional_effects()` instead of reading `pred_vals$data`, which its
  `bayesmanecfit` sibling does. Pre-existing and untouched by this PR; changing
  it moves the plotted line (brms's 100-point grid and mean, against the bnec
  grid at `resolution` and a median), so it regenerates the vignette figures and
  belongs with #190.
- The shipped `manec_example` still carries `w_pred_vals$posterior`, since
  regenerating package data means refitting. It is harmless, is what the
  backward-compatibility test uses, and is a candidate for #190.
