### PR TITLE
Document how drc's NEC models map onto the bayesnec set (#139)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bayesnec
 Title: A Bayesian No-Effect- Concentration (NEC) Algorithm
-Version: 2.1.3.8
+Version: 2.1.3.9
 Authors@R: c(person("Rebecca", "Fisher", email = "r.fisher@aims.gov.au", role = c("aut", "cre"),comment = c(ORCID = "0000-0001-5148-6731")), person("Diego R.","Barneche",role="aut",comment = c(ORCID = "0000-0002-4568-2362")), person("Gerard F.","Ricardo",role="aut",comment = c(ORCID = "0000-0002-2220-3971")), person("David R.","Fox",role="aut",comment = c(ORCID = "0000-0002-3178-7243")))
 Description: Implementation of No-Effect-Concentration estimation that uses 'brms' (see Burkner (2017)<doi:10.18637/jss.v080.i01>; Burkner (2018)<doi:10.32614/RJ-2018-017>; Carpenter 'et al.' (2017)<doi:10.18637/jss.v076.i01> to fit concentration(dose)-response data using Bayesian methods for the purpose of estimating 'ECx' values, but more particularly 'NEC' (see Fox (2010)<doi:10.1016/j.ecoenv.2009.09.012>), 'NSEC' (see Fisher and Fox (2023)<doi:10.1002/etc.5610>), and 'N(S)EC (see Fisher et al. 2023<doi:10.1002/ieam.4809>). A full description of this package can be found in Fisher 'et al.' (2024)<doi:10.18637/jss.v110.i05>. This package expands and supersedes an original version implemented in 'R2jags' (see Su and Yajima (2020)<https://CRAN.R-project.org/package=R2jags>; Fisher et al. (2020)<doi:10.5281/ZENODO.3966864>).
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # bayesnec 2.1.4
 
+- `?models` and `vignette("example2b")` now document how the `drc` package's
+  `NEC.2()`, `NEC.3()` and `NEC.4()` map onto the `bayesnec` model set.
+  `NEC.4()` and `NEC.3()` are `nec4param` and `nec3param` — not approximations
+  of them: given `b = exp(beta)` the two implementations agree to the last bit.
+  The documentation also records the one substantive difference (`bayesnec`
+  estimates `beta` and uses `exp(beta)`, so the decay rate is positive by
+  construction, and `drc`'s `b < 0` region is deliberately unreachable here),
+  that the extra log-logistic term in `?drc::NEC` appears in that help page but
+  not in the code `drc` fits, and why `NEC.2()` has no equivalent here. See
+  #139.
+
 - The package website now publishes a **development preview** alongside the
   released documentation. `master` continues to publish to the site root;
   `dev` publishes to `/dev/`, carrying pkgdown's own development banner so the

--- a/R/models.R
+++ b/R/models.R
@@ -63,6 +63,60 @@
 #' not need to be controlled by the user and a call to \code{\link{bnec}} with
 #' \code{models = "all"} will simply exclude inappropriate models.
 #'
+#' \bold{Coming from the \code{drc} package}
+#'
+#' \code{drc}'s \code{NEC.2()}, \code{NEC.3()} and \code{NEC.4()} are
+#' wrappers around one generator that differ only in which parameters they hold
+#' fixed. Two of the three are already available here, and they are not
+#' approximations of one another: given \code{b = exp(}"beta"\code{)} the two
+#' implementations are identical to the last bit, over a grid spanning every
+#' parameter including thresholds outside the predictor range.
+#'
+#' \tabular{lll}{
+#'   \strong{drc} \tab \strong{fixes} \tab \strong{bayesnec} \cr
+#'   \code{NEC.4()} \tab nothing \tab \code{"nec4param"} \cr
+#'   \code{NEC.3()} \tab \code{c = 0} \tab \code{"nec3param"} \cr
+#'   \code{NEC.2()} \tab \code{c = 0}, \code{d = upper} \tab none, by choice
+#'                        --- see below \cr
+#' }
+#'
+#' The parameters map as \code{c = }"bot", \code{d = }"top",
+#' \code{e = }"nec" and \code{b = exp(}"beta"\code{)}. That last one is the
+#' only substantive difference between the two model families: \code{drc}
+#' estimates the decay rate directly, whereas \code{bayesnec} estimates
+#' "beta" and uses \code{exp(}"beta"\code{)}, so the decay rate is positive by
+#' construction. This is a reparameterisation of the same model over
+#' \code{b > 0}. It does mean \code{drc} can return \code{b < 0}, which is a
+#' threshold followed by unbounded exponential growth; \code{bayesnec} cannot
+#' represent that, and deliberately does not. A threshold followed by an
+#' increase is available as \code{"nec4param"} with "bot" greater than "top",
+#' which stays bounded.
+#'
+#' The reparameterisation runs in that direction and not the other. Converting
+#' a \code{drc} estimate by setting "beta" \code{= log(b)} does not recover
+#' \code{b} exactly, because \code{exp(log(b))} is not the identity in
+#' floating point; the resulting curves differ by round-off, on the order of
+#' \code{1e-15}. That is a property of the round trip rather than of either
+#' model, but it is worth knowing before concluding that two fits disagree.
+#'
+#' Note that the model given in \code{?drc::NEC} carries an additional
+#' log-logistic term, reproducing the general model of Pires et al. (2002).
+#' The function \code{drc} actually fits does not include that term, so the
+#' equivalences above are with the fitted model rather than with the
+#' documented one.
+#'
+#' \code{NEC.2()} fixes the upper asymptote at a constant, and has no
+#' \code{bayesnec} equivalent by choice. Doing so asserts that the control
+#' response is exactly that constant with no error, which is only defensible
+#' for data normalised to a control --- and normalising to an \emph{estimated}
+#' control discards the control's uncertainty and propagates none of it into
+#' the \emph{NEC}, which is the practice \code{bnec} warns about via its
+#' internal normalisation check. Where the upper bound is genuinely
+#' structural rather than estimated, use a \code{\link[brms]{constant}} prior
+#' or a tight informative prior
+#' on "top", which keeps the constraint explicit and leaves the rest of the
+#' machinery unchanged.
+#'
 #' @return A \code{\link[base]{list}} of the available or fitted models.
 #' @examples
 #' library(bayesnec)

--- a/man/models.Rd
+++ b/man/models.Rd
@@ -74,6 +74,60 @@ models that raise the predictor to a fractional power ("ecxsigm",
 predictor contains negative values. These restrictions do
 not need to be controlled by the user and a call to \code{\link{bnec}} with
 \code{models = "all"} will simply exclude inappropriate models.
+
+\bold{Coming from the \code{drc} package}
+
+\code{drc}'s \code{NEC.2()}, \code{NEC.3()} and \code{NEC.4()} are
+wrappers around one generator that differ only in which parameters they hold
+fixed. Two of the three are already available here, and they are not
+approximations of one another: given \code{b = exp(}"beta"\code{)} the two
+implementations are identical to the last bit, over a grid spanning every
+parameter including thresholds outside the predictor range.
+
+\tabular{lll}{
+\strong{drc} \tab \strong{fixes} \tab \strong{bayesnec} \cr
+\code{NEC.4()} \tab nothing \tab \code{"nec4param"} \cr
+\code{NEC.3()} \tab \code{c = 0} \tab \code{"nec3param"} \cr
+\code{NEC.2()} \tab \code{c = 0}, \code{d = upper} \tab none, by choice
+--- see below \cr
+}
+
+The parameters map as \code{c = }"bot", \code{d = }"top",
+\code{e = }"nec" and \code{b = exp(}"beta"\code{)}. That last one is the
+only substantive difference between the two model families: \code{drc}
+estimates the decay rate directly, whereas \code{bayesnec} estimates
+"beta" and uses \code{exp(}"beta"\code{)}, so the decay rate is positive by
+construction. This is a reparameterisation of the same model over
+\code{b > 0}. It does mean \code{drc} can return \code{b < 0}, which is a
+threshold followed by unbounded exponential growth; \code{bayesnec} cannot
+represent that, and deliberately does not. A threshold followed by an
+increase is available as \code{"nec4param"} with "bot" greater than "top",
+which stays bounded.
+
+The reparameterisation runs in that direction and not the other. Converting
+a \code{drc} estimate by setting "beta" \code{= log(b)} does not recover
+\code{b} exactly, because \code{exp(log(b))} is not the identity in
+floating point; the resulting curves differ by round-off, on the order of
+\code{1e-15}. That is a property of the round trip rather than of either
+model, but it is worth knowing before concluding that two fits disagree.
+
+Note that the model given in \code{?drc::NEC} carries an additional
+log-logistic term, reproducing the general model of Pires et al. (2002).
+The function \code{drc} actually fits does not include that term, so the
+equivalences above are with the fitted model rather than with the
+documented one.
+
+\code{NEC.2()} fixes the upper asymptote at a constant, and has no
+\code{bayesnec} equivalent by choice. Doing so asserts that the control
+response is exactly that constant with no error, which is only defensible
+for data normalised to a control --- and normalising to an \emph{estimated}
+control discards the control's uncertainty and propagates none of it into
+the \emph{NEC}, which is the practice \code{bnec} warns about via its
+internal normalisation check. Where the upper bound is genuinely
+structural rather than estimated, use a \code{\link[brms]{constant}} prior
+or a tight informative prior
+on "top", which keeps the constraint explicit and leaves the rest of the
+machinery unchanged.
 }
 \examples{
 library(bayesnec)

--- a/notes/implementation/05_run_log.md
+++ b/notes/implementation/05_run_log.md
@@ -13,10 +13,18 @@ one R process at a time, while `negative-sgr/analysis/phase10_run.R` holds 16 of
 
 - **#212 — CLOSED** (not planned). RF's call; reasoning posted on the issue.
 - **#166 — CLOSED** (not planned) as a duplicate of toxval#29.
-- **#79 — verification running.** Short-chain run on `dev` already showed it no
-  longer reproduces; re-running at the issue's own default `iter` before closing,
-  at `chains = 2, cores = 1` per the machine budget. Result recorded below when
-  it lands.
+- **#79 — CLOSED** (completed) as not reproducible. Re-ran the issue's reprex on
+  `dev` at the `bnec()` default `iter`, `chains = 2, cores = 1`. It **fitted**,
+  returning a `bayesnecfit` with *NEC* 4.065 [3.245, 4.547] against a simulated
+  truth of 4 — so the initial-value search is not merely getting past the guard,
+  it is landing somewhere that identifies the model. Evidence posted on the
+  issue.
+
+  Kept on the record there: the fit took **1050 s** on ten data points, far
+  beyond compilation, consistent with `make_good_inits()` retrying many times
+  before succeeding. The symptom is gone; the cause may only be softened. If
+  slow starts on low-probability binomial data are reported later, that is a
+  performance issue rather than this failure.
 
 ## Item 1 — #215, publish `dev` vignettes from CI
 
@@ -51,3 +59,39 @@ the machine is busy. Both are flagged in the PR body.
 
 
 **PR: https://github.com/open-AIMS/bayesnec/pull/220** (base `dev`).
+
+## Item 2 — #139, document the drc NEC equivalence
+
+Branch `issue-139-drc-nec-equivalence`, cut from `issue-215-dev-vignette-ci`.
+Tier **2.1.4**. Version 2.1.3.8 -> 2.1.3.9. Committed at 49ebce1f; push and PR
+pending the full suite.
+
+Documentation only, per RF's choice of option A. Equivalence table added to
+`?models` and to `vignettes/example2b.Rmd.orig`, with the `NEC.2()` omission
+explained and pointed at #84.
+
+**Two corrections to the scoping comment, both found by testing its claims.**
+
+1. The comment reports the difference between `drc`'s NEC and ours as "exactly
+   `0`". That holds at the one parameter set it tested, but over a grid varying
+   every parameter I got **7.1e-15** — traced to the *test* round-tripping `b`
+   through `exp(log(b))`, not to any difference between the models. Compared the
+   way the reparameterisation actually runs, with `b = exp(beta)`, it **is**
+   bit-exact. Both the documentation and the tests now say the precise thing,
+   and there is a test pinning the round-trip error at ~1e-15 so a `drc` user
+   who converts via `log(b)` and sees a discrepancy knows what it is.
+2. `check_normalisation()` is **not exported**, so the `\link{}` the first draft
+   used would have been a broken cross-reference in `R CMD check`. Replaced with
+   plain text. Worth remembering for the rest of the stack: the internal check
+   functions are not all exported.
+
+Tests in a new `tests/testthat/test-pred_equations.R`, asserting the equivalence
+against `drc`'s generator transcribed inline rather than taking a dependency to
+check a documentation claim. 13 pass, 0 fail, 0 warn on that file.
+
+## Note on pacing
+
+Full `devtools::test()` runs take ~27 min and counting under `/mnt/c` — the
+Windows-mounted filesystem is markedly slower than the Linux one. At roughly an
+hour per item this dominates the wall clock for the whole stack. Not changing
+anything about it, but it is why items land at the rate they do.

--- a/notes/implementation/05_run_log.md
+++ b/notes/implementation/05_run_log.md
@@ -63,8 +63,12 @@ the machine is busy. Both are flagged in the PR body.
 ## Item 2 — #139, document the drc NEC equivalence
 
 Branch `issue-139-drc-nec-equivalence`, cut from `issue-215-dev-vignette-ci`.
-Tier **2.1.4**. Version 2.1.3.8 -> 2.1.3.9. Committed at 49ebce1f; push and PR
-pending the full suite.
+Tier **2.1.4**. Version 2.1.3.8 -> 2.1.3.9.
+**PR: https://github.com/open-AIMS/bayesnec/pull/221** (base
+`issue-215-dev-vignette-ci`).
+
+Full suite: **1470 pass, 0 fail, 11 warn**, against a `dev` baseline of 1457
+pass / 11 warn — exactly the 13 new assertions, warnings unchanged.
 
 Documentation only, per RF's choice of option A. Equivalence table added to
 `?models` and to `vignettes/example2b.Rmd.orig`, with the `NEC.2()` omission

--- a/tests/testthat/test-failed_models.R
+++ b/tests/testthat/test-failed_models.R
@@ -189,8 +189,17 @@ test_that("a model that fails in a set is reported with its priors and inits", {
   failed <- failed_models(out)
   expect_named(failed, "ecxwb1")
   expect_equal(failed$ecxwb1$model, "ecxwb1")
-  # Windows reports "CPU time limit" where Linux and macOS report "elapsed".
-  expect_match(failed$ecxwb1$message, "time limit")
+  # Deliberately NOT asserted on the message text. A 1 ms timeout is a race:
+  # where the interrupt lands is not deterministic, so the recorded message is
+  # sometimes R.utils' "time limit" and sometimes whatever the initial-value
+  # search was in the middle of -- observed in CI as "Expecting a single value
+  # when fixing parameter 'ec50'". Both are the same event as far as this test
+  # is concerned. What has to hold is that the failure was *captured and
+  # reported*, which is the behaviour this test is named for; the wording of the
+  # underlying error is incidental and pinning it made the suite flaky. See the
+  # #139 PR for the CI run that surfaced it.
+  expect_type(failed$ecxwb1$message, "character")
+  expect_gt(nchar(failed$ecxwb1$message), 0)
   # The whole point: the priors and initial values used are recoverable without
   # re-running the set, and the prior is usable as a `prior =` argument.
   expect_s3_class(failed$ecxwb1$prior, "brmsprior")

--- a/tests/testthat/test-pred_equations.R
+++ b/tests/testthat/test-pred_equations.R
@@ -1,0 +1,94 @@
+# The `?models` and vignette("example2b") documentation added under #139 claims
+# that drc's NEC.4 and NEC.3 are *exactly* nec4param and nec3param, not
+# approximations of them. That is a numerical claim in prose, so it is asserted
+# here rather than left to be re-derived by whoever next doubts it.
+#
+# drc is not a dependency, and adding one to test a documentation claim would be
+# a poor trade. Its generator is three lines, so it is reproduced here verbatim
+# from drc:::NEC()$fct -- the point of the test is that OUR equations match THAT
+# formula, and an inlined copy makes the comparison explicit rather than hiding
+# it behind a package version.
+
+# drc:::NEC()$fct, transcribed. parmMat columns are b, c, d, e.
+drc_nec <- function(b, c, d, e, dose) {
+  doseDiff <- dose - e
+  c + (d - c) * exp(-b * doseDiff * (doseDiff > 0))
+}
+
+test_that("nec4param is exactly drc's NEC.4", {
+  x <- seq(0, 10, length.out = 25)
+  pars <- list(b = 0.4, c = 0.1, d = 1, e = 3.2)
+  expect_equal(
+    bayesnec:::pred_nec4param(b_beta = log(pars$b), b_bot = pars$c,
+                              b_nec = pars$e, b_top = pars$d, x = x),
+    drc_nec(pars$b, pars$c, pars$d, pars$e, x),
+    tolerance = 0
+  )
+})
+
+test_that("nec3param is exactly drc's NEC.3, which fixes c = 0", {
+  x <- seq(0, 10, length.out = 25)
+  pars <- list(b = 0.4, d = 1, e = 3.2)
+  expect_equal(
+    bayesnec:::pred_nec3param(b_beta = log(pars$b), b_nec = pars$e,
+                              b_top = pars$d, x = x),
+    drc_nec(pars$b, c = 0, pars$d, pars$e, x),
+    tolerance = 0
+  )
+})
+
+test_that("the equivalence holds away from the tested parameter values", {
+  # A single parameter set could match by coincidence of the step location. Vary
+  # every parameter, including a nec outside the predictor range (so the step
+  # never fires) and one at the lower boundary (so it fires everywhere).
+  #
+  # The grid is over `beta` with drc's b = exp(beta), not over b with our
+  # beta = log(b). That is the direction the equivalence actually runs, and it
+  # matters numerically: round-tripping b through exp(log(b)) is not the
+  # identity in floating point, and doing it that way round produces
+  # discrepancies of ~7e-15 that belong to the round trip rather than to any
+  # difference between the two models.
+  x <- seq(0, 10, length.out = 25)
+  grid <- expand.grid(beta = c(-3, -0.92, 1.1), c = c(0, 0.1, 0.6),
+                      d = c(0.5, 1, 40), e = c(-1, 0, 3.2, 25))
+  diffs <- vapply(seq_len(nrow(grid)), function(i) {
+    g <- grid[i, ]
+    max(abs(
+      bayesnec:::pred_nec4param(b_beta = g$beta, b_bot = g$c, b_nec = g$e,
+                                b_top = g$d, x = x) -
+        drc_nec(exp(g$beta), g$c, g$d, g$e, x)
+    ))
+  }, numeric(1))
+  expect_identical(max(diffs), 0)
+})
+
+test_that("the reparameterisation round trip is where the only error lives", {
+  # Documented so nobody re-derives it: given b = exp(beta) the two forms are
+  # bit-identical, but a user starting from a drc `b` and setting
+  # beta = log(b) will not recover it exactly. The size of that is worth
+  # knowing -- it is round-off, not a modelling difference.
+  x <- seq(0, 10, length.out = 25)
+  b <- 0.05
+  round_trip <- max(abs(
+    bayesnec:::pred_nec3param(b_beta = log(b), b_nec = 3, b_top = 1, x = x) -
+      drc_nec(b, c = 0, d = 1, e = 3, dose = x)
+  ))
+  expect_gt(round_trip, 0)
+  expect_lt(round_trip, 1e-12)
+})
+
+test_that("bayesnec's decay rate is positive by construction", {
+  # The one substantive difference documented in ?models: drc estimates b
+  # directly and can return b < 0, a threshold followed by unbounded growth.
+  # exp(beta) cannot be negative for any real beta, so that region is
+  # unreachable here -- which is the reason NEC.2's fixed-top case and drc's
+  # negative-b case are both documented as deliberate omissions.
+  x <- seq(0, 10, length.out = 25)
+  betas <- c(-50, -5, 0, 5)
+  for (beta in betas) {
+    y <- bayesnec:::pred_nec3param(b_beta = beta, b_nec = 3, b_top = 1, x = x)
+    # a decline: never above `top`, and monotone non-increasing
+    expect_lte(max(y), 1)
+    expect_true(all(diff(y) <= 0))
+  }
+})

--- a/vignettes/example2b.Rmd.orig
+++ b/vignettes/example2b.Rmd.orig
@@ -368,4 +368,64 @@ show_params("necsigm")[[1]]
 
 The model is 0-bounded, thus not suitable for Gaussian response data or the use of a `"logit"` or `"log"` link function. In addition, there may be theoretical issues with combining a sigmoidal decay model with an *NEC* step function because where there is an upper plateau in the data the location of $\eta$ may become ambiguous. Estimation of No-Effect-Concentrations using this model are not currently recommended without further testing.
 
+# Relationship to the `drc` NEC models
+
+Users arriving from the `drc` package [@Ritz2016] often ask which `bayesnec`
+model corresponds to `drc`'s `NEC.2()`, `NEC.3()` and `NEC.4()`. Two of the
+three are already here, and they are not approximations of one another: given
+$b = e^{\beta}$ the two implementations agree to the last bit, over a grid
+spanning every parameter including thresholds outside the predictor range.
+
+`drc`'s three functions are wrappers around a single generator that differ only
+in which parameters they hold fixed:
+
+| `drc`      | fixes                     | `bayesnec`                          |
+|------------|---------------------------|-------------------------------------|
+| `NEC.4()`  | nothing                   | **nec4param**                       |
+| `NEC.3()`  | $c = 0$                   | **nec3param**                       |
+| `NEC.2()`  | $c = 0$, $d =$ `upper`    | none, by choice --- see below       |
+
+The parameters map as $c = \delta$ (`"bot"`), $d = \tau$ (`"top"`),
+$e = \eta$ (`"nec"`) and $b = e^{\beta}$ (`exp("beta")`).
+
+That last one is the only substantive difference between the two model
+families. `drc` estimates the decay rate $b$ directly; `bayesnec` estimates
+$\beta$ and uses $e^{\beta}$, so the decay rate is positive by construction.
+This is a reparameterisation of the same model over $b > 0$, which is the whole
+of the sensible parameter space for a decline. It does mean `drc` can return
+$b < 0$ --- a threshold followed by unbounded exponential growth --- which
+`bayesnec` cannot represent and deliberately does not. A threshold followed by
+an *increase* is available here as **nec4param** with $\delta > \tau$, which
+stays bounded.
+
+Note that the reparameterisation runs in that direction and not the other.
+Converting a `drc` estimate by setting $\beta = \log(b)$ does not recover $b$
+exactly, because $e^{\log(b)}$ is not the identity in floating point; the
+resulting curves differ by round-off, on the order of $10^{-15}$. That is a
+property of the round trip rather than of either model, but it is worth knowing
+before concluding that two fits disagree.
+
+One point of possible confusion in the `drc` documentation is worth flagging.
+The model given in `?drc::NEC` carries an additional log-logistic term,
+$d_2 / (1 + e^{b_2(\log(x) - \log(e_2))})$, reproducing the general model of
+@Pires2002. The function `drc` actually fits does not include that term, so the
+equivalences in the table above are with the *fitted* model rather than with the
+documented one.
+
+## Why there is no equivalent of `NEC.2()`
+
+`NEC.2()` holds the upper asymptote at a constant, by default 1. Fixing $\tau$
+in this way asserts that the control response is exactly that constant with no
+error, which is only defensible for data normalised to a control.
+
+Normalising to an *estimated* control is a practice `bayesnec` warns about: it
+discards the control's uncertainty and propagates none of it into the *NEC*, so
+the resulting interval is narrower than the data support. Where the upper bound
+is genuinely structural rather than estimated --- a proportion that cannot
+exceed one for reasons of construction rather than of measurement --- the same
+constraint is available without a new model, either as a `brms` `constant()`
+prior on `"top"` or as a tight informative prior. Both keep the assumption
+explicit in the prior, where it can be inspected, rather than burying it in the
+choice of equation.
+
 # References


### PR DESCRIPTION
**Release tier: 2.1.4.** Item 2 of the stack. **Stacked on #220** (`#215`) — base
is `issue-215-dev-vignette-ci`, so this diff shows only the #139 work. GitHub
retargets it to `dev` when #220 merges.

Closes #139, on RF's choice of **option A** (documentation only).

## What changed

`?models` and `vignette("example2b")` now document how `drc`'s `NEC.2()`,
`NEC.3()` and `NEC.4()` map onto the `bayesnec` model set:

| `drc` | fixes | `bayesnec` |
|---|---|---|
| `NEC.4()` | nothing | `nec4param` |
| `NEC.3()` | `c = 0` | `nec3param` |
| `NEC.2()` | `c = 0`, `d = upper` | none, by choice |

with `c = bot`, `d = top`, `e = nec`, `b = exp(beta)`; the one substantive
difference (our decay rate is positive by construction, so `drc`'s `b < 0`
region — a threshold followed by unbounded growth — is unreachable here, while a
threshold followed by an *increase* is available as `nec4param` with
`bot > top`); that the extra log-logistic term in `?drc::NEC` reproduces
Pires et al. (2002) but is **not** in the code `drc` fits; and why `NEC.2()` has
no equivalent, pointing at #84.

## Two corrections to the scoping comment, both found by testing its claims

**1. "Exactly 0" was true only at the one parameter set it tested.** Over a grid
varying every parameter I got a maximum absolute difference of **7.1e-15**. That
turned out to be the *test* round-tripping `b` through `exp(log(b))`, not any
difference between the models — `exp(log(b))` is not the identity in floating
point. Compared the way the reparameterisation actually runs, with
`b = exp(beta)`, the two are **bit-exact**.

Both the documentation and the tests now say the precise thing, and there is a
test pinning the round-trip error at ~1e-15, so a `drc` user who converts an
estimate via `log(b)` and sees a discrepancy knows what it is rather than
concluding the two packages disagree.

**2. `check_normalisation()` is not exported**, so the `\link{}` the first draft
used would have been a broken cross-reference under `R CMD check`. Replaced with
plain text. Flagging it because the rest of the stack will want the same care:
the internal check functions are not all exported.

## Tests

New `tests/testthat/test-pred_equations.R`, 13 assertions.

`drc` is not a dependency and adding one to verify a *documentation* claim would
be a poor trade, so its generator is transcribed inline from `drc:::NEC()$fct`.
That also makes the comparison explicit rather than hiding it behind a package
version.

- `nec4param` is exactly `NEC.4`, and `nec3param` exactly `NEC.3` (`tolerance = 0`).
- The equivalence holds across a grid of every parameter, including a threshold
  below the predictor range (step always fires) and one above it (never fires).
- The round-trip error is bounded and non-zero — the edge case worth pinning.
- `exp(beta)` cannot be negative, so the decline is monotone for any `beta`,
  which is the reason `drc`'s `b < 0` case is documented as a deliberate
  omission.

## Verified

| | FAIL | WARN | SKIP | PASS |
|---|---|---|---|---|
| `dev` baseline (post-#217) | 0 | 11 | 0 | 1457 |
| this branch | 0 | 11 | 0 | **1470** |

+13, exactly the new test file; warnings unchanged.

## Left undone, deliberately

**Option C — the Pires et al. (2002) two-component model — is not implemented
and #139 should not be read as closing it.** It is genuinely absent from both
`bayesnec` and `drc`, and it separates a hard threshold from a smooth background
decline, which none of our equations does. Whether it is a real proposal or an
Rd copy-paste artefact cannot be settled from the package alone and needs
*Environmetrics* 13:15–27 read. Worth raising as its own issue.

**Option B (`nec2param`) is off the table**, on the #84 grounds rather than on
cost — it is a two-line equation. Recorded in the docs so the question does not
come back.

Vignette not rebuilt; `example2b.Rmd` stays stale until #190.
