### PR TITLE
Accept a dispersion prior, and fill an incomplete prior set (#207)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bayesnec
 Title: A Bayesian No-Effect- Concentration (NEC) Algorithm
-Version: 2.1.3.10
+Version: 2.1.3.11
 Authors@R: c(person("Rebecca", "Fisher", email = "r.fisher@aims.gov.au", role = c("aut", "cre"),comment = c(ORCID = "0000-0001-5148-6731")), person("Diego R.","Barneche",role="aut",comment = c(ORCID = "0000-0002-4568-2362")), person("Gerard F.","Ricardo",role="aut",comment = c(ORCID = "0000-0002-2220-3971")), person("David R.","Fox",role="aut",comment = c(ORCID = "0000-0002-3178-7243")))
 Description: Implementation of No-Effect-Concentration estimation that uses 'brms' (see Burkner (2017)<doi:10.18637/jss.v080.i01>; Burkner (2018)<doi:10.32614/RJ-2018-017>; Carpenter 'et al.' (2017)<doi:10.18637/jss.v076.i01> to fit concentration(dose)-response data using Bayesian methods for the purpose of estimating 'ECx' values, but more particularly 'NEC' (see Fox (2010)<doi:10.1016/j.ecoenv.2009.09.012>), 'NSEC' (see Fisher and Fox (2023)<doi:10.1002/etc.5610>), and 'N(S)EC (see Fisher et al. 2023<doi:10.1002/ieam.4809>). A full description of this package can be found in Fisher 'et al.' (2024)<doi:10.18637/jss.v110.i05>. This package expands and supersedes an original version implemented in 'R2jags' (see Su and Yajima (2020)<https://CRAN.R-project.org/package=R2jags>; Fisher et al. (2020)<doi:10.5281/ZENODO.3966864>).
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,29 @@
 # bayesnec 2.1.4
 
+- `bnec()` now accepts a prior on the family's own dispersion parameter —
+  `sigma`, `shape` or `phi`. Supplying one previously failed in the
+  initial-value search, because it compared the prior's parameter names against
+  the *curve's* arguments as an exact set, so any row naming something the mean
+  curve does not have killed the call. There is now no way to regularise
+  dispersion where the data are sparse and the `brms` default is too vague, and
+  `get_priors()` could not report it either, so a fit's prior set was a complete
+  record of everything except dispersion. No initial value is generated for it:
+  Stan random-initialises any parameter absent from an init list. See #207.
+
+- A prior set that is missing parameters the model needs is now filled from the
+  `bayesnec` defaults, with a warning naming each one, instead of being accepted
+  as though it were complete. Previously the unmentioned parameters fell through
+  to `brms`, which means a **flat** prior — the opposite of what `bayesnec` is
+  for, since it generates weakly informative priors precisely because flat ones
+  are rarely useful in non-linear modelling. The case this bit hardest is the
+  one `define_disp_prior()` exists to prevent: drop the `c0` and slope rows a
+  route B `disp()` term adds and the fit ran on flat priors for parameters its
+  own documentation calls "near-perfectly confounded", with nothing to say so.
+  Editing a returned prior set and handing it back is exactly the workflow
+  `get_priors()` invites, so this was easy to hit. **This changes results**: a
+  fit that previously ran on flat priors for the parameters it did not mention
+  will now run on `bayesnec` priors and give different numbers. See #207.
+
 - `define_prior()` no longer collapses the `top` and `bot` priors when a large
   share of the response is exactly zero. The gamma rates for those parameters
   are set from quantiles of the response, and those quantiles are zero once

--- a/R/get_priors.R
+++ b/R/get_priors.R
@@ -223,7 +223,15 @@ usable_prior <- function(prior) {
   if (is.null(prior) || nrow(prior) == 0) {
     return(prior)
   }
-  keep <- prior$source == "user" & prior$class == "b" & prior$coef == ""
+  # class "b" is the curve's own coefficients and the parameters a route B
+  # disp() term adds. The dispersion classes are kept too, so that a prior the
+  # user supplied on sigma/shape/phi round trips and get_priors() is a complete
+  # record of the fit rather than a record of everything except dispersion.
+  # `source == "user"` is what makes that safe: a dispersion prior brms chose
+  # for itself is still dropped, because reporting it would suggest bayesnec had
+  # made a choice it did not make. See #207.
+  keep <- prior$source == "user" & prior$coef == "" &
+    (prior$class == "b" | prior$class %in% dispersion_classes())
   out <- prior[keep, , drop = FALSE]
   for (bound in c("lb", "ub")) {
     if (bound %in% names(out)) {
@@ -232,4 +240,21 @@ usable_prior <- function(prior) {
   }
   rownames(out) <- NULL
   out
+}
+
+#' Classes brms uses for a family's own dispersion parameter
+#'
+#' The parameter that is not part of the mean curve but describes the spread
+#' around it: \code{sigma} for gaussian, \code{shape} for Gamma, negbinomial
+#' and their hurdle/zero-inflated forms, \code{phi} for Beta and beta_binomial.
+#' Poisson, binomial and bernoulli have none. \code{zi} and \code{hu} are
+#' deliberately absent: bayesnec models those as a second parameter block, so a
+#' prior on them carries class "b" with a prefixed \code{nlpar}, not a class of
+#' their own.
+#'
+#' @return A \code{\link[base]{character}} vector.
+#'
+#' @noRd
+dispersion_classes <- function() {
+  c("sigma", "shape", "phi")
 }

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -771,19 +771,20 @@ add_brm_defaults <- function(
   if (!("warmup" %in% names(brm_args))) {
     brm_args$warmup <- floor(brm_args$iter / 5) * 4
   }
+  default_priors <- define_prior(
+    model,
+    family,
+    predictor,
+    response,
+    prior_type = prior_type,
+    model_survival = model_survival,
+    disp_spec = disp_spec
+  )
   priors <- try(validate_priors(brm_args$prior, model), silent = TRUE)
   if (inherits(priors, "try-error")) {
-    brm_args$prior <- define_prior(
-      model,
-      family,
-      predictor,
-      response,
-      prior_type = prior_type,
-      model_survival = model_survival,
-      disp_spec = disp_spec
-    )
+    brm_args$prior <- default_priors
   } else {
-    brm_args$prior <- priors
+    brm_args$prior <- fill_missing_priors(priors, default_priors, model)
   }
   if (!("init" %in% names(brm_args)) || skip_check) {
     msg_tag <- family$family
@@ -1095,4 +1096,67 @@ newdata_eval_fitted <- function(
 #' @export
 step <- function(x) {
   as.numeric(x > 0)
+}
+
+#' Fill a user-supplied prior set from the bayesnec defaults
+#'
+#' \code{validate_priors()} checks that a supplied prior is a
+#' \code{brmsprior} for the right model, and nothing more, so a set that is
+#' merely *incomplete* was used as though it were complete. Every parameter the
+#' user did not mention then fell through to \pkg{brms}, which means a flat
+#' prior.
+#'
+#' That is the opposite of what bayesnec is for. The package generates weakly
+#' informative priors deliberately, because flat priors are rarely useful in
+#' non-linear modelling, and the case this bites hardest is the one
+#' \code{define_disp_prior()} exists to prevent: drop the \code{c0} and slope
+#' rows a route B \code{disp()} term adds and the fit runs on flat priors for
+#' parameters its own documentation describes as "near-perfectly confounded".
+#' Nothing warned.
+#'
+#' Editing a returned prior set and handing it back is exactly the workflow
+#' \code{\link{get_priors}} invites, so this is easy to hit rather than
+#' exotic.
+#'
+#' Filling rather than erroring is the deliberate choice: an error would refuse
+#' the user's partial set and produce no fit at all, where filling gives them
+#' the model they asked for with the priors bayesnec would have chosen anyway.
+#' The warning names every parameter filled, so the result is never silent.
+#' See #207.
+#'
+#' @param priors A \code{\link[brms]{brmsprior}} supplied by the user.
+#' @param defaults A \code{\link[brms]{brmsprior}} from
+#' \code{define_prior()}.
+#' @param model A \code{\link[base]{character}} string naming the model.
+#'
+#' @return An object of class \code{\link[brms]{brmsprior}}.
+#'
+#' @noRd
+fill_missing_priors <- function(priors, defaults, model) {
+  if (is.null(defaults) || nrow(defaults) == 0) {
+    return(priors)
+  }
+  # Identity is class + nlpar + dpar. coef is not part of it: bayesnec's
+  # generated priors never set it, and a user row that does is a
+  # coefficient-level prior sitting alongside the parameter-level one rather
+  # than replacing it.
+  key <- function(p) paste(p$class, p$nlpar, p$dpar, sep = "\r")
+  missing <- !key(defaults) %in% key(priors)
+  if (!any(missing)) {
+    return(priors)
+  }
+  add <- defaults[missing, , drop = FALSE]
+  named <- add$nlpar
+  named[!nzchar(named)] <- add$class[!nzchar(named)]
+  warning("The prior supplied for model ", model, " has no entry for ",
+          paste0(named, collapse = ", "),
+          ". Using the bayesnec default for ",
+          if (length(named) > 1) "those parameters" else "that parameter",
+          " rather than leaving ",
+          if (length(named) > 1) "them" else "it",
+          " on a flat prior; see ?get_priors to inspect the full set.",
+          call. = FALSE)
+  out <- rbind(priors, add)
+  rownames(out) <- NULL
+  out
 }

--- a/R/inits_functions.R
+++ b/R/inits_functions.R
@@ -48,6 +48,18 @@ make_inits <- function(model, fct_args, priors, chains) {
             uniform = runif)
   priors <- blank_bounds_to_na(as.data.frame(priors))
   priors <- priors[priors$prior != "", ]
+  # Only the curve's own coefficients are the business of the initial-value
+  # search. A prior on the family's dispersion parameter -- sigma, shape, phi --
+  # carries class "sigma"/"shape"/"phi" rather than "b", describes no part of
+  # the mean curve, and previously made the name check below fail outright, so a
+  # user simply could not supply one. Dropping it here is the same move
+  # add_brm_defaults() already makes for the parameters a disp() variance
+  # function introduces, and it has the second effect the fix needs: no initial
+  # value is generated for the dispersion parameter, which is correct. Stan
+  # random-initialises any parameter absent from an init list, and bayesnec has
+  # never given sigma an init, so nothing downstream needs teaching. The prior
+  # itself still reaches brm(); only the init search ignores it. See #207.
+  priors <- priors[priors$class == "b", ]
   par_names <- character(length = nrow(priors))
   for (j in seq_along(par_names)) {
     sep <- ifelse(priors$class[j] == "b", "_", "")

--- a/notes/implementation/04_stack_run.md
+++ b/notes/implementation/04_stack_run.md
@@ -173,3 +173,14 @@ Wake on the long side and let CI and the test suite run between wakes.
 **Do not start an item you cannot finish** in the remaining budget — better to
 end a wake having logged the state cleanly than to leave a half-built branch
 load-bearing for the next one.
+
+## Operational note: do not nest background launches
+
+Launching a long job with `nohup ... &` from *inside* an already-backgrounded
+task does not work — when the outer task's shell exits, the inner job is reaped
+with it. This cost one wake cycle on #207: a chained "wait for the fit, then
+start the suite" command reported success, but the suite never ran and left no
+log.
+
+Launch long jobs **directly**, one per tool call, and use a separate
+`until`-loop task to wait on them. Waiting and launching are two calls, not one.

--- a/notes/implementation/05_run_log.md
+++ b/notes/implementation/05_run_log.md
@@ -143,3 +143,39 @@ instead of the incidental wording.
 timing-dependent test, and CI runners are slower and more variable than this
 machine. A red check on a test unrelated to the item in hand should be checked
 against the pass/fail arithmetic before it is assumed to be the item's fault.
+
+## Item 4 — #207, dispersion priors and incomplete prior sets
+
+Branch `issue-207-dispersion-priors`, cut from `issue-210-define-prior-zeros`.
+Tier **2.1.4**. Version 2.1.3.10 -> 2.1.3.11.
+**PR: https://github.com/open-AIMS/bayesnec/pull/223**.
+
+Both parts done. Full suite **1526 pass / 0 fail / 11 warn**, +22 on the branch
+below.
+
+**A correction to the issue's premise, recorded on the issue itself.** RF read
+part 2 as saying `disp()` loses automatic prior building. It does not — checked
+on `dev`, `get_priors()` on a `disp("power")` formula returns proper `c0` and
+`c1` priors. The loss happens only when the user supplies an *incomplete* set,
+which `validate_priors()` accepted wholesale. RF's stated principle then decides
+the open question directly: warn and fill from bayesnec defaults, not error.
+
+**Flagged for review: this changes results.** A fit that previously ran on flat
+priors for unmentioned parameters now runs on bayesnec priors. Own NEWS
+paragraph.
+
+**Process slip worth recording.** A `git add -A` swept the whole #207 change set
+into a commit whose message was about the run notes. Caught on push (`nothing to
+commit, working tree clean` with the wrong commit at HEAD), split with
+`reset --soft` and force-pushed with `--force-with-lease`. Stage deliberately
+when two unrelated changes are in the tree at once.
+
+---
+
+# 2.1.4 TIER COMPLETE
+
+#216 (merged), #215 (PR 220), #139 (PR 221), #210 (PR 222), #207 (PR 223).
+All green at the time of writing except 223, which is still in CI.
+
+Next: the 2.2.0 tier. The first PR of it opens the `# bayesnec 2.2.0` heading in
+NEWS.md.

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -107,3 +107,69 @@ test_that("pull_draw_index prefers the stored index over rebuilding it", {
   expect_identical(bayesnec:::pull_draw_index(legacy, models, 100),
                    bayesnec:::weighted_draw_index(models, 100, stats, NULL))
 })
+
+# #207 part 2: validate_priors() accepted any brmsprior wholesale, so a set
+# missing rows was used as though it were complete and the unmentioned
+# parameters fell through to brms flat priors. bayesnec generates weakly
+# informative priors on purpose, so the gaps are filled from its own defaults
+# and the user is told which.
+
+fake_prior <- function(nlpar, class = "b", prior = "normal(0, 1)") {
+  data.frame(prior = prior, class = class, coef = "", group = "", resp = "",
+             dpar = "", nlpar = nlpar, lb = NA_character_, ub = NA_character_,
+             stringsAsFactors = FALSE)
+}
+
+test_that("fill_missing_priors fills gaps and names them", {
+  defaults <- do.call(rbind, lapply(c("top", "beta", "bot", "nec", "c0", "c1"),
+                                    fake_prior))
+  supplied <- defaults[!defaults$nlpar %in% c("c0", "c1"), ]
+  expect_warning(
+    out <- bayesnec:::fill_missing_priors(supplied, defaults, "nec4param"),
+    "no entry for c0, c1"
+  )
+  expect_setequal(out$nlpar, defaults$nlpar)
+  # the user's own rows must survive untouched
+  expect_identical(out[out$nlpar == "top", "prior"],
+                   supplied[supplied$nlpar == "top", "prior"])
+})
+
+test_that("a complete prior is returned unchanged and without a warning", {
+  defaults <- do.call(rbind, lapply(c("top", "beta", "bot", "nec"), fake_prior))
+  supplied <- defaults
+  supplied$prior <- "normal(9, 9)"
+  expect_silent(out <- bayesnec:::fill_missing_priors(supplied, defaults,
+                                                      "nec4param"))
+  expect_identical(out, supplied)
+})
+
+test_that("a user value overrides the default rather than being duplicated", {
+  # The whole point of supplying a prior. Matching is on class + nlpar + dpar,
+  # so a row the user set must replace the default, not sit beside it.
+  defaults <- do.call(rbind, lapply(c("top", "beta"), fake_prior))
+  supplied <- fake_prior("top", prior = "normal(100, 1)")
+  expect_warning(out <- bayesnec:::fill_missing_priors(supplied, defaults,
+                                                       "nec4param"),
+                 "no entry for beta")
+  expect_equal(sum(out$nlpar == "top"), 1)
+  expect_identical(out$prior[out$nlpar == "top"], "normal(100, 1)")
+})
+
+test_that("a dispersion row is not confused with a curve parameter", {
+  # class is part of the key, so a sigma row and a curve row with an empty
+  # nlpar must not collide.
+  defaults <- rbind(fake_prior("top"), fake_prior("", class = "sigma"))
+  supplied <- fake_prior("top")
+  expect_warning(out <- bayesnec:::fill_missing_priors(supplied, defaults,
+                                                       "nec4param"),
+                 "no entry for sigma")
+  expect_equal(nrow(out), 2)
+})
+
+test_that("empty defaults are a no-op", {
+  supplied <- fake_prior("top")
+  expect_silent(out <- bayesnec:::fill_missing_priors(supplied,
+                                                      supplied[0, ],
+                                                      "nec4param"))
+  expect_identical(out, supplied)
+})

--- a/tests/testthat/test-inits_functions.R
+++ b/tests/testthat/test-inits_functions.R
@@ -223,3 +223,50 @@ test_that("check_models drops fractional-power models for negative predictors", 
   # ... while models valid for negative predictors are retained.
   expect_true(all(c("nec3param", "ecxexp") %in% kept))
 })
+
+# #207 part 1: a prior on the family's own dispersion parameter -- sigma, shape,
+# phi -- used to kill make_inits() outright, because the name check compared the
+# prior's parameter names against the *curve's* arguments as an exact set. A
+# user therefore could not regularise dispersion at all.
+
+disp_prior_df <- function(class = "sigma") {
+  data.frame(prior = c("normal(1,1)", "normal(0,5)", "normal(0.5,1)",
+                       "gamma(5,2)", "student_t(3,0,2.5)"),
+             class = c(rep("b", 4), class), coef = "", group = "",
+             resp = "", dpar = "",
+             nlpar = c("top", "beta", "bot", "nec", ""),
+             lb = "", ub = "", stringsAsFactors = FALSE)
+}
+
+test_that("make_inits accepts a prior on the dispersion parameter", {
+  fct_args <- c("b_top", "b_beta", "b_bot", "b_nec")
+  for (cl in c("sigma", "shape", "phi")) {
+    out <- bayesnec:::make_inits("nec4param", fct_args,
+                                 priors = disp_prior_df(cl), chains = 2)
+    expect_length(out, 2)
+    expect_setequal(names(out[[1]]), fct_args)
+  }
+})
+
+test_that("no initial value is generated for the dispersion parameter", {
+  # Deliberate: Stan random-initialises any parameter absent from an init list,
+  # and bayesnec has never given sigma an init. The prior still reaches brm();
+  # only the init search ignores it.
+  out <- bayesnec:::make_inits("nec4param",
+                               c("b_top", "b_beta", "b_bot", "b_nec"),
+                               priors = disp_prior_df(), chains = 2)
+  expect_false(any(grepl("sigma", names(out[[1]]))))
+  expect_length(out[[1]], 4)
+})
+
+test_that("a prior naming a parameter the curve does not have still errors", {
+  # The name check must keep doing its job. Only dispersion classes are exempt.
+  bad <- disp_prior_df()
+  bad <- bad[bad$class == "b", ]
+  bad$nlpar[1] <- "notaparameter"
+  expect_error(
+    bayesnec:::make_inits("nec4param", c("b_top", "b_beta", "b_bot", "b_nec"),
+                          priors = bad, chains = 2),
+    "do not match expectation"
+  )
+})


### PR DESCRIPTION
**Release tier: 2.1.4** — the last item of that tier. Item 4 of the stack,
**stacked on #222** (`#210`) → #221 (`#139`) → #220 (`#215`).

Closes #207. Both defects in the issue, plus a correction to one of its
premises.

## Part 1 — a supplied dispersion prior is no longer rejected

`make_inits()` tested `identical(sort(par_names), sort(fct_args))` — exact set
equality between the prior's parameter names and the **curve's** arguments — so
any row naming `sigma`, `shape` or `phi` killed the call. There was no route to
regularise dispersion where the data are sparse and the `brms` default is too
vague, and `get_priors()` could not report it either, so a fit's prior set was a
complete record of everything except dispersion.

The prior is now filtered to the curve's own `class == "b"` rows before the
check. That is the same move `add_brm_defaults()` already makes for the
parameters a `disp()` variance function adds, so the pattern was established.
The prior still reaches `brm()` in full; only the initial-value search ignores
the dispersion row — which is correct, since Stan random-initialises any
parameter absent from an init list and `bayesnec` has never given `sigma` one.

Verified on the issue's exact reprex, and across all three dispersion classes.

## Part 2 — and a correction to the issue's premise

The issue was read as saying `disp()` loses `bayesnec`'s automatic prior
building. **It does not.** On `dev` at 9ef03b85:

```r
get_priors(y ~ crf(x, "nec4param") + disp("power"), data = nec_data,
           family = gaussian())
#>              normal(-1.515, 2)     b    c0
#>                   normal(0, 2)     b    c1
```

`define_disp_prior()` works, and every parameter the term introduces gets a
`bayesnec` prior. The priors are lost **only when the user supplies an
incomplete set**, which `validate_priors()` then accepted wholesale — so the
parameters they did not mention fell through to `brms`, which means a **flat**
prior, silently.

That is the opposite of what the package is for. Per RF's decision on the issue
— *bayesnec is proactive about weakly informative priors because flat priors are
rarely useful in non-linear modelling* — the gaps are now filled from
`bayesnec`'s own defaults, with a warning naming each one:

> The prior supplied for model nec4param has no entry for **c0, c1**. Using the
> bayesnec default for those parameters rather than leaving them on a flat
> prior; see ?get_priors to inspect the full set.

**Filling rather than erroring is the deliberate choice.** An error refuses the
user's partial set and produces no fit at all; filling gives them the model they
asked for with the priors `bayesnec` would have chosen anyway, and the warning
means it is never silent.

Verified end to end on the issue's second reprex. Before, `pull_prior(fit)` gave
`(flat) c0 default` and `(flat) c1 default`. Now:

```
normal(-1.515, 2)   b   c0   user
normal(0, 2)        b   c1   user
```

## ⚠ This changes results

A fit that previously ran on flat priors for parameters its supplied prior did
not mention will now run on `bayesnec` priors and give different numbers. That
is the intended fix, but it is not silent and it gets its own `NEWS.md`
paragraph rather than being folded into the Part 1 entry.

## Also: `usable_prior()` keeps dispersion rows

So that a supplied dispersion prior round trips and `get_priors()` becomes a
complete record of the fit. The `source == "user"` test is retained, so a
dispersion prior **brms** chose is still dropped — reporting that would suggest
`bayesnec` had made a choice it did not make.

`dispersion_classes()` is `c("sigma", "shape", "phi")`, covering every family
`bayesnec` supports. `zi` and `hu` are deliberately absent: those are modelled
as a second parameter block, so a prior on them carries class `"b"` with a
prefixed `nlpar` rather than a class of its own.

## Tests

`test-inits_functions.R` — a dispersion prior accepted across all three classes;
no init generated for it; a prior naming a parameter the curve does not have
still errors, so the name check keeps doing its job.

`test-helpers.R` — `fill_missing_priors()` fills and names the gaps; a complete
prior is returned unchanged and **silently**; a user value **overrides** the
default rather than being duplicated (matching is on class + nlpar + dpar); a
`sigma` row with an empty `nlpar` does not collide with a curve parameter; empty
defaults are a no-op.

## Verified

| | FAIL | WARN | SKIP | PASS |
|---|---|---|---|---|
| #210 branch below this one | 0 | 11 | 0 | 1504 |
| this branch | 0 | 11 | 0 | **1526** |

+22, exactly the new assertions; warnings unchanged.
