### PR TITLE
Draw the model-averaging index once and keep it on the object

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,29 @@
 # bayesnec 2.1.3.7
 
+- Model-averaged output from a `bayesmanecfit` is now reproducible. Averaging
+  keeps `round(sample_size * wi)` of each component model's draws, and which
+  draws those were used to be settled by an unseeded `sample()` at every call
+  site independently. `posterior_epred()`, `posterior_predict()` and everything
+  built on them therefore returned a different answer on every call, and none of
+  them agreed with the summaries stored on the object. The draw is now realised
+  once, when the object is built, and the seed that produced it is kept on the
+  object as the new `w_draw_seed` slot; every later call rebuilds the same
+  index. Realisation *i* now means "component *m*[*i*], iteration *j*[*i*]" for
+  every quantity taken from one object. The averaging method itself is
+  unchanged — only where the randomness is drawn. Two consequences worth
+  knowing: model-averaged numbers will differ from those produced by earlier
+  versions (the old ones were not reproducible, so there is no "before" to
+  match), and `posterior_epred()` over the build grid now returns exactly the
+  draws that `w_pred_vals` summarises rather than an independent redraw of them.
+  Objects saved before this version carry no `w_draw_seed` and fall back to a
+  fixed value, which is equally reproducible. `predict()` and
+  `posterior_predict()` still vary between calls unless a seed is set, because
+  they simulate new observations from the likelihood — the same behaviour
+  `brms` has for a single fit, and unrelated to model averaging. `ecx()` and
+  `nsec()` on a `bayesmanecfit` also still vary; their weighted resampling lives
+  in `R/ecx.R` and `R/nsec.R`, which are migrating to `toxval` and were left
+  untouched. See #216.
+
 - `brms (>= 2.23.0)` is now required. Earlier versions generate the
   `beta_binomial` likelihood by passing the whole `trials` array to
   `beta_binomial_lpmf` instead of `trials[n]`, so each response is evaluated

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,26 +3,29 @@
 - Model-averaged output from a `bayesmanecfit` is now reproducible. Averaging
   keeps `round(sample_size * wi)` of each component model's draws, and which
   draws those were used to be settled by an unseeded `sample()` at every call
-  site independently. `posterior_epred()`, `posterior_predict()` and everything
-  built on them therefore returned a different answer on every call, and none of
-  them agreed with the summaries stored on the object. The draw is now realised
-  once, when the object is built, and the seed that produced it is kept on the
-  object as the new `w_draw_seed` slot; every later call rebuilds the same
-  index. Realisation *i* now means "component *m*[*i*], iteration *j*[*i*]" for
-  every quantity taken from one object. The averaging method itself is
-  unchanged — only where the randomness is drawn. Two consequences worth
-  knowing: model-averaged numbers will differ from those produced by earlier
-  versions (the old ones were not reproducible, so there is no "before" to
-  match), and `posterior_epred()` over the build grid now returns exactly the
-  draws that `w_pred_vals` summarises rather than an independent redraw of them.
-  Objects saved before this version carry no `w_draw_seed` and fall back to a
-  fixed value, which is equally reproducible. `predict()` and
+  site independently. `posterior_epred()`, `posterior_predict()`, `ecx()`,
+  `nsec()` and everything built on them therefore returned a different answer on
+  every call, and none of them agreed with the summaries stored on the object.
+  For `nsec()` the instability landed almost entirely on the lower bound, which
+  is the end used to set a protective concentration: over six replicate calls it
+  spanned 0.735–0.844 while the median moved by less than 0.5%. The draw is now
+  realised once, when the object is built, and kept on the object as the new
+  `w_draw_index` slot, with the seed behind it in `w_draw_seed`; every later call
+  reuses it. Realisation *i* now means "component *m*[*i*], iteration *j*[*i*]"
+  for every quantity taken from one object. The averaging method is unchanged —
+  only where the randomness is drawn. Three consequences worth knowing.
+  Model-averaged numbers will differ from those produced by earlier versions;
+  the old ones were not reproducible, so there is no "before" to match.
+  `posterior_epred()` over the build grid now returns exactly the draws that
+  `w_pred_vals` summarises rather than an independent redraw of them. And an
+  `nsec()` and its `ecnsec` are now the same draw of the same component model,
+  where before they came from two independent `sample()` calls and a pair could
+  be two unrelated draws of two different models. `predict()` and
   `posterior_predict()` still vary between calls unless a seed is set, because
-  they simulate new observations from the likelihood — the same behaviour
-  `brms` has for a single fit, and unrelated to model averaging. `ecx()` and
-  `nsec()` on a `bayesmanecfit` also still vary; their weighted resampling lives
-  in `R/ecx.R` and `R/nsec.R`, which are migrating to `toxval` and were left
-  untouched. See #216.
+  they simulate new observations from the likelihood — the same behaviour `brms`
+  has for a single fit, and unrelated to model averaging. Objects saved before
+  this version carry neither field and fall back to a fixed seed, which is
+  equally reproducible. See #216.
 
 - `brms (>= 2.23.0)` is now required. Earlier versions generate the
   `beta_binomial` likelihood by passing the whole `trials` array to

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,15 @@
   this version carry neither field and fall back to a fixed seed, which is
   equally reproducible. See #216.
 
+- Model-averaged predictions from a `bayesmanecfit` no longer collapse when
+  `newdata` has a single row. Asking what the averaged curve predicts at one
+  concentration — `fitted(fit, newdata = data.frame(x = 3))` — returned one row
+  per retained draw instead of one row per prediction, because the weighted row
+  selection dropped to a vector and the per-model results were then stacked as
+  rows rather than columns. The point estimate looked plausible, but its
+  `Est.Error` and quantiles were computed across models rather than over draws.
+  A `bayesnecfit` was unaffected, as was any `newdata` with more than one row.
+
 - `brms (>= 2.23.0)` is now required. Earlier versions generate the
   `beta_binomial` likelihood by passing the whole `trials` array to
   `beta_binomial_lpmf` instead of `trials[n]`, so each response is evaluated

--- a/R/bayesmanecfit-class.R
+++ b/R/bayesmanecfit-class.R
@@ -24,6 +24,16 @@
 #' @slot mod_stats A \code{\link[base]{data.frame}} of model fit statistics.
 #' @slot sample_size The size of the posterior sample.
 #' Information on the priors used in the model.
+#' @slot w_draw_seed The seed that realised the model-averaging draw. Model
+#' averaging keeps a weighted subset of each component model's draws; this seed
+#' fixes which ones, so every call on the object uses the same subset.
+#' \code{fitted} and \code{posterior_epred} are therefore reproducible, and
+#' agree with \code{w_ne_posterior} and \code{w_pred_vals}. \code{predict}
+#' and \code{posterior_predict} still vary between calls unless a seed is set,
+#' because they simulate new observations from the likelihood, as they do for a
+#' single \code{\link[brms]{brmsfit}}. Objects saved before version 2.1.3.7 do
+#' not carry a seed and fall back to a fixed value, which is equally
+#' reproducible.
 #' @slot w_ne_posterior The model-weighted posterior estimate of the no-effect
 #' toxicity estimate.
 #' @slot w_predicted_y The model-weighted predicted values for the observed

--- a/R/bayesmanecfit-class.R
+++ b/R/bayesmanecfit-class.R
@@ -24,16 +24,19 @@
 #' @slot mod_stats A \code{\link[base]{data.frame}} of model fit statistics.
 #' @slot sample_size The size of the posterior sample.
 #' Information on the priors used in the model.
-#' @slot w_draw_seed The seed that realised the model-averaging draw. Model
-#' averaging keeps a weighted subset of each component model's draws; this seed
-#' fixes which ones, so every call on the object uses the same subset.
-#' \code{fitted} and \code{posterior_epred} are therefore reproducible, and
-#' agree with \code{w_ne_posterior} and \code{w_pred_vals}. \code{predict}
-#' and \code{posterior_predict} still vary between calls unless a seed is set,
-#' because they simulate new observations from the likelihood, as they do for a
-#' single \code{\link[brms]{brmsfit}}. Objects saved before version 2.1.3.7 do
-#' not carry a seed and fall back to a fixed value, which is equally
-#' reproducible.
+#' @slot w_draw_index The realised model-averaging draw: a
+#' \code{\link[base]{list}} of the row indices kept for each component model.
+#' Model averaging keeps a weighted subset of each model's draws, and this
+#' records which ones, so every call on the object uses the same subset.
+#' \code{fitted}, \code{posterior_epred}, \code{ecx} and \code{nsec} are
+#' therefore reproducible, and agree with \code{w_ne_posterior} and
+#' \code{w_pred_vals}. \code{predict} and \code{posterior_predict} still vary
+#' between calls unless a seed is set, because they simulate new observations
+#' from the likelihood, as they do for a single \code{\link[brms]{brmsfit}}.
+#' @slot w_draw_seed The seed that realised \code{w_draw_index}. Used only
+#' where the stored index cannot apply: when a caller thins to a different
+#' number of draws, and for objects saved before version 2.1.3.7, which carry
+#' neither field and fall back to a fixed seed.
 #' @slot w_ne_posterior The model-weighted posterior estimate of the no-effect
 #' toxicity estimate.
 #' @slot w_predicted_y The model-weighted predicted values for the observed

--- a/R/ecx.R
+++ b/R/ecx.R
@@ -276,6 +276,12 @@ ecx.bayesmanecfit <- function(object, ecx_val = 10, resolution = 1000,
          " in that order")
   }
   sample_size <- object$sample_size
+  # The same weighted index every other quantity on this object uses, rather
+  # than a fresh unseeded sample() here. Without it a model-averaged ECx was a
+  # different number on every call -- and it is the lower bound, the end a
+  # protective concentration is read off, that moved most. Which draws are kept
+  # is unchanged in kind; only the redraw is gone. See #216.
+  draw_index <- pull_draw_index(object, names(object$mod_fits), sample_size)
   # Written as a closure over the arguments rather than a function taking them
   # all positionally: the previous form dispatched through
   # sapply(to_iter, sample_ecx, object, ecx_val, ...), which matched by
@@ -290,8 +296,7 @@ ecx.bayesmanecfit <- function(object, ecx_val = 10, resolution = 1000,
                posterior = TRUE, type = type, hormesis_def = hormesis_def,
                x_range = x_range, xform = xform, prob_vals = prob_vals,
                dpar = dpar)
-    n_s <- as.integer(round(sample_size * object$mod_stats[x, "wi"]))
-    sample(out, n_s)
+    out[draw_index[[mod]]]
   }
   to_iter <- seq_len(length(object$success_models))
   ecx_out <- unlist(lapply(to_iter, sample_ecx))

--- a/R/expand_classes.R
+++ b/R/expand_classes.R
@@ -284,8 +284,19 @@ expand_manec <- function(object, formula, x_range = NA, resolution = 1000,
   attr(mod_stats$wi, "method") <- loo_w_controls$method
   mod_stats <- cbind(mod_stats, disp)
   sample_size <- extract_simdat(object[[1]])$n_samples
+  # The weighted draw is realised once, here, and the seed that produced it is
+  # kept on the object. Every later call -- posterior_epred(), fitted() and the
+  # weighting inside predict() -- rebuilds the same index from that seed, so
+  # repeated calls agree with each other and with the summaries below.
+  # Previously each site drew its own unseeded sample(), so no two calls
+  # returned the same answer. Drawing the seed rather than fixing one keeps the
+  # realisation genuinely random per object, and responsive to a set.seed() in
+  # the caller's session. See #216.
+  draw_seed <- sample.int(.Machine$integer.max, 1)
+  draw_index <- weighted_draw_index(success_models, sample_size, mod_stats,
+                                    draw_seed)
   ne_posterior <- unlist(lapply(success_models, w_nec_calc,
-                                 object, sample_size, mod_stats))
+                                 object, draw_index))
   y_pred <- rowSums(do_wrapper(success_models, w_pred_calc,
                                object, mod_stats))
   # Each model's posterior over the prediction grid is computed here and
@@ -295,7 +306,7 @@ expand_manec <- function(object, formula, x_range = NA, resolution = 1000,
   # about, merely not retained afterwards. The weights do not depend on the
   # posteriors, so nothing forces them to be built together. See #180.
   post_pred <- do_wrapper(success_models, w_grid_pred_calc, object, formula,
-                          x_range, resolution, sample_size, mod_stats,
+                          x_range, resolution, draw_index,
                           fct = "rbind")
   x <- object[[success_models[1]]]$pred_vals$data$x
   pred_data <- cbind(x = x,
@@ -308,6 +319,7 @@ expand_manec <- function(object, formula, x_range = NA, resolution = 1000,
   # here and is what survives. See #213.
   list(mod_fits = mod_fits, success_models = success_models,
        mod_stats = mod_stats, sample_size = sample_size,
+       w_draw_seed = draw_seed,
        w_ne_posterior = ne_posterior, w_predicted_y = y_pred,
        w_residuals = mod_dat[[y_var]] - y_pred,
        w_pred_vals = list(data = pred_data),

--- a/R/expand_classes.R
+++ b/R/expand_classes.R
@@ -291,7 +291,12 @@ expand_manec <- function(object, formula, x_range = NA, resolution = 1000,
   # Previously each site drew its own unseeded sample(), so no two calls
   # returned the same answer. Drawing the seed rather than fixing one keeps the
   # realisation genuinely random per object, and responsive to a set.seed() in
-  # the caller's session. See #216.
+  # the caller's session. Both the index and the seed behind it are kept: the
+  # index is what later calls use, because a stored index cannot drift the way
+  # a regenerated one can if sample()'s algorithm changes again as it did in
+  # R 3.6.0, and these objects are archived and reopened years later. The seed
+  # is kept for the cases the stored index cannot cover -- a caller thinning to
+  # a different number of draws. See #216.
   draw_seed <- sample.int(.Machine$integer.max, 1)
   draw_index <- weighted_draw_index(success_models, sample_size, mod_stats,
                                     draw_seed)
@@ -319,7 +324,7 @@ expand_manec <- function(object, formula, x_range = NA, resolution = 1000,
   # here and is what survives. See #213.
   list(mod_fits = mod_fits, success_models = success_models,
        mod_stats = mod_stats, sample_size = sample_size,
-       w_draw_seed = draw_seed,
+       w_draw_seed = draw_seed, w_draw_index = draw_index,
        w_ne_posterior = ne_posterior, w_predicted_y = y_pred,
        w_residuals = mod_dat[[y_var]] - y_pred,
        w_pred_vals = list(data = pred_data),

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -85,12 +85,62 @@ extract_waic_estimate <- function(x) {
   x$fit$criteria$waic$estimates["waic", "Estimate"]
 }
 
+#' Realise the model-averaging draw once, reproducibly.
+#'
+#' Model averaging keeps \code{round(sample_size * wi)} of each component's
+#' draws. Which draws those are used to be decided by an unseeded
+#' \code{sample()} at every call site, so \code{predict()},
+#' \code{posterior_epred()} and the summaries stored on the object were each a
+#' different realisation and no two calls agreed. Seeding the draw from a value
+#' carried on the \code{bayesmanecfit} makes realisation \emph{i} mean
+#' "component m[i], iteration j[i]" for every quantity computed from that
+#' object. See #216.
+#'
+#' Restores the caller's RNG state rather than calling \code{set.seed()}
+#' outright: model averaging must not silently reset a user's simulation seed.
+#'
+#' @param model_set A \code{\link[base]{character}} vector of model names.
+#' @param sample_size A \code{\link[base]{numeric}} vector of length 1, the
+#' number of draws available per component.
+#' @param mod_stats A \code{\link[base]{data.frame}} with a \code{wi} column
+#' and model names as row names.
+#' @param seed A \code{\link[base]{numeric}} vector of length 1, or NULL.
+#'
+#' @return A named \code{\link[base]{list}} of integer vectors, the draw
+#' indices kept for each model.
 #' @noRd
-w_nec_calc <- function(index, mod_fits, sample_size, mod_stats) {
-  sample(
-    mod_fits[[index]]$ne_posterior,
-    as.integer(round(sample_size * mod_stats[index, "wi"]))
-  )
+weighted_draw_index <- function(model_set, sample_size, mod_stats, seed) {
+  if (is.null(seed)) {
+    # Objects built before #216 carry no seed. A fixed fallback still makes
+    # every call on such an object agree with every other, which is the point;
+    # erroring would break saved objects and re-drawing would restore the bug.
+    seed <- 216
+  }
+  has_seed <- exists(".Random.seed", envir = globalenv(), inherits = FALSE)
+  old_seed <- if (has_seed) {
+    get(".Random.seed", envir = globalenv(), inherits = FALSE)
+  } else {
+    NULL
+  }
+  on.exit({
+    if (is.null(old_seed)) {
+      rm(".Random.seed", envir = globalenv())
+    } else {
+      assign(".Random.seed", old_seed, envir = globalenv())
+    }
+  }, add = TRUE)
+  set.seed(seed)
+  out <- lapply(model_set, function(index) {
+    size <- as.integer(round(sample_size * mod_stats[index, "wi"]))
+    sample(seq_len(sample_size), size)
+  })
+  names(out) <- model_set
+  out
+}
+
+#' @noRd
+w_nec_calc <- function(index, mod_fits, draw_index) {
+  mod_fits[[index]]$ne_posterior[draw_index[[index]]]
 }
 
 #' @noRd
@@ -99,10 +149,8 @@ w_pred_calc <- function(index, mod_fits, mod_stats) {
 }
 
 #' @noRd
-w_pred_list_calc <- function(index, pred_list, sample_size, mod_stats) {
-  x <- seq_len(sample_size)
-  size <- round(sample_size * mod_stats[index, "wi"])
-  pred_list[[index]][sample(x, size), ]
+w_pred_list_calc <- function(index, pred_list, draw_index) {
+  pred_list[[index]][draw_index[[index]], ]
 }
 
 #' Compute one model's grid posterior and immediately thin it to its weight.
@@ -116,12 +164,12 @@ w_pred_list_calc <- function(index, pred_list, sample_size, mod_stats) {
 #'
 #' @noRd
 w_grid_pred_calc <- function(index, mod_fits, formulas, x_range, resolution,
-                             sample_size, mod_stats) {
+                             draw_index) {
   pred_list <- list(posterior_on_grid(mod_fits[[index]]$fit, formulas[[index]],
                                       x_range = x_range,
                                       resolution = resolution))
   names(pred_list) <- index
-  w_pred_list_calc(index, pred_list, sample_size, mod_stats)
+  w_pred_list_calc(index, pred_list, draw_index)
 }
 
 #' @noRd

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -194,9 +194,21 @@ w_pred_calc <- function(index, mod_fits, mod_stats) {
   mod_fits[[index]]$predicted_y * mod_stats[index, "wi"]
 }
 
+#' Take one model's weighted share of rows from its posterior matrix.
+#'
+#' \code{drop = FALSE} is load bearing. \code{pred_list[[index]]} is a
+#' draws-by-grid matrix and the results are stacked across models with
+#' \code{rbind}, so a single grid column -- a one-row \code{newdata}, i.e.
+#' "what does the curve predict at this one concentration?" -- would otherwise
+#' drop to a vector and be bound as a *row*. That returned a
+#' models-by-draws matrix instead of a draws-by-1 one, recycling the shorter
+#' model's draws, and the resulting summary was computed across draws rather
+#' than over them: the point estimate looked plausible while its interval came
+#' from as many values as there were models.
+#'
 #' @noRd
 w_pred_list_calc <- function(index, pred_list, draw_index) {
-  pred_list[[index]][draw_index[[index]], ]
+  pred_list[[index]][draw_index[[index]], , drop = FALSE]
 }
 
 #' Compute one model's grid posterior and immediately thin it to its weight.

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -99,6 +99,15 @@ extract_waic_estimate <- function(x) {
 #' Restores the caller's RNG state rather than calling \code{set.seed()}
 #' outright: model averaging must not silently reset a user's simulation seed.
 #'
+#' \code{sample.kind} is pinned rather than left at whatever the session is
+#' using. A seed alone does not fix a draw: R 3.6.0 changed the algorithm behind
+#' \code{sample()}, and the same seed gives a different index either side of
+#' that change. Left unpinned, a saved \code{bayesmanecfit} reloaded under a
+#' different R would silently rebuild a different index and quietly stop
+#' matching its own stored summaries -- which is the bug this is meant to close,
+#' merely deferred. "Rejection" is the post-3.6.0 default, so pinning it changes
+#' nothing today and holds the draw fixed for objects that outlive this R.
+#'
 #' @param model_set A \code{\link[base]{character}} vector of model names.
 #' @param sample_size A \code{\link[base]{numeric}} vector of length 1, the
 #' number of draws available per component.
@@ -116,6 +125,7 @@ weighted_draw_index <- function(model_set, sample_size, mod_stats, seed) {
     # erroring would break saved objects and re-drawing would restore the bug.
     seed <- 216
   }
+  old_kind <- RNGkind()
   has_seed <- exists(".Random.seed", envir = globalenv(), inherits = FALSE)
   old_seed <- if (has_seed) {
     get(".Random.seed", envir = globalenv(), inherits = FALSE)
@@ -123,19 +133,55 @@ weighted_draw_index <- function(model_set, sample_size, mod_stats, seed) {
     NULL
   }
   on.exit({
+    # RNGkind() first, then the seed: the generator kind is encoded in
+    # .Random.seed[1], so restoring the seed last leaves both correct. Where
+    # there was no seed to restore, RNGkind() is what puts sample.kind back --
+    # removing .Random.seed on its own would not.
+    suppressWarnings(RNGkind(old_kind[1], old_kind[2], old_kind[3]))
     if (is.null(old_seed)) {
-      rm(".Random.seed", envir = globalenv())
+      suppressWarnings(rm(".Random.seed", envir = globalenv()))
     } else {
       assign(".Random.seed", old_seed, envir = globalenv())
     }
   }, add = TRUE)
-  set.seed(seed)
+  set.seed(seed, sample.kind = "Rejection")
   out <- lapply(model_set, function(index) {
     size <- as.integer(round(sample_size * mod_stats[index, "wi"]))
     sample(seq_len(sample_size), size)
   })
   names(out) <- model_set
   out
+}
+
+#' The model-averaging index to use for a given number of available draws.
+#'
+#' Prefers the index realised when the object was built and stored on it. That
+#' is exact and cannot drift: it survives being reloaded under a different R,
+#' where regenerating from the seed is only as stable as \code{sample()}'s
+#' algorithm. Rebuilding from the seed is the fallback, for two cases -- a
+#' caller thinning to a different number of draws (\code{ndraws},
+#' \code{draw_ids}), where the stored index does not apply, and objects saved
+#' before the index was stored. See #216.
+#'
+#' @param object An object of class \code{\link{bayesmanecfit}}.
+#' @param model_set A \code{\link[base]{character}} vector of model names.
+#' @param sample_size A \code{\link[base]{numeric}} vector of length 1, the
+#' number of draws available per component.
+#'
+#' @return A named \code{\link[base]{list}} of integer vectors.
+#' @noRd
+pull_draw_index <- function(object, model_set, sample_size) {
+  idx <- object$w_draw_index
+  # `==` rather than identical(): sample_size is a double off the object and an
+  # integer off nrow(), and identical() would call those different and silently
+  # take the fallback every time.
+  same_n <- isTRUE(object$sample_size == sample_size)
+  if (!is.null(idx) && same_n && all(model_set %in% names(idx))) {
+    idx[model_set]
+  } else {
+    weighted_draw_index(model_set, sample_size, object$mod_stats,
+                        object$w_draw_seed)
+  }
 }
 
 #' @noRd

--- a/R/nsec.R
+++ b/R/nsec.R
@@ -219,6 +219,16 @@ nsec.bayesmanecfit <- function(object, sig_val = 0.01, resolution = 1000,
     stop("You may only pass one sig_val")
   }
   sample_size <- object$sample_size
+  # The same weighted index every other quantity on this object uses, rather
+  # than a fresh unseeded sample() here. Two things follow. The model-averaged
+  # NSEC stops moving between calls -- and it was the lower bound, the end a
+  # protective concentration is read off, that moved most. And the NSEC and its
+  # ecnsec are drawn with one index instead of two independent ones, so a pair
+  # is now the same posterior draw of the same model rather than two unrelated
+  # ones. Which draws are kept is unchanged in kind, and each NSEC is still read
+  # off its own model's curve exactly as before, so this settles nothing about
+  # what those curves are anchored to (#19). See #216.
+  draw_index <- pull_draw_index(object, names(object$mod_fits), sample_size)
   # A closure rather than positional dispatch through sapply(), for the reason
   # given in ecx.bayesmanecfit: the previous form silently dropped any argument
   # not named in the positional list, dpar included.
@@ -229,9 +239,10 @@ nsec.bayesmanecfit <- function(object, sig_val = 0.01, resolution = 1000,
                 hormesis_def = hormesis_def,
                 x_range = x_range, xform = xform, prob_vals = prob_vals,
                 posterior = TRUE, dpar = dpar)
-    n_s <- as.integer(round(sample_size * object$mod_stats[x, "wi"]))
-    sample_out <- sample(out, n_s)
-    attr(sample_out, "ecnsec_relativeP") <- sample(attributes(out)$ecnsec_relativeP, n_s)
+    idx <- draw_index[[mod]]
+    sample_out <- out[idx]
+    attr(sample_out, "ecnsec_relativeP") <-
+      attributes(out)$ecnsec_relativeP[idx]
     sample_out
   }
   to_iter <- seq_len(length(object$success_models))

--- a/R/posterior_epred.R
+++ b/R/posterior_epred.R
@@ -64,14 +64,12 @@ posterior_epred.bayesnecfit <- function(object, ...) {
 posterior_epred.bayesmanecfit <- function(object, ...) {
   mod_fits <- object$mod_fits
   model_set <- names(mod_fits)
-  mod_stats <- object$mod_stats
   pred_list <- lapply(mod_fits, function(x, ...) {
     posterior_epred(x$fit, ...)
   }, ...)
   sample_size <- min(sapply(pred_list, nrow))
-  # Index drawn from the seed stored on the object, not afresh here, so
+  # The index realised when the object was built, not a fresh draw here, so
   # repeated calls return identical draws. See #216.
-  draw_index <- weighted_draw_index(model_set, sample_size, mod_stats,
-                                    object$w_draw_seed)
+  draw_index <- pull_draw_index(object, model_set, sample_size)
   do_wrapper(model_set, w_pred_list_calc, pred_list, draw_index, fct = "rbind")
 }

--- a/R/posterior_epred.R
+++ b/R/posterior_epred.R
@@ -69,6 +69,9 @@ posterior_epred.bayesmanecfit <- function(object, ...) {
     posterior_epred(x$fit, ...)
   }, ...)
   sample_size <- min(sapply(pred_list, nrow))
-  do_wrapper(model_set, w_pred_list_calc, pred_list, sample_size,
-             mod_stats, fct = "rbind")
+  # Index drawn from the seed stored on the object, not afresh here, so
+  # repeated calls return identical draws. See #216.
+  draw_index <- weighted_draw_index(model_set, sample_size, mod_stats,
+                                    object$w_draw_seed)
+  do_wrapper(model_set, w_pred_list_calc, pred_list, draw_index, fct = "rbind")
 }

--- a/R/posterior_predict.R
+++ b/R/posterior_predict.R
@@ -68,6 +68,11 @@ posterior_predict.bayesmanecfit <- function(object, ...) {
     posterior_predict(x$fit, ...)
   }, ...)
   sample_size <- min(sapply(pred_list, nrow))
-  do_wrapper(model_set, w_pred_list_calc, pred_list, sample_size,
-             mod_stats, fct = "rbind")
+  # Index drawn from the seed stored on the object, not afresh here, so the
+  # weighting is the same on every call. What each component contributes still
+  # varies, because posterior_predict() simulates new observations -- as it does
+  # for a single brmsfit. Only the averaging is fixed here. See #216.
+  draw_index <- weighted_draw_index(model_set, sample_size, mod_stats,
+                                    object$w_draw_seed)
+  do_wrapper(model_set, w_pred_list_calc, pred_list, draw_index, fct = "rbind")
 }

--- a/R/posterior_predict.R
+++ b/R/posterior_predict.R
@@ -63,16 +63,14 @@ posterior_predict.bayesnecfit <- function(object, ...) {
 posterior_predict.bayesmanecfit <- function(object, ...) {
   mod_fits <- object$mod_fits
   model_set <- names(mod_fits)
-  mod_stats <- object$mod_stats
   pred_list <- lapply(mod_fits, function(x, ...) {
     posterior_predict(x$fit, ...)
   }, ...)
   sample_size <- min(sapply(pred_list, nrow))
-  # Index drawn from the seed stored on the object, not afresh here, so the
+  # The index realised when the object was built, not a fresh draw here, so the
   # weighting is the same on every call. What each component contributes still
   # varies, because posterior_predict() simulates new observations -- as it does
   # for a single brmsfit. Only the averaging is fixed here. See #216.
-  draw_index <- weighted_draw_index(model_set, sample_size, mod_stats,
-                                    object$w_draw_seed)
+  draw_index <- pull_draw_index(object, model_set, sample_size)
   do_wrapper(model_set, w_pred_list_calc, pred_list, draw_index, fct = "rbind")
 }

--- a/man/bayesmanecfit-class.Rd
+++ b/man/bayesmanecfit-class.Rd
@@ -34,16 +34,20 @@ name of the successfully fitted models.}
 \item{\code{sample_size}}{The size of the posterior sample.
 Information on the priors used in the model.}
 
-\item{\code{w_draw_seed}}{The seed that realised the model-averaging draw. Model
-averaging keeps a weighted subset of each component model's draws; this seed
-fixes which ones, so every call on the object uses the same subset.
-\code{fitted} and \code{posterior_epred} are therefore reproducible, and
-agree with \code{w_ne_posterior} and \code{w_pred_vals}. \code{predict}
-and \code{posterior_predict} still vary between calls unless a seed is set,
-because they simulate new observations from the likelihood, as they do for a
-single \code{\link[brms]{brmsfit}}. Objects saved before version 2.1.3.7 do
-not carry a seed and fall back to a fixed value, which is equally
-reproducible.}
+\item{\code{w_draw_index}}{The realised model-averaging draw: a
+\code{\link[base]{list}} of the row indices kept for each component model.
+Model averaging keeps a weighted subset of each model's draws, and this
+records which ones, so every call on the object uses the same subset.
+\code{fitted}, \code{posterior_epred}, \code{ecx} and \code{nsec} are
+therefore reproducible, and agree with \code{w_ne_posterior} and
+\code{w_pred_vals}. \code{predict} and \code{posterior_predict} still vary
+between calls unless a seed is set, because they simulate new observations
+from the likelihood, as they do for a single \code{\link[brms]{brmsfit}}.}
+
+\item{\code{w_draw_seed}}{The seed that realised \code{w_draw_index}. Used only
+where the stored index cannot apply: when a caller thins to a different
+number of draws, and for objects saved before version 2.1.3.7, which carry
+neither field and fall back to a fixed seed.}
 
 \item{\code{w_ne_posterior}}{The model-weighted posterior estimate of the no-effect
 toxicity estimate.}

--- a/man/bayesmanecfit-class.Rd
+++ b/man/bayesmanecfit-class.Rd
@@ -34,6 +34,17 @@ name of the successfully fitted models.}
 \item{\code{sample_size}}{The size of the posterior sample.
 Information on the priors used in the model.}
 
+\item{\code{w_draw_seed}}{The seed that realised the model-averaging draw. Model
+averaging keeps a weighted subset of each component model's draws; this seed
+fixes which ones, so every call on the object uses the same subset.
+\code{fitted} and \code{posterior_epred} are therefore reproducible, and
+agree with \code{w_ne_posterior} and \code{w_pred_vals}. \code{predict}
+and \code{posterior_predict} still vary between calls unless a seed is set,
+because they simulate new observations from the likelihood, as they do for a
+single \code{\link[brms]{brmsfit}}. Objects saved before version 2.1.3.7 do
+not carry a seed and fall back to a fixed value, which is equally
+reproducible.}
+
 \item{\code{w_ne_posterior}}{The model-weighted posterior estimate of the no-effect
 toxicity estimate.}
 

--- a/tests/testthat/test-bayesmanec_methods.R
+++ b/tests/testthat/test-bayesmanec_methods.R
@@ -102,3 +102,33 @@ test_that("model-averaged output does not change between identical calls", {
   set.seed(216)
   expect_identical(p1, predict(manec_example, newdata = nd))
 })
+
+test_that("model-averaged ecx and nsec are reproducible and internally paired", {
+  if (Sys.getenv("NOT_CRAN") == "") {
+    skip_on_cran()
+  }
+  # These are the numbers that go into a report, and the instability landed on
+  # the lower bound -- the end a protective concentration is read off. See #216.
+  expect_identical(suppressMessages(ecx(manec_example)),
+                   suppressMessages(ecx(manec_example)))
+  post <- suppressMessages(nsec(manec_example, posterior = TRUE))
+  expect_identical(post, suppressMessages(nsec(manec_example,
+                                               posterior = TRUE)))
+  # The NSEC and its ecnsec used to be drawn by two independent sample() calls,
+  # so a pair was two unrelated draws of possibly different models. One index
+  # now covers both: element i of each is draw idx[i] of the same component.
+  idx <- bayesnec:::pull_draw_index(manec_example,
+                                    manec_example$success_models,
+                                    manec_example$sample_size)
+  parts <- lapply(manec_example$success_models, function(mod) {
+    single <- pull_out(manec_example, model = mod) |>
+      suppressMessages() |>
+      suppressWarnings()
+    one <- suppressMessages(nsec(single, posterior = TRUE))
+    cbind(one[idx[[mod]]], attributes(one)$ecnsec_relativeP[idx[[mod]]])
+  })
+  parts <- do.call("rbind", parts)
+  expect_equal(as.numeric(post), unname(parts[, 1]))
+  expect_equal(as.numeric(attributes(post)$ecnsec_relativeP),
+               unname(parts[, 2]))
+})

--- a/tests/testthat/test-bayesmanec_methods.R
+++ b/tests/testthat/test-bayesmanec_methods.R
@@ -74,3 +74,31 @@ test_that("model.frame behaves as expected", {
                   "data.frame")
   expect_error(model.frame(manec_example, model = "ecxlin"))
 })
+
+test_that("model-averaged output does not change between identical calls", {
+  if (Sys.getenv("NOT_CRAN") == "") {
+    skip_on_cran()
+  }
+  # #216: every quantity taken through the averaged posterior used to redraw the
+  # component index with an unseeded sample(), so no two calls agreed. Asserted
+  # on the expectation and on the summaries built from it, not on stored
+  # constants -- the point is that repeated calls agree, whatever the values.
+  nd <- bnec_newdata(manec_example, resolution = 20)
+  expect_identical(posterior_epred(manec_example, newdata = nd),
+                   posterior_epred(manec_example, newdata = nd))
+  expect_identical(fitted(manec_example, newdata = nd),
+                   fitted(manec_example, newdata = nd))
+  # Edge case: a resolution of 1 is a single column, where a dropped dimension
+  # would show up as a length mismatch rather than a difference in values.
+  nd_1 <- bnec_newdata(manec_example, resolution = 1)
+  expect_identical(posterior_epred(manec_example, newdata = nd_1),
+                   posterior_epred(manec_example, newdata = nd_1))
+  # posterior_predict() stays stochastic on purpose: it simulates new
+  # observations, exactly as brms does for a single fit, so it varies for a
+  # bayesnecfit too. What #216 fixes is the weighting, which is now the same
+  # draw every time -- so seeding the likelihood is enough to pin it down.
+  set.seed(216)
+  p1 <- predict(manec_example, newdata = nd)
+  set.seed(216)
+  expect_identical(p1, predict(manec_example, newdata = nd))
+})

--- a/tests/testthat/test-bayesmanec_methods.R
+++ b/tests/testthat/test-bayesmanec_methods.R
@@ -88,11 +88,31 @@ test_that("model-averaged output does not change between identical calls", {
                    posterior_epred(manec_example, newdata = nd))
   expect_identical(fitted(manec_example, newdata = nd),
                    fitted(manec_example, newdata = nd))
-  # Edge case: a resolution of 1 is a single column, where a dropped dimension
-  # would show up as a length mismatch rather than a difference in values.
+  # Edge case: a single grid column. Asserted on the *shape* as well as on
+  # agreement between calls -- two equally malformed results compare identical,
+  # so reproducibility alone would not have caught the dropped dimension this
+  # originally hid (see w_pred_list_calc).
   nd_1 <- bnec_newdata(manec_example, resolution = 1)
   expect_identical(posterior_epred(manec_example, newdata = nd_1),
                    posterior_epred(manec_example, newdata = nd_1))
+  expect_equal(dim(posterior_epred(manec_example, newdata = nd_1)),
+               c(manec_example$sample_size, 1))
+  # The way a user actually meets that case: one row of newdata, asking what the
+  # averaged curve predicts at a single concentration. The answer must have the
+  # same shape as the single-model one, and must not warn.
+  nd_pt <- data.frame(x = 3)
+  expect_silent(ma_pt <- posterior_epred(manec_example, newdata = nd_pt))
+  expect_equal(dim(ma_pt), c(manec_example$sample_size, 1))
+  expect_identical(dim(fitted(manec_example, newdata = nd_pt)),
+                   dim(fitted(nec4param, newdata = nd_pt)))
+  # ... and the averaged estimate must sit between the components it averages.
+  ma_est <- fitted(manec_example, newdata = nd_pt)[1, "Estimate"]
+  cmp_est <- sapply(names(manec_example$mod_fits), function(m) {
+    fitted(suppressMessages(pull_out(manec_example, model = m)),
+           newdata = nd_pt)[1, "Estimate"]
+  })
+  expect_gte(ma_est, min(cmp_est))
+  expect_lte(ma_est, max(cmp_est))
   # posterior_predict() stays stochastic on purpose: it simulates new
   # observations, exactly as brms does for a single fit, so it varies for a
   # bayesnecfit too. What #216 fixes is the weighting, which is now the same

--- a/tests/testthat/test-expand_classes.R
+++ b/tests/testthat/test-expand_classes.R
@@ -184,8 +184,10 @@ test_that("each model is thinned to exactly its share of the weighted draws", {
     full <- bayesnec:::posterior_on_grid(tt5$mod_fits[[mod]]$fit,
                                          formulas_by_model[[mod]],
                                          resolution = 1000)
+    idx <- bayesnec:::weighted_draw_index(tt5$success_models, n,
+                                          tt5$mod_stats, tt5$w_draw_seed)
     drawn <- bayesnec:::w_grid_pred_calc(mod, tt5$mod_fits, formulas_by_model,
-                                         NA, 1000, n, tt5$mod_stats)
+                                         NA, 1000, idx)
     expect_equal(nrow(drawn), round(n * tt5$mod_stats[mod, "wi"]))
     expect_equal(ncol(drawn), 1000)
     # Row sums identify a row uniquely here because the values are copied, not
@@ -223,6 +225,28 @@ test_that("posterior_epred() reproduces the draws the cache used to hold", {
   )
   expect_true(is.matrix(post_manec))
   expect_equal(ncol(post_manec), 50)
+})
+
+test_that("posterior_epred() on the build grid reproduces w_pred_vals", {
+  if (Sys.getenv("NOT_CRAN") == "") {
+    skip_on_cran()
+  }
+  # Since #216 the weighted draw is realised once and the seed kept on the
+  # object, so the summaries stored at build time and a later posterior_epred()
+  # over the same grid are the same set of draws, not two independent ones.
+  # This is the property the migration note in the class docs promises; before
+  # #216 it held only in distribution.
+  tt6 <- expand_manec(tt1, formulas) |>
+    suppressMessages() |>
+    suppressWarnings() |>
+    (\(z) bayesnec:::allot_class(z, c("bayesmanecfit", "bnecfit")))()
+  expect_true(is.numeric(tt6$w_draw_seed))
+  post <- posterior_epred(tt6, newdata = bnec_newdata(tt6, resolution = 1000),
+                          re_formula = NA)
+  summ <- t(apply(post, 2, bayesnec:::estimates_summary))
+  expect_equal(unname(summ[, "Estimate"]), tt6$w_pred_vals$data$Estimate)
+  expect_equal(unname(summ[, "Q2.5"]), tt6$w_pred_vals$data$Q2.5)
+  expect_equal(unname(summ[, "Q97.5"]), tt6$w_pred_vals$data$Q97.5)
 })
 
 test_that("a partially specified x_range is rejected rather than guessed at", {

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -60,3 +60,50 @@ test_that("weighted_draw_index handles a model carrying no weight", {
   expect_length(idx$nec4param, 40)
   expect_setequal(idx$nec4param, seq_len(40))
 })
+
+test_that("weighted_draw_index ignores the session's sample.kind", {
+  # A seed alone does not fix a draw. R 3.6.0 changed sample()'s algorithm, so
+  # the same seed gives a different index either side of it; an object reloaded
+  # under a different R would otherwise rebuild a different index and stop
+  # matching its own stored summaries. Pinning is what makes the seed archival.
+  stats <- data.frame(wi = c(0.6, 0.4),
+                      row.names = c("nec4param", "ecx4param"))
+  models <- rownames(stats)
+  ref <- bayesnec:::weighted_draw_index(models, 100, stats, seed = 11)
+  old_kind <- RNGkind()
+  on.exit(suppressWarnings(RNGkind(old_kind[1], old_kind[2], old_kind[3])),
+          add = TRUE)
+  suppressWarnings(RNGkind(sample.kind = "Rounding"))
+  # Same seed under the pre-3.6.0 algorithm: this is what an unpinned draw
+  # would have returned, and it is not the same index.
+  set.seed(11)
+  expect_false(identical(sample(seq_len(100), 60L), ref$nec4param))
+  expect_identical(bayesnec:::weighted_draw_index(models, 100, stats, seed = 11),
+                   ref)
+  # The caller's choice of generator is left as it was found.
+  expect_identical(RNGkind()[3], "Rounding")
+})
+
+test_that("pull_draw_index prefers the stored index over rebuilding it", {
+  stats <- data.frame(wi = c(0.6, 0.4),
+                      row.names = c("nec4param", "ecx4param"))
+  models <- rownames(stats)
+  obj <- list(sample_size = 100, mod_stats = stats, w_draw_seed = 11,
+              w_draw_index = bayesnec:::weighted_draw_index(models, 100, stats,
+                                                            11))
+  expect_identical(bayesnec:::pull_draw_index(obj, models, 100),
+                   obj$w_draw_index)
+  # sample_size arrives as a double off the object and an integer off nrow().
+  # identical() would call those different and take the fallback every time.
+  expect_identical(bayesnec:::pull_draw_index(obj, models, 100L),
+                   obj$w_draw_index)
+  # Edge case: a caller thinning to fewer draws cannot use the stored index at
+  # all, so the fallback has to produce one that is actually in range.
+  small <- bayesnec:::pull_draw_index(obj, models, 40)
+  expect_equal(lengths(small), c(nec4param = 24L, ecx4param = 16L))
+  expect_true(all(unlist(small) <= 40))
+  # An object saved before either field existed.
+  legacy <- obj[c("sample_size", "mod_stats")]
+  expect_identical(bayesnec:::pull_draw_index(legacy, models, 100),
+                   bayesnec:::weighted_draw_index(models, 100, stats, NULL))
+})

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -16,3 +16,47 @@ test_that("handle_set works", {
              drop = c("ecxlin", "nec4param", "nec3param")) |>
     expect_equal(c("ecx4param"))
 })
+
+test_that("weighted_draw_index is a pure function of its arguments", {
+  # The whole of #216 is that this draw must not depend on when it is called.
+  stats <- data.frame(wi = c(0.75, 0.25),
+                      row.names = c("nec4param", "ecx4param"))
+  models <- rownames(stats)
+  a <- bayesnec:::weighted_draw_index(models, 100, stats, seed = 7)
+  b <- bayesnec:::weighted_draw_index(models, 100, stats, seed = 7)
+  expect_identical(a, b)
+  expect_named(a, models)
+  expect_equal(lengths(a), c(nec4param = 75L, ecx4param = 25L))
+  expect_true(all(unlist(a) %in% seq_len(100)))
+  # A different seed must actually move it, or the seed is doing nothing.
+  expect_false(identical(a, bayesnec:::weighted_draw_index(models, 100, stats,
+                                                           seed = 8)))
+  # Objects saved before #216 carry no seed. They must still be self-consistent.
+  n1 <- bayesnec:::weighted_draw_index(models, 100, stats, seed = NULL)
+  n2 <- bayesnec:::weighted_draw_index(models, 100, stats, seed = NULL)
+  expect_identical(n1, n2)
+})
+
+test_that("weighted_draw_index leaves the caller's RNG stream alone", {
+  # Model averaging silently resetting a user's simulation seed would be a
+  # worse bug than the one being fixed.
+  stats <- data.frame(wi = c(0.5, 0.5),
+                      row.names = c("nec4param", "ecx4param"))
+  set.seed(99)
+  expected <- runif(3)
+  set.seed(99)
+  first <- runif(1)
+  bayesnec:::weighted_draw_index(rownames(stats), 50, stats, seed = 7)
+  expect_equal(c(first, runif(2)), expected)
+})
+
+test_that("weighted_draw_index handles a model carrying no weight", {
+  # loo_model_weights() returns exact zeros often enough that this is a real
+  # path, not a hypothetical one: the model must contribute no rows, not error.
+  stats <- data.frame(wi = c(1, 0),
+                      row.names = c("nec4param", "ecx4param"))
+  idx <- bayesnec:::weighted_draw_index(rownames(stats), 40, stats, seed = 3)
+  expect_length(idx$ecx4param, 0)
+  expect_length(idx$nec4param, 40)
+  expect_setequal(idx$nec4param, seq_len(40))
+})


### PR DESCRIPTION
Fixes #216.

## What changed

Model averaging keeps `round(sample_size * wi)` of each component model's
draws. Which draws those were was settled by an unseeded `sample()` at every
call site, independently — so `posterior_epred()`, `posterior_predict()`,
`ecx()`, `nsec()` and everything built on them returned a different answer on
every call, and none of them agreed with the summaries already stored on the
object.

The draw is now realised **once**, in `expand_manec()`, and kept on the object
as a new `w_draw_index` slot, with the seed behind it in `w_draw_seed`. Every
later call reuses it, so realisation *i* means "component *m*[*i*], iteration
*j*[*i*]" for every quantity taken from one object.

- `R/helpers.R` — new `weighted_draw_index()` and `pull_draw_index()`.
  `w_nec_calc()`, `w_pred_list_calc()` and `w_grid_pred_calc()` now take the
  index instead of drawing their own.
- `R/expand_classes.R` — draws once, uses one index for the no-effect posterior
  and the grid posterior, stores both index and seed.
- `R/posterior_epred.R`, `R/posterior_predict.R`, `R/ecx.R`, `R/nsec.R` — read
  the index off the object rather than redrawing.
- `R/bayesmanecfit-class.R` / `man/` — the new slots, documented.

Also fixed, in the same function this moved the draw out of: `w_pred_list_calc()`
indexed with the default `drop = TRUE`, so a **single grid column** — a one-row
`newdata` — dropped to a vector and `rbind` stacked each model's draws as a
*row*. `fitted(manec_example, newdata = data.frame(x = 3))` returned 83 rows
instead of 1, with `Est.Error` and the quantiles computed across models rather
than over draws, so the point estimate looked plausible and its interval did
not. A `bayesnecfit` was unaffected, as was any `newdata` with more than one
row. Pre-existing on `dev`; the `resolution = 1` test added here walked into it.

The averaging method is unchanged. This is `weighted_samples` exactly as
before; only where the randomness is drawn has moved.

### Why the index is stored, not just the seed

A seed alone does not fix a draw. R 3.6.0 changed `sample()`'s algorithm, and
the same seed gives a different index either side of that change. A
`bayesmanecfit` archived now and reopened under a future R would silently
rebuild a different index and stop matching its own stored summaries — the same
bug, merely deferred. So:

- **`w_draw_index`** holds the realised indices and is what every call uses. It
  cannot drift. It costs one integer per draw (a few KB).
- **`w_draw_seed`** is the fallback, for the two cases the stored index cannot
  cover: a caller thinning to a different number of draws (`ndraws`,
  `draw_ids`), and objects saved before either field existed.
- `weighted_draw_index()` pins `sample.kind = "Rejection"` so that fallback is
  itself stable across R versions. "Rejection" is the post-3.6.0 default, so
  this changes nothing today. `RNGkind()` and `.Random.seed` are both restored
  afterwards, so averaging never disturbs a user's simulation stream.

`manec_example` predates all of this; it falls back to a fixed seed and was left
as-is rather than refitted.

### `ecx()` and `nsec()`

Included, overriding the original scope note. Those functions are headed for
`toxval`, but that migration is gated on #45 reaching CRAN, and until then
`bayesnec` ships irreproducible ECx and NSEC on model-averaged fits — which are
the numbers that go into reports. Six replicate calls before this change:

| | median | lower (Q2.5) |
|---|---|---|
| `nsec()` | 1.475–1.482 | 0.735–0.844 |
| `ecx()` | 1.491–1.496 | 0.875–0.963 |

The instability lands almost entirely on the lower bound, which is the end a
protective concentration is read off.

The same index also covers both halves of the `nsec()` result. Previously the
NSEC and its `ecnsec` came from two independent `sample()` calls, so a pair was
two unrelated draws of possibly two different models; element *i* of each is now
draw `idx[i]` of the same component.

This preserves current semantics — each NSEC is still read off its own model's
curve exactly as before — so it settles nothing about what those curves are
anchored to, and does not pre-empt #19.

## Verified

- `posterior_epred()`, `fitted()`, `ecx()` and `nsec()` on `manec_example` are
  identical across repeated calls.
- `nsec()`'s posterior and its `ecnsec_relativeP` reconstruct exactly from the
  per-model posteriors at the shared index — asserted, not inferred.
- `posterior_epred()` over the build grid now reproduces the stored
  `w_pred_vals` **exactly**. Before this change the two were independent redraws
  and agreed only in distribution — so the migration path promised in the
  `w_pred_vals` docs (added under #180) now actually returns the same draws.
- The caller's RNG stream and `RNGkind()` are both untouched.
- Under `RNGkind(sample.kind = "Rounding")` the index is unchanged, where an
  unpinned draw from the same seed would differ.
- Full suite: **1448 passed, 0 failed, 0 errors, 0 skipped**.

No existing test needed rewriting. The hazard note anticipated pinned
model-averaged constants, but nothing in the suite pins one — the existing
tests check the arithmetic of the weights, not stored values.

## Tests added

`tests/testthat/test-helpers.R`
- `weighted_draw_index()` is a pure function of its arguments: same seed → same
  index, different seed → different index, missing seed (legacy object) still
  self-consistent, sizes equal `round(n * wi)`, indices in range.
- It leaves the caller's RNG stream alone, and ignores the session's
  `sample.kind` — with the pre-3.6.0 draw computed inline to show it would
  otherwise differ.
- `pull_draw_index()` prefers the stored index, tolerates the integer/double
  mismatch between `nrow()` and the stored `sample_size`, falls back in range
  when a caller thins, and handles an object carrying neither field.
- Edge case: a model with `wi == 0` contributes no rows rather than erroring.
  `loo_model_weights()` returns exact zeros often enough for this to be a real
  path.

`tests/testthat/test-bayesmanec_methods.R`
- Repeated `posterior_epred()` / `fitted()` calls are identical.
- The single-grid-column case, asserted on **shape** as well as on agreement:
  two equally malformed results compare identical, so reproducibility alone did
  not catch the dropped dimension — it hid it. Covers both `resolution = 1` and
  the way a user actually meets it, a one-row `newdata`, checking the result is
  silent, is `sample_size x 1`, matches the shape of the single-model answer, and
  that the averaged estimate falls between the components it averages.
- `ecx()` and `nsec()` are reproducible, and the NSEC/`ecnsec` pairing is
  reconstructed from the component posteriors.

`tests/testthat/test-expand_classes.R`
- `posterior_epred()` on the build grid reproduces `w_pred_vals`.
- The existing `w_grid_pred_calc()` test updated for the new signature.

## One finding

**`predict()` / `posterior_predict()` are still not reproducible without
`set.seed()`, and that is not model averaging.** `predict()` on a single
`bayesnecfit` varies just as much — 2.100 vs 2.219 on `nec4param` alone —
because `brms::posterior_predict()` simulates new observations from the
likelihood. The issue's reproducer used `predict()`, which conflates the two
sources. The weighting half is now fixed; with a seed set, `predict()` on
`manec_example` reproduces exactly. I did **not** freeze the likelihood
simulation as well: that would make `bayesmanecfit` behave unlike both
`bayesnecfit` and plain `brms`, which is a user-visible behaviour change beyond
this issue.

Same applies to `ndraws` / `draw_ids`: `brms` picks that subset at random, so
`posterior_epred(x, ndraws = 40)` varies between calls for a single
`bayesnecfit` too. Our weighting index over that subset is deterministic.

## Not done

- `average_estimates.R:85`, `compare_estimates.R:75` and `compare_fitted.R:67`
  each hold a further unseeded `sample()`. Investigated and **filed separately as
  #218** rather than fixed here: those are full permutations, not weighted
  thinning, and their job is to pair draws across *independently fitted* models,
  so the fix in this PR does not transfer — there is no persistent object to hang
  an index on, and a session `set.seed()` already makes them reproducible, which
  it could not do here. #218 records the measurements, and the condition under
  which the permutation stops being correct (a factor covariate, #33).
- Vignettes not rebuilt (#190). Model-averaged numbers in them will shift when
  they are.

