### PR TITLE
Make the precompile workflow runnable, and declare workflow permissions (#230)

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -7,6 +7,13 @@ on:
 
 name: pkgdown
 
+# github-pages-deploy-action pushes to gh-pages, which needs write access to
+# repository contents. Relying on the repository's default workflow permissions
+# leaves the deploy dependent on a setting that is read-only by default on
+# newer repositories. See #230.
+permissions:
+  contents: write
+
 jobs:
   pkgdown:
     runs-on: ubuntu-latest

--- a/.github/workflows/precompile-vignettes.yaml
+++ b/.github/workflows/precompile-vignettes.yaml
@@ -10,6 +10,13 @@
 # PR with the regenerated `.Rmd` files and figures. It deliberately does not
 # push to the branch directly: precompilation changes every number in every
 # vignette, and that is a diff someone should look at.
+#
+# `workflow_dispatch` only works once this file is on the repository's DEFAULT
+# branch (`master` here). Until then GitHub answers a dispatch with
+# "workflow not found on the default branch" and the workflow is invisible to
+# `gh workflow list`. The `push` trigger on the `precompile/*` namespace exists
+# so the job can be exercised from `dev` before it ever reaches `master` --
+# push a branch named e.g. `precompile/test` and it runs. See #230.
 on:
   workflow_dispatch:
     inputs:
@@ -19,6 +26,29 @@ on:
           Leave blank to rebuild all of them -- slow, and what #190 wants.
         required: false
         default: ''
+      dry_run:
+        description: >-
+          Skip the fitting entirely and only exercise the plumbing -- checkout,
+          dependency install, and the pull-request step. Use this to verify the
+          workflow before committing hours of compute to it.
+        type: boolean
+        required: false
+        default: false
+  push:
+    branches: ['precompile/**']
+    # The branch suffix selects what to rebuild, since a push carries no inputs:
+    #   precompile/example1        -> rebuild example1 only
+    #   precompile/example1,ex4    -> rebuild both
+    #   precompile/all             -> rebuild everything (what #190 wants)
+    #   precompile/dry-run         -> skip fitting entirely; see PRECOMPILE_DRY_RUN
+
+# create-pull-request needs both of these, and the repository setting
+# "Allow GitHub Actions to create and approve pull requests" must be on.
+# Without them the final step fails after the whole fitting run has completed,
+# which is the most expensive possible place to discover a permissions problem.
+permissions:
+  contents: write
+  pull-requests: write
 
 name: precompile vignettes
 
@@ -47,19 +77,41 @@ jobs:
           extra-packages: any::knitr, any::purrr, any::rmarkdown, local::.
           needs: check
 
-      # Compiled Stan models are the bulk of the cost and they do not change
-      # between runs unless the model code does, so key the cache on sysdata.rda
-      # and the pred equations rather than on a lockfile.
-      - name: Cache compiled Stan models
-        uses: actions/cache@v4
-        with:
-          path: ~/.cmdstan
-          key: stan-${{ runner.os }}-${{ hashFiles('R/sysdata.rda', 'R/pred_equations.R') }}
-          restore-keys: stan-${{ runner.os }}-
+      # NOT cached: compiled Stan models. brms defaults to the rstan backend and
+      # nothing in this package sets `backend = "cmdstanr"`, so models are
+      # compiled in-process and nothing is written to ~/.cmdstan -- an earlier
+      # cache step on that path stored and restored an empty directory on every
+      # run while reading as though compilation were cached. Recompilation is
+      # the bulk of the cost here and it is genuinely paid each run; that is
+      # what `timeout-minutes` below has to accommodate, and what the
+      # `vignettes` input exists to let you batch around. See #230.
 
       - name: Precompile
         run: |
+          # The restore is driven off the directory rather than a variable, and
+          # deliberately so: `shell: Rscript {0}` runs this at top level, where
+          # on.exit() registers against no frame and silently never fires (which
+          # is why the held-back files were not being restored), AND
+          # precompile.R opens with `rm(list = ls())`, which sourced at top
+          # level clears the global environment -- so any flag held in a
+          # variable across the source() call would be wiped too. See #230.
+          ref <- Sys.getenv("PRECOMPILE_REF")
+          suffix <- if (startsWith(ref, "precompile/")) {
+            sub("^precompile/", "", ref)
+          } else {
+            ""
+          }
+          dry <- identical(tolower(Sys.getenv("PRECOMPILE_DRY_RUN")), "true") ||
+            identical(suffix, "dry-run")
+
+          local({
           sel <- Sys.getenv("VIGNETTE_SELECTION")
+          # A push carries no inputs, so the branch suffix stands in for them.
+          # `all` and `dry-run` are the two suffixes that are not vignette names.
+          if (!nzchar(sel) && nzchar(suffix) &&
+                !suffix %in% c("all", "dry-run")) {
+            sel <- suffix
+          }
           if (nzchar(sel)) {
             keep <- trimws(strsplit(sel, ",")[[1]])
             cat("Rebuilding only:", paste(keep, collapse = ", "), "\n")
@@ -73,18 +125,42 @@ jobs:
               file.rename(file.path("vignettes", paste0(d, ".Rmd.orig")),
                           file.path(".precompile_held", paste0(d, ".Rmd.orig")))
             }
-            on.exit({
-              for (f in dir(".precompile_held")) {
-                file.rename(file.path(".precompile_held", f),
-                            file.path("vignettes", f))
-              }
-              unlink(".precompile_held", recursive = TRUE)
-            }, add = TRUE)
           }
-          source("vignettes/precompile.R")
+          })
+          if (dry) {
+            # Nothing is fitted. A marker file gives the pull-request step an
+            # actual diff to commit, so this exercises the whole chain --
+            # including the `permissions:` above and the repository's
+            # "Allow GitHub Actions to create and approve pull requests"
+            # setting, which is the failure that would otherwise surface only
+            # after a full run. See #230.
+            writeLines(
+              c("Dry run of the precompile workflow.",
+                paste("ref:", ref),
+                "Delete this file; it is not part of the package."),
+              "vignettes/.precompile-dry-run"
+            )
+            cat("DRY RUN -- precompile.R was not sourced.\n")
+          } else {
+            source("vignettes/precompile.R")
+          }
+          # Restored after the run, so a partial rebuild leaves the tree as it
+          # found it. Keyed on the directory existing, which survives
+          # precompile.R's rm(list = ls()).
+          if (dir.exists(".precompile_held")) {
+            for (f in dir(".precompile_held")) {
+              file.rename(file.path(".precompile_held", f),
+                          file.path("vignettes", f))
+            }
+            unlink(".precompile_held", recursive = TRUE)
+          }
         shell: Rscript {0}
         env:
           VIGNETTE_SELECTION: ${{ inputs.vignettes }}
+          # Empty on a workflow_dispatch that named no vignettes; on a push it is
+          # the branch suffix, and `all` means the same as leaving it blank.
+          PRECOMPILE_REF: ${{ github.ref_name }}
+          PRECOMPILE_DRY_RUN: ${{ inputs.dry_run }}
 
       - name: Open a PR with the rebuilt vignettes
         uses: peter-evans/create-pull-request@v6
@@ -96,6 +172,7 @@ jobs:
           add-paths: |
             vignettes/*.Rmd
             vignettes/*.png
+            vignettes/.precompile-dry-run
           body: >-
             Regenerated by the `precompile vignettes` workflow from
             `${{ github.ref_name }}`.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bayesnec
 Title: A Bayesian No-Effect- Concentration (NEC) Algorithm
-Version: 2.1.3.11
+Version: 2.1.3.14
 Authors@R: c(person("Rebecca", "Fisher", email = "r.fisher@aims.gov.au", role = c("aut", "cre"),comment = c(ORCID = "0000-0001-5148-6731")), person("Diego R.","Barneche",role="aut",comment = c(ORCID = "0000-0002-4568-2362")), person("Gerard F.","Ricardo",role="aut",comment = c(ORCID = "0000-0002-2220-3971")), person("David R.","Fox",role="aut",comment = c(ORCID = "0000-0002-3178-7243")))
 Description: Implementation of No-Effect-Concentration estimation that uses 'brms' (see Burkner (2017)<doi:10.18637/jss.v080.i01>; Burkner (2018)<doi:10.32614/RJ-2018-017>; Carpenter 'et al.' (2017)<doi:10.18637/jss.v076.i01> to fit concentration(dose)-response data using Bayesian methods for the purpose of estimating 'ECx' values, but more particularly 'NEC' (see Fox (2010)<doi:10.1016/j.ecoenv.2009.09.012>), 'NSEC' (see Fisher and Fox (2023)<doi:10.1002/etc.5610>), and 'N(S)EC (see Fisher et al. 2023<doi:10.1002/ieam.4809>). A full description of this package can be found in Fisher 'et al.' (2024)<doi:10.18637/jss.v110.i05>. This package expands and supersedes an original version implemented in 'R2jags' (see Su and Yajima (2020)<https://CRAN.R-project.org/package=R2jags>; Fisher et al. (2020)<doi:10.5281/ZENODO.3966864>).
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,22 @@
 # bayesnec 2.1.4
 
+- The vignette precompilation workflow added in 2.1.4 can now actually be run,
+  and the documentation site configuration records what `pkgdown` really does.
+  `workflow_dispatch` only takes effect once a workflow file is on the
+  repository's default branch, so the job was invisible and undispatchable while
+  it lived on `dev` alone; it now also triggers on pushes to a `precompile/**`
+  branch, which makes it exercisable before it reaches `master`. Both workflows
+  declare the `permissions` they need rather than depending on the repository
+  default. The step that rebuilds a subset of vignettes now restores the ones it
+  held back — the previous `on.exit()` never fired, because `shell: Rscript {0}`
+  runs at top level. The cache on `~/.cmdstan` was removed: `brms` uses the
+  `rstan` backend here, so nothing is ever written there and the step cached an
+  empty directory while reading as though compilation were cached. The workflow
+  also gained a dry-run mode and branch-suffix selection, so that a run which
+  will take hours can have its plumbing — permissions, checkout, and the
+  pull-request step — verified first. See #230.
+
+
 - `bnec()` now accepts a prior on the family's own dispersion parameter —
   `sigma`, `shape` or `phi`. Supplying one previously failed in the
   initial-value search, because it compared the prior's parameter names against

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -4,13 +4,25 @@ template:
   params:
     bootswatch: yeti
 
-# Development mode "auto" keys off the version in DESCRIPTION, which is exactly
-# how this repo already distinguishes the two lines: `master` carries a release
-# version (2.1.3.1) and `dev` carries a four-component development version
-# (2.1.3.7). So a build from `master` lands at the site root and a build from
-# `dev` lands at /dev/, with no branch name hard-coded anywhere and no second
-# config file to keep in sync. pkgdown also adds its own "development version"
-# banner to the dev site, which is the point of #215 -- the two must not be
-# mistakable for each other.
+# Development mode "auto" keys off the version in DESCRIPTION, but NOT in the way
+# an earlier version of this comment claimed. pkgdown:::dev_mode_auto() returns
+# "devel" for ANY version with four or more components whose first three are not
+# 0.0.0 -- the size of the fourth component is irrelevant. So:
+#
+#   dev_mode_auto("2.1.3.1")  -> "devel"    <- master today
+#   dev_mode_auto("2.1.3.12") -> "devel"    <- dev today
+#   dev_mode_auto("2.1.4")    -> "release"
+#
+# `master` is at 2.1.3.1, a four-component version, so it currently resolves to
+# devel as well and would publish into /dev/ rather than the root. This works
+# only while releases carry a THREE-component version; bayesnec has historically
+# released four-component ones (2.1.3.1 is on CRAN), and that is the
+# incompatibility. ssdtools relies on the same rule deliberately -- its main
+# branch carries 2.6.0.9002 and publishes to /dev/, with the root published on
+# release at a three-component version.
+#
+# So this is a versioning convention, not a config setting: cut releases as
+# x.y.z and the two sites separate correctly; cut one as x.y.z.n and they
+# collide again, silently. See #230.
 development:
   mode: auto


### PR DESCRIPTION
**Release tier: 2.1.4.** Phase 1 of `notes/implementation/06_review_run.md`. Branched from `dev`, independent of the 224–228 stack — touches only `.github/` and `_pkgdown.yml`.

Closes **#230**.

## The blocking defect

`precompile-vignettes.yaml` could not be run at all. `workflow_dispatch` only takes effect once the workflow file is on the repository's **default branch** (`master`); it was added by #220 to `dev` alone, so GitHub answered a dispatch with a 404 and the workflow was absent from `gh workflow list`:

```
$ gh workflow run precompile-vignettes.yaml --repo open-AIMS/bayesnec --ref dev
HTTP 404: workflow precompile-vignettes.yaml not found on the default branch
```

That matters beyond CI: #190 (the full `precompile.R` run) is a release gate, every vignette number on `dev` is stale, and this workflow is the mechanism #220 added to make that refresh possible without a local Stan toolchain.

**Resolved without touching `master`** — a `push` trigger on a `precompile/**` branch namespace, so the job can be exercised from `dev` now and becomes dispatchable in the ordinary way once it reaches `master` at release.

## The other three defects

- **No `permissions:` block on either workflow.** `peter-evans/create-pull-request` needs `contents: write` and `pull-requests: write`; `JamesIves/github-pages-deploy-action` needs `contents: write`. Both now declare them rather than depending on the repository default, which is read-only on newer repositories. (`ssdtools`, which RF pointed at as the reference setup, declares `permissions: contents: write` for the same reason.)
- **The `~/.cmdstan` cache cached nothing.** The job never installs cmdstanr and nothing in the package sets `backend = "cmdstanr"`, so `brms` uses `rstan`, which compiles in-process and writes nothing there. Removed, with a comment saying so — recompilation genuinely is paid every run, which is what `timeout-minutes` has to accommodate.
- **The `on.exit()` restore never fired.** `shell: Rscript {0}` runs at top level, where `on.exit()` registers against no frame. The held-back `.Rmd.orig` files were not being restored.

  The obvious fix — wrap in `local()` and keep a flag — does not work either, because `precompile.R` opens with `rm(list = ls())`, which sourced at top level clears the global environment and takes the flag with it. The restore is therefore keyed on `dir.exists(".precompile_held")`, which survives it. Verified end to end:

  ```
  held back: example7
  during run,     vignettes/ = example1.Rmd.orig example4.Rmd.orig
  after restore,  vignettes/ = example1.Rmd.orig example4.Rmd.orig example7.Rmd.orig
  held dir removed: TRUE
  ```

## Added: a way to test this without spending hours

The expensive failure mode is a five-hour fitting run that dies at the final step on a permissions problem. So:

- **`dry_run`** (input, or the branch `precompile/dry-run`) skips the fitting entirely and writes a marker file, exercising checkout, dependency install, `permissions:`, and `create-pull-request` — including the repository's *Allow GitHub Actions to create and approve pull requests* setting, which cannot be verified from a config file.
- **Branch-suffix selection**, since a push carries no inputs: `precompile/example1` rebuilds one vignette, `precompile/example1,example4` two, `precompile/all` everything.

Resolution simulated across all seven cases:

```
precompile/example1          -> selection=example1           dry=FALSE
precompile/example1,example4 -> selection=example1,example4  dry=FALSE
precompile/all               -> selection=<all>              dry=FALSE
precompile/dry-run           -> selection=<all>              dry=TRUE
dev (input example2b)        -> selection=example2b          dry=FALSE
dev (no input)               -> selection=<all>              dry=FALSE
dev (input dry_run=true)     -> selection=<all>              dry=TRUE
```

## `_pkgdown.yml` — comment corrected, no behaviour change

The comment stated a rule `pkgdown` does not implement. `pkgdown:::dev_mode_auto()` returns `"devel"` for **any** version with four or more components whose first three are not `0.0.0` — the size of the fourth is irrelevant:

```r
dev_mode_auto("2.1.3.1")   # master today -> "devel"
dev_mode_auto("2.1.3.12")  # dev today    -> "devel"
dev_mode_auto("2.1.4")     #              -> "release"
```

So `master`, at `2.1.3.1`, currently resolves to devel too and would publish into `/dev/` rather than the root. `ssdtools` relies on the same rule deliberately — `main` carries `2.6.0.9002` and publishes to `/dev/`, with the root published on release at a three-component version.

**This is a versioning convention, not a config setting, so it is documented rather than fixed here.** Cutting 2.1.4 as `2.1.4` makes the two sites separate correctly; cutting a future release as `2.1.4.1` would silently collide them again. **A call for RF at release time.**

## Verification

YAML parses; the trigger-resolution logic and the hold/restore logic are both simulated above. The workflow itself is exercised by pushing `precompile/dry-run` — result reported in a comment on this PR.

## Not done here

No R code is touched, so there is nothing to test with `devtools::test()`. `vignettes/precompile.R` itself is unchanged.