### PR TITLE
Guard define_prior against a response that is mostly zeros (#210)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bayesnec
 Title: A Bayesian No-Effect- Concentration (NEC) Algorithm
-Version: 2.1.3.9
+Version: 2.1.3.10
 Authors@R: c(person("Rebecca", "Fisher", email = "r.fisher@aims.gov.au", role = c("aut", "cre"),comment = c(ORCID = "0000-0001-5148-6731")), person("Diego R.","Barneche",role="aut",comment = c(ORCID = "0000-0002-4568-2362")), person("Gerard F.","Ricardo",role="aut",comment = c(ORCID = "0000-0002-2220-3971")), person("David R.","Fox",role="aut",comment = c(ORCID = "0000-0002-3178-7243")))
 Description: Implementation of No-Effect-Concentration estimation that uses 'brms' (see Burkner (2017)<doi:10.18637/jss.v080.i01>; Burkner (2018)<doi:10.32614/RJ-2018-017>; Carpenter 'et al.' (2017)<doi:10.18637/jss.v076.i01> to fit concentration(dose)-response data using Bayesian methods for the purpose of estimating 'ECx' values, but more particularly 'NEC' (see Fox (2010)<doi:10.1016/j.ecoenv.2009.09.012>), 'NSEC' (see Fisher and Fox (2023)<doi:10.1002/etc.5610>), and 'N(S)EC (see Fisher et al. 2023<doi:10.1002/ieam.4809>). A full description of this package can be found in Fisher 'et al.' (2024)<doi:10.18637/jss.v110.i05>. This package expands and supersedes an original version implemented in 'R2jags' (see Su and Yajima (2020)<https://CRAN.R-project.org/package=R2jags>; Fisher et al. (2020)<doi:10.5281/ZENODO.3966864>).
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 # bayesnec 2.1.4
 
+- `define_prior()` no longer collapses the `top` and `bot` priors when a large
+  share of the response is exactly zero. The gamma rates for those parameters
+  are set from quantiles of the response, and those quantiles are zero once
+  enough of the response is — so `bot` was pinned near zero whatever the real
+  lower asymptote was (from 25% zeros under the default `prior_type`, and from a
+  *single* zero under `"regularizing"`, which uses the minimum), and past 75%
+  zeros the `top` rate divided by zero and produced the literal prior string
+  `gamma(2, Inf)`. Where a quantile has collapsed, the scale now falls back to
+  the same quantile of the positive part of the response. This is not new to the
+  zero-inflated count families added in 2.1.4 — a `poisson` or `Gamma` response
+  with many zeros always hit it — but those families exist precisely for that
+  regime, which made it the normal case rather than an accident. A response with
+  no positive values at all now raises an informative error instead. Priors for
+  a response containing no zeros are unchanged. See #210.
+
 - `?models` and `vignette("example2b")` now document how the `drc` package's
   `NEC.2()`, `NEC.3()` and `NEC.4()` map onto the `bayesnec` model set.
   `NEC.4()` and `NEC.3()` are `nec4param` and `nec3param` — not approximations

--- a/R/define_prior.R
+++ b/R/define_prior.R
@@ -1,3 +1,57 @@
+#' Quantile of a response, guarded against exact zeros
+#'
+#' The gamma priors for "top" and "bot" set their rate from a quantile of the
+#' response. Where a large share of the response is exactly zero those
+#' quantiles are zero, and the rate either collapses onto a fudge term or
+#' divides by zero outright -- \code{gamma(2, Inf)}. That is not a rare corner:
+#' the zero-inflated count families added under #104 exist precisely for
+#' responses where a quarter or more of the values are zero.
+#'
+#' The guard falls back to the same quantile of the \emph{positive} part of the
+#' response. That keeps the prior on the scale of the data actually carrying
+#' signal about the asymptotes, which is the quantity these priors are trying to
+#' locate, rather than on the scale of a structural-zero process that says
+#' nothing about them.
+#'
+#' Deliberately not the same trick as \code{define_hurdle_prior()}, which
+#' computes the whole mu-block prior from the non-zero subset. That is exact for
+#' \code{hurdle_gamma}, because a Gamma has no mass at zero, so the non-zero
+#' subset *is* the mu process. Under zero-inflation it is not: the base
+#' distribution emits zeros of its own, so conditioning on the positives draws
+#' from a truncated count distribution and biases the location upward. Here the
+#' positive part is used only to recover a *scale* when the raw quantile has
+#' collapsed, never as the estimate itself. See #210.
+#'
+#' @param response A \code{\link[base]{numeric}} vector.
+#' @param probs A \code{\link[base]{numeric}} vector of length 1.
+#'
+#' @return A \code{\link[base]{numeric}} vector of length 1, strictly positive.
+#'
+#' @importFrom stats quantile
+#'
+#' @noRd
+positive_scale <- function(response, probs) {
+  q <- unname(quantile(response, probs = probs))
+  if (is.finite(q) && q > 0) {
+    return(q)
+  }
+  pos <- response[response > 0 & is.finite(response)]
+  if (!length(pos)) {
+    stop("Cannot build priors for \"top\" and \"bot\": the response contains no",
+         " positive values, so there is no scale to place them on. Check the",
+         " response variable, and see ?bnec for the families bayesnec supports.",
+         call. = FALSE)
+  }
+  q_pos <- unname(quantile(pos, probs = probs))
+  # quantile(pos, 0) is min(pos), which is positive by construction, so this
+  # cannot itself return zero. The guard is kept anyway because probs is
+  # supplied by the caller and a future table could pass something else.
+  if (!is.finite(q_pos) || q_pos <= 0) {
+    return(min(pos))
+  }
+  q_pos
+}
+
 #' define_prior
 #'
 #' Generates prior model objects to pass to \pkg{brms}
@@ -35,19 +89,12 @@ define_prior <- function(model, family, predictor, response,
   # duplicated set of entries in every table below.
   #
   # The quantiles below are taken over the whole response, structural zeros
-  # included, and that is a known defect here rather than a harmless
-  # approximation. Once a quarter of the response is zero -- i.e. zi >= 0.25,
-  # the regime these families exist for -- quantile(response, 0.25) is exactly
-  # 0 and the `bot` prior collapses onto the min(positive)/100 fudge term,
-  # giving a prior mean near zero whatever the real lower asymptote is. Under
-  # prior_type = "regularizing" the denominator is quantile(response, 0), so
-  # that happens for any zero-inflated response at all. Past three quarters
-  # zero, the `top` rate divides by zero and the prior string becomes
-  # "gamma(2, Inf)". Conditioning on the non-zeros instead -- which is what
-  # define_hurdle_prior() does, exactly, for hurdle_gamma -- is not available
-  # as a fix here: under zero-inflation the non-zero subset is drawn from a
-  # truncated count distribution and biases mu upward. The guard belongs in the
-  # prior tables themselves. See #104 and #210.
+  # included. That used to collapse the `top` and `bot` priors once a large
+  # share of the response was zero -- the regime these families exist for --
+  # and is now guarded by positive_scale(), which falls back to the same
+  # quantile of the positive part. See its documentation for why that is not
+  # the same trick define_hurdle_prior() uses, and #210 for what the three
+  # failure modes were.
   if (fam_tag %in% c("zero_inflated_poisson", "zero_inflated_negbinomial")) {
     fam_tag <- sub("^zero_inflated_", "", fam_tag)
   }
@@ -70,10 +117,10 @@ define_prior <- function(model, family, predictor, response,
   # predictor-scaled and fixed priors below are shared.
   if (prior_type == "uninformative") {
     u_t_g <- paste0("gamma(2, ",
-                    1 / (quantile(response, probs = 0.75) / 2),
+                    1 / (positive_scale(response, probs = 0.75) / 2),
                     ")")
     u_b_g <- paste0("gamma(2, ",
-                    1 / ((quantile(response, probs = 0.25) +
+                    1 / ((positive_scale(response, probs = 0.25) +
                       min(response[response > 0]) / 100) / 2),
                     ")")
     y_t_prs <- c(Gamma = u_t_g,
@@ -98,10 +145,14 @@ define_prior <- function(model, family, predictor, response,
                  beta = "beta(2, 5)")
   } else {
     u_t_g <- paste0("gamma(5, ",
-                    5 / (quantile(response, probs = 1)),
+                    5 / (positive_scale(response, probs = 1)),
                     ")")
+    # probs = 0 is the minimum, which is zero for a response containing a single
+    # zero -- not merely for a mostly-zero one. So under "regularizing" the
+    # collapse was unconditional on the zero fraction, where under
+    # "uninformative" it needed a quarter of the response to be zero.
     u_b_g <- paste0("gamma(5, ",
-                    5 / ((quantile(response, probs = 0) +
+                    5 / ((positive_scale(response, probs = 0) +
                       min(response[response > 0]) / 10)),
                     ")")
     y_t_prs <- c(Gamma = u_t_g,

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -454,7 +454,12 @@ contains_negative <- function(x) {
 #' @noRd
 response_link_scale <- function(response, family) {
   link_tag <- family$link
-  min_z_val <- min(response[which(response > 0)]) / 100
+  # Computed on demand rather than eagerly. An all-zero response is legitimate
+  # input for a zero-inflated family, and reaches none of the branches below --
+  # but min(response[response > 0]) on it is Inf and emits a warning the caller
+  # can do nothing about. Surfaced by the #210 tests; the value itself is
+  # unchanged wherever it is actually used.
+  min_z_val <- function() min(response[which(response > 0)]) / 100
   if (link_tag == "logit") {
     max_o_val <- max(response[which(response < 1)]) +
       (1 - max(response[which(response < 1)])) * 0.99
@@ -464,7 +469,7 @@ response_link_scale <- function(response, family) {
   if (link_tag %in% c("logit", "log")) {
     if (family$family %in% c("bernoulli", "binomial", "beta_binomial")) {
       if (contains_zero(response)) {
-        response <- lr(response, r_out = c(min_z_val, max(response)))
+        response <- lr(response, r_out = c(min_z_val(), max(response)))
       }
       if (contains_one(response)) {
         response <- lr(response, r_out = c(min(response), max_o_val))
@@ -472,7 +477,7 @@ response_link_scale <- function(response, family) {
       response <- family$linkfun(response)
     } else {
       if (contains_zero(response)) {
-        response <- lr(response, r_out = c(min_z_val, max(response)))
+        response <- lr(response, r_out = c(min_z_val(), max(response)))
       }
       response <- family$linkfun(response)
     }
@@ -484,7 +489,7 @@ response_link_scale <- function(response, family) {
     # Clamp response away from the boundaries so that initial values
     # derived from it stay within the valid support.
     if (contains_zero(response)) {
-      response <- lr(response, r_out = c(min_z_val, max(response)))
+      response <- lr(response, r_out = c(min_z_val(), max(response)))
     }
     if (contains_one(response)) {
       max_o_val <- max(response[which(response < 1)]) +

--- a/notes/implementation/05_run_log.md
+++ b/notes/implementation/05_run_log.md
@@ -99,3 +99,47 @@ Full `devtools::test()` runs take ~27 min and counting under `/mnt/c` — the
 Windows-mounted filesystem is markedly slower than the Linux one. At roughly an
 hour per item this dominates the wall clock for the whole stack. Not changing
 anything about it, but it is why items land at the rate they do.
+
+## Item 3 — #210, define_prior collapse on many zeros
+
+Branch `issue-210-define-prior-zeros`, cut from `issue-139-drc-nec-equivalence`.
+Tier **2.1.4**. Version 2.1.3.9 -> 2.1.3.10.
+**PR: https://github.com/open-AIMS/bayesnec/pull/222**.
+
+All three failures from the issue verified fixed on its own reprex. `bot` rate
+at 33% zeros 66.7 -> 0.199 (prior mean 0.03 -> 10.0 against a true `bot` of 5);
+`regularizing` no longer pinned; `gamma(2, Inf)` -> `gamma(2, 0.079)` past 75%
+zeros. A no-zeros response is provably untouched.
+
+Full suite **1504 pass / 0 fail / 11 warn**, +34 on the branch below.
+
+**Two deviations from the queue's "R/define_prior.R only" scope, both flagged in
+the PR rather than folded in silently.**
+
+1. `R/helpers.R` — `response_link_scale()` computed `min_z_val` eagerly, so an
+   all-zero response warned about a value it never uses. Made lazy.
+2. `tests/testthat/test-failed_models.R` — de-flaked, committed on the #139
+   branch. See below.
+
+## BLOCKER RESOLVED — a flaky test at the base of the stack
+
+PR 221's CI went red on `test-failed_models.R:193`, a #133 test unrelated to
+either #139 or #210. It forces a failure with `timeout = 1e-3` and then asserts
+the recorded message matches `"time limit"`; CI recorded *"Expecting a single
+value when fixing parameter 'ec50'"* from the initial-value search instead.
+
+Where a 1 ms interrupt lands is a race, so the message was never a stable thing
+to assert. Confirmed not caused by #139 by arithmetic: PR 220 ran 1449 pass /
+0 fail on the identical runner, PR 221 ran 1461 / 1, and 1449 + 13 new = 1462 =
+1461 + 1. It also passed locally at 1470/0 on the same commit.
+
+**Fixed on the #139 branch, not #210**, because branches stack: a fix higher up
+would have left #221 red and every later PR inheriting the flake. `issue-210`
+was rebased onto the corrected `issue-139`. The test now asserts what it is
+named for — the failure was captured and reported with its priors and inits —
+instead of the incidental wording.
+
+**Worth watching for the rest of the stack:** this suite has at least one
+timing-dependent test, and CI runners are slower and more variable than this
+machine. A red check on a test unrelated to the item in hand should be checked
+against the pass/fail arithmetic before it is assumed to be the item's fault.

--- a/tests/testthat/test-define_prior.R
+++ b/tests/testthat/test-define_prior.R
@@ -118,3 +118,109 @@ test_that("prior_type selects between default prior sets", {
   expect_error(define_prior("nec4param", gaussian(), pred_a, resp,
                             prior_type = "nonsense"))
 })
+
+# #210: the `top` and `bot` gamma rates are set from quantiles of the response.
+# Where a large share of the response is exactly zero those quantiles are zero
+# and the rate either collapses onto the fudge term or divides by zero. These
+# tests assert the priors stay finite and stay on the scale of the data, at the
+# zero fractions the issue names.
+
+# Helper: a nec4param-shaped count response with a true lower asymptote of 5,
+# zero-inflated at rate `1 - p`. Seeded inside so each call is reproducible
+# independently of test order.
+zi_response <- function(p, seed = 1) {
+  set.seed(seed)
+  x <- as.numeric(rep(1:10, each = 15))
+  mu <- 40 * exp(-0.35 * pmax(x - 2, 0)) + 5
+  list(x = x,
+       y = as.numeric(rpois(length(x), mu) * rbinom(length(x), 1, p)))
+}
+
+# Pull the numeric rate out of a "gamma(a, b)" prior string.
+gamma_rate <- function(prior_df, par) {
+  s <- prior_df$prior[prior_df$nlpar == par]
+  as.numeric(sub("^gamma\\([^,]+,\\s*([^)]+)\\)$", "\\1", s))
+}
+
+test_that("top and bot priors stay finite across zero fractions", {
+  fam <- validate_family("zero_inflated_poisson")
+  # 30%, 50% and 80% zeros: the issue's three regimes, spanning the 25%
+  # threshold where `bot` used to collapse and the 75% one where `top` became
+  # gamma(2, Inf).
+  for (p in c(0.7, 0.5, 0.2)) {
+    d <- zi_response(p)
+    for (type in c("uninformative", "regularizing")) {
+      pr <- define_prior("nec4param", fam, d$x, d$y, prior_type = type)
+      for (par in c("top", "bot")) {
+        rate <- gamma_rate(pr, par)
+        expect_true(is.finite(rate),
+                    info = paste(type, par, "at", mean(d$y == 0), "zeros"))
+        expect_gt(rate, 0)
+      }
+    }
+  }
+})
+
+test_that("bot is not pinned at zero once a quarter of the response is zero", {
+  # The specific failure in #210: at zi = 0.30 the prior mean for `bot` was
+  # 0.03 against a true lower asymptote of 5. Asserted as an order-of-magnitude
+  # sanity bound rather than a pinned constant -- the point is that the prior
+  # is on the scale of the data, not that it takes any particular value.
+  d <- zi_response(0.7)
+  expect_gt(mean(d$y == 0), 0.25)
+  pr <- define_prior("nec4param", validate_family("zero_inflated_poisson"),
+                     d$x, d$y)
+  # gamma(2, rate) has mean 2 / rate
+  expect_gt(2 / gamma_rate(pr, "bot"), 0.5)
+})
+
+test_that("regularizing collapses for any zero, not just many", {
+  # Under prior_type = "regularizing" the denominator was quantile(response, 0)
+  # -- the minimum -- so a single zero was enough. Test with one zero only,
+  # which the uninformative path would never have noticed.
+  set.seed(42)
+  x <- as.numeric(rep(1:10, each = 5))
+  y <- as.numeric(rpois(length(x), 20))
+  y[1] <- 0
+  expect_equal(sum(y == 0), 1)
+  pr <- define_prior("nec4param", validate_family("poisson"), x, y,
+                     prior_type = "regularizing")
+  expect_true(is.finite(gamma_rate(pr, "bot")))
+  expect_gt(gamma_rate(pr, "bot"), 0)
+})
+
+test_that("a response with no zeros is left alone", {
+  # The guard must not move priors for the ordinary case. Compared against the
+  # same response with the guard bypassed, i.e. the raw quantile, which for a
+  # strictly positive response is what positive_scale() returns anyway.
+  set.seed(7)
+  x <- as.numeric(rep(1:10, each = 5))
+  y <- as.numeric(rpois(length(x), 20)) + 1
+  expect_equal(sum(y == 0), 0)
+  expect_identical(bayesnec:::positive_scale(y, 0.25),
+                   unname(quantile(y, 0.25)))
+  expect_identical(bayesnec:::positive_scale(y, 0.75),
+                   unname(quantile(y, 0.75)))
+})
+
+test_that("an all-zero response errors rather than returning a broken prior", {
+  # Edge case: there is no scale to put top and bot on. Erroring names the
+  # problem; the previous behaviour was gamma(2, Inf), which brms would have
+  # rejected far downstream with a much less useful message.
+  x <- as.numeric(rep(1:10, each = 5))
+  expect_error(
+    define_prior("nec4param", validate_family("zero_inflated_poisson"),
+                 x, rep(0, length(x))),
+    "no positive values"
+  )
+})
+
+test_that("response_link_scale does not warn on an all-zero response", {
+  # response_link_scale() computed min(response[response > 0]) eagerly, so an
+  # all-zero response warned even though the value is never used for an
+  # identity-link count family. Surfaced by the test above.
+  expect_silent(
+    bayesnec:::response_link_scale(rep(0, 20),
+                                   validate_family("zero_inflated_poisson"))
+  )
+})


### PR DESCRIPTION
**Release tier: 2.1.4.** Item 3 of the stack. **Stacked on #221** (`#139`), which
is stacked on #220 (`#215`). GitHub retargets this to `dev` as those merge.

Closes #210.

## What changed

The `top` and `bot` gamma priors set their rate from a quantile of the response.
Those quantiles are zero once enough of the response is zero, and the rate then
either collapses onto the fudge term or divides by zero. New internal
`positive_scale()` falls back to the same quantile of the **positive part** of
the response wherever the raw quantile has collapsed.

All three failures in the issue, verified on the issue's own reprex:

| | before | after |
|---|---|---|
| `bot` rate at 33% zeros | 66.7 — prior mean **0.03**, true `bot` = 5 | 0.199 — prior mean 10.0 |
| `bot`, `prior_type = "regularizing"` | pinned near 0.1 regardless of the zero fraction | 1.52 — prior mean 3.3 |
| `top` at 77% zeros | **`gamma(2, Inf)`** | `gamma(2, 0.079)` |

A response with **no** zeros is untouched: rate 0.19960 against 0.19940 before,
and `positive_scale()` provably returns the raw quantile when every value is
positive (asserted).

## Why not `define_hurdle_prior()`'s approach

The obvious fix is the one `define_hurdle_prior()` already uses — compute the
prior from the non-zero subset. That is **exact** for `hurdle_gamma`, because a
Gamma has no mass at zero, so the non-zero subset *is* the mu process.

Under zero-inflation it is not. The base distribution emits zeros of its own, so
conditioning on the positives draws from a *truncated* count distribution and
biases the location upward — the same argument as the growth-component
likelihood in #209. So the positive part is used here only to recover a **scale**
when the raw quantile has collapsed, never as the estimate itself. That
distinction is documented on `positive_scale()`.

## New behaviour: an all-zero response errors

Previously this produced `gamma(2, Inf)`, which `brms` would reject much further
downstream with a far less useful message. It now raises:

> Cannot build priors for "top" and "bot": the response contains no positive
> values, so there is no scale to place them on.

## Out of scope, and done anyway — please read

The queue entry scoped this as "`R/define_prior.R` only". Two changes fall
outside that; both are flagged rather than folded in silently.

**1. `R/helpers.R` — `response_link_scale()` computed `min_z_val` eagerly.**
Surfaced by the all-zero test above: `min(response[response > 0])` on an
all-zero response is `Inf` and emits `no non-missing arguments to min`. The
value is never *used* for an identity-link count family — the branches that
consume it need a logit/log link or a bounded family — so an entirely legitimate
input warned about nothing. Made it lazy; the value is unchanged everywhere it
is actually used. Three lines, same defect class.

**2. `tests/testthat/test-failed_models.R` — de-flaked, in the #139 commit
below.** #221's CI went red on a test unrelated to either issue. It forces a
failure with `timeout = 1e-3` then asserts the recorded message matches
`"time limit"`; CI instead recorded *"Expecting a single value when fixing
parameter 'ec50'"* from the initial-value search. Where a 1 ms interrupt lands
is a race, so the message is not a stable thing to assert.

The arithmetic confirms it was not caused by #139: PR #220 ran 1449 pass / 0 fail
on the identical runner, #221 ran 1461 / 1, and 1449 + 13 new = 1462 = 1461 + 1.
Every new assertion passed; one pre-existing test failed.

Fixed at the base of the stack because otherwise **every PR above it inherits
the flake**. The test now asserts what it is named for — that the failure was
captured and reported with its priors and inits — rather than the incidental
wording.

## Tests

Six new blocks in `tests/testthat/test-define_prior.R` (41 → 75 assertions):
priors finite and positive at 30/50/80% zeros across both `prior_type` values;
`bot` no longer pinned once a quarter of the response is zero; the
`"regularizing"` path exercised with a **single** zero, since that path used the
minimum and so collapsed for any zero at all; a no-zeros response provably
unchanged; the all-zero error; and `response_link_scale()` silent on an all-zero
response.

## Verified

| | FAIL | WARN | SKIP | PASS |
|---|---|---|---|---|
| #139 branch below this one | 0 | 11 | 0 | 1470 |
| this branch | 0 | 11 | 0 | **1504** |

+34, exactly the new assertions; warnings unchanged.
