### PR TITLE
Build the guarded prior strings only for the families that use them (#229)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bayesnec
 Title: A Bayesian No-Effect- Concentration (NEC) Algorithm
-Version: 2.1.3.11
+Version: 2.1.3.12
 Authors@R: c(person("Rebecca", "Fisher", email = "r.fisher@aims.gov.au", role = c("aut", "cre"),comment = c(ORCID = "0000-0001-5148-6731")), person("Diego R.","Barneche",role="aut",comment = c(ORCID = "0000-0002-4568-2362")), person("Gerard F.","Ricardo",role="aut",comment = c(ORCID = "0000-0002-2220-3971")), person("David R.","Fox",role="aut",comment = c(ORCID = "0000-0002-3178-7243")))
 Description: Implementation of No-Effect-Concentration estimation that uses 'brms' (see Burkner (2017)<doi:10.18637/jss.v080.i01>; Burkner (2018)<doi:10.32614/RJ-2018-017>; Carpenter 'et al.' (2017)<doi:10.18637/jss.v076.i01> to fit concentration(dose)-response data using Bayesian methods for the purpose of estimating 'ECx' values, but more particularly 'NEC' (see Fox (2010)<doi:10.1016/j.ecoenv.2009.09.012>), 'NSEC' (see Fisher and Fox (2023)<doi:10.1002/etc.5610>), and 'N(S)EC (see Fisher et al. 2023<doi:10.1002/ieam.4809>). A full description of this package can be found in Fisher 'et al.' (2024)<doi:10.18637/jss.v110.i05>. This package expands and supersedes an original version implemented in 'R2jags' (see Su and Yajima (2020)<https://CRAN.R-project.org/package=R2jags>; Fisher et al. (2020)<doi:10.5281/ZENODO.3966864>).
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # bayesnec 2.1.4
 
+- The guard added for #210 is no longer evaluated for families whose priors do
+  not use it. The gamma-scaled `top` and `bot` prior strings are read only by
+  `Gamma`, `poisson` and `negbinomial`; every other family builds those priors
+  from `quantile()` and `sd()` directly, or from literals. Building the guarded
+  strings unconditionally made a "response contains no positive values" error
+  reachable for `gaussian`, where an entirely negative response — log ratios,
+  growth increments, anything expressed as a change — is ordinary input and
+  previously produced perfectly good priors. Related, `bnec()` no longer builds
+  the default priors when the user has supplied a complete set of their own, so
+  a failure while building a default the fit will not use can no longer block
+  it. See #229.
+
+
 - `bnec()` now accepts a prior on the family's own dispersion parameter —
   `sigma`, `shape` or `phi`. Supplying one previously failed in the
   initial-value search, because it compared the prior's parameter names against

--- a/R/define_prior.R
+++ b/R/define_prior.R
@@ -115,14 +115,26 @@ define_prior <- function(model, family, predictor, response,
   #    models, sits at the upper end of the response range.
   # Only the response-scaled (top/bot) priors differ between the two sets; the
   # predictor-scaled and fixed priors below are shared.
+  # Only these three families read u_t_g / u_b_g out of the tables below; every
+  # other entry is a literal or is built from quantile()/sd() directly, and is
+  # well defined on a response that is entirely negative or entirely zero. So
+  # the gamma-scaled strings are built only when they will be used. Building
+  # them unconditionally made positive_scale()'s "no positive values" error --
+  # and the unguarded min(response[response > 0]) beside it -- reachable for
+  # gaussian, where an all-negative response (log ratios, growth increments,
+  # anything expressed as a change) is ordinary input. See #229.
+  gamma_scaled <- fam_tag %in% c("Gamma", "poisson", "negbinomial")
   if (prior_type == "uninformative") {
-    u_t_g <- paste0("gamma(2, ",
-                    1 / (positive_scale(response, probs = 0.75) / 2),
-                    ")")
-    u_b_g <- paste0("gamma(2, ",
-                    1 / ((positive_scale(response, probs = 0.25) +
-                      min(response[response > 0]) / 100) / 2),
-                    ")")
+    u_t_g <- u_b_g <- NA_character_
+    if (gamma_scaled) {
+      u_t_g <- paste0("gamma(2, ",
+                      1 / (positive_scale(response, probs = 0.75) / 2),
+                      ")")
+      u_b_g <- paste0("gamma(2, ",
+                      1 / ((positive_scale(response, probs = 0.25) +
+                        min(response[response > 0]) / 100) / 2),
+                      ")")
+    }
     y_t_prs <- c(Gamma = u_t_g,
                  poisson = u_t_g,
                  negbinomial = u_t_g,
@@ -144,17 +156,21 @@ define_prior <- function(model, family, predictor, response,
                  "beta_binomial" = "beta(2, 5)",
                  beta = "beta(2, 5)")
   } else {
-    u_t_g <- paste0("gamma(5, ",
-                    5 / (positive_scale(response, probs = 1)),
-                    ")")
-    # probs = 0 is the minimum, which is zero for a response containing a single
-    # zero -- not merely for a mostly-zero one. So under "regularizing" the
-    # collapse was unconditional on the zero fraction, where under
-    # "uninformative" it needed a quarter of the response to be zero.
-    u_b_g <- paste0("gamma(5, ",
-                    5 / ((positive_scale(response, probs = 0) +
-                      min(response[response > 0]) / 10)),
-                    ")")
+    u_t_g <- u_b_g <- NA_character_
+    if (gamma_scaled) {
+      u_t_g <- paste0("gamma(5, ",
+                      5 / (positive_scale(response, probs = 1)),
+                      ")")
+      # probs = 0 is the minimum, which is zero for a response containing a
+      # single zero -- not merely for a mostly-zero one. So under
+      # "regularizing" the collapse was unconditional on the zero fraction,
+      # where under "uninformative" it needed a quarter of the response to be
+      # zero.
+      u_b_g <- paste0("gamma(5, ",
+                      5 / ((positive_scale(response, probs = 0) +
+                        min(response[response > 0]) / 10)),
+                      ")")
+    }
     y_t_prs <- c(Gamma = u_t_g,
                  poisson = u_t_g,
                  negbinomial = u_t_g,

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -771,20 +771,37 @@ add_brm_defaults <- function(
   if (!("warmup" %in% names(brm_args))) {
     brm_args$warmup <- floor(brm_args$iter / 5) * 4
   }
-  default_priors <- define_prior(
-    model,
-    family,
-    predictor,
-    response,
-    prior_type = prior_type,
-    model_survival = model_survival,
-    disp_spec = disp_spec
-  )
+  build_defaults <- function() {
+    define_prior(
+      model,
+      family,
+      predictor,
+      response,
+      prior_type = prior_type,
+      model_survival = model_survival,
+      disp_spec = disp_spec
+    )
+  }
   priors <- try(validate_priors(brm_args$prior, model), silent = TRUE)
   if (inherits(priors, "try-error")) {
-    brm_args$prior <- default_priors
+    # No usable prior from the user, so the defaults are the fit. If they cannot
+    # be built the error is the right outcome and is allowed to propagate.
+    brm_args$prior <- build_defaults()
   } else {
-    brm_args$prior <- fill_missing_priors(priors, default_priors, model)
+    # Built here rather than up front so a user who supplied their own complete
+    # set is never blocked by a default they will not use: #207 made this call
+    # unconditional, which turned any failure inside define_prior() into a hard
+    # stop even when there was a perfectly good user prior to fall back on.
+    # Where the defaults cannot be built there is nothing to fill from, and the
+    # user's set is used as supplied -- silently, because without the defaults
+    # there is no way to tell whether it is incomplete, and warning on every
+    # such fit would be noise the user cannot act on. See #229.
+    default_priors <- try(build_defaults(), silent = TRUE)
+    brm_args$prior <- if (inherits(default_priors, "try-error")) {
+      priors
+    } else {
+      fill_missing_priors(priors, default_priors, model)
+    }
   }
   if (!("init" %in% names(brm_args)) || skip_check) {
     msg_tag <- family$family

--- a/tests/testthat/test-define_prior.R
+++ b/tests/testthat/test-define_prior.R
@@ -224,3 +224,79 @@ test_that("response_link_scale does not warn on an all-zero response", {
                                    validate_family("zero_inflated_poisson"))
   )
 })
+
+# #229: the #210 guard was evaluated for every family, not only the ones whose
+# priors use it, so a response with no positive values errored even where the
+# family's own top/bot priors are perfectly well defined on it.
+
+test_that("a gaussian response with no positive values still builds priors", {
+  # Ordinary gaussian input: log ratios, growth increments, anything expressed
+  # as a change. The gaussian entries in the prior tables come from quantile()
+  # and sd() and never read the gamma-scaled strings.
+  set.seed(1)
+  x <- as.numeric(rep(1:10, each = 5))
+  y <- -rexp(50, 1) - 0.5
+  expect_equal(sum(y > 0), 0)
+  pr <- define_prior("nec4param", validate_family("gaussian"), x, y)
+  expect_s3_class(pr, "brmsprior")
+  expect_setequal(pr$nlpar, c("beta", "top", "bot", "nec"))
+  expect_true(all(grepl("^normal\\(", pr$prior[pr$nlpar %in% c("top", "bot")])))
+})
+
+test_that("the bounded families are unaffected by zeros in the response", {
+  # Their top/bot priors are literals -- beta(5, 2), beta(2, 5) -- so nothing
+  # about the response can make them unbuildable. Asserted because the eager
+  # evaluation of the gamma-scaled strings reached them too, and a proportion
+  # containing zeros is the ordinary case these families are used for.
+  #
+  # Note "Beta", not "beta": validate_family() dispatches on the brms
+  # constructor name. Not tested on an all-zero response, which no bounded
+  # family would be handed and which trips an unrelated pre-existing warning in
+  # response_link_scale() -- see the comment at R/helpers.R on min_z_val.
+  set.seed(3)
+  x <- as.numeric(rep(1:10, each = 5))
+  y <- c(rep(0, 12), runif(38, 0.05, 0.95))
+  for (fam in c("Beta", "binomial", "bernoulli", "beta_binomial")) {
+    pr <- define_prior("nec4param", validate_family(fam), x, y)
+    expect_s3_class(pr, "brmsprior")
+    expect_true(all(grepl("^beta\\(", pr$prior[pr$nlpar %in% c("top", "bot")])),
+                info = fam)
+  }
+})
+
+test_that("the count families still error when there is no scale to use", {
+  # The #210 behaviour must survive: for these three the gamma rate genuinely
+  # cannot be placed, so the informative error is still the right answer.
+  x <- as.numeric(rep(1:10, each = 5))
+  for (fam in c("poisson", "negbinomial", "zero_inflated_poisson")) {
+    expect_error(
+      define_prior("nec4param", validate_family(fam), x, rep(0, length(x))),
+      "no positive values",
+      info = fam
+    )
+  }
+})
+
+test_that("a supplied prior is not blocked by an unbuildable default", {
+  # #207 made add_brm_defaults() build the defaults unconditionally, so a
+  # failure inside define_prior() became a hard stop even for a user who had
+  # supplied a complete set of their own. An all-zero poisson response is the
+  # case that reaches it.
+  x <- as.numeric(rep(1:10, each = 5))
+  y <- rep(0, length(x))
+  up <- brms::prior_string("normal(0, 5)", nlpar = "beta") +
+    brms::prior_string("gamma(2, 0.1)", nlpar = "top", lb = 0) +
+    brms::prior_string("gamma(2, 0.5)", nlpar = "bot", lb = 0) +
+    brms::prior_string("gamma(5, 0.36)", nlpar = "nec", lb = 1, ub = 10)
+  # `init` is supplied so the initial-value search is skipped. It is not being
+  # avoided for speed: on an all-zero response no draw can put the curve inside
+  # the response range, so make_good_inits() retries until it gives up, and this
+  # test is about prior construction, not about inits.
+  out <- suppressMessages(
+    bayesnec:::add_brm_defaults(list(prior = up, init = "random"), "nec4param",
+                               validate_family("poisson"), x, y,
+                               skip_check = FALSE, custom_name = NULL)
+  )
+  expect_s3_class(out$prior, "brmsprior")
+  expect_setequal(out$prior$nlpar, c("beta", "top", "bot", "nec"))
+})


### PR DESCRIPTION
**Release tier: 2.1.4.** Phase 1 of `notes/implementation/06_review_run.md`. Branched from `dev`, independent of the 224–228 stack.

Closes **#229**. Found by the post-merge review of the 2.1.4 tier; introduced by #222 (#210) and made unavoidable by #223 (#207).

## The regression

`u_t_g` and `u_b_g` — the gamma-scaled `top`/`bot` prior strings — were built unconditionally for every family, but only `Gamma`, `poisson` and `negbinomial` ever read them out of the tables. Every other family's entries are literals (`beta(5, 2)`) or come from `quantile()`/`sd()` directly, and are well defined on a response that is entirely negative.

So `positive_scale()`'s new "no positive values" error, and the unguarded `min(response[response > 0])` beside it, became reachable for **gaussian** — where an entirely negative response (log ratios, growth increments, anything expressed as a change) is ordinary input:

```r
set.seed(1); x <- as.numeric(rep(1:10, each = 5)); y <- -rexp(50, 1) - 0.5
define_prior("nec4param", validate_family("gaussian"), x, y)
```

Before #222 this returned valid priors (with two harmless `min()` warnings):

```
                                        prior class nlpar
                                 normal(0, 5)     b  beta
 normal(-0.646912064123937, 2.22941542670029)     b   top
  normal(-2.38921489539536, 2.22941542670029)     b   bot
                  gamma(5, 0.363636363636364)     b   nec
```

After it: `Error : Cannot build priors for "top" and "bot": the response contains no positive values`.

## Why there was no workaround

#207 made `add_brm_defaults()` build the defaults **before** consulting `validate_priors()`, so the error fired even for a user who had supplied a complete, valid prior set of their own — a default the fit would never use blocking a fit it had everything else for.

## The fix

- **`R/define_prior.R`** — a `gamma_scaled` guard, so the two strings are built only when `fam_tag` is one of the three families that read them. The #210 behaviour is unchanged for those three: a `poisson` response with no positive values still errors, and that is still the right answer.
- **`R/helpers.R`** — defaults are built through `build_defaults()` on demand. Where the user supplied a usable prior and the defaults cannot be built, their set is used as supplied. That fallback is deliberately silent, and the code says why: without the defaults there is no way to tell whether their set is incomplete, so a warning would be noise they could not act on.

## Tests

Four added to `test-define_prior.R`; the file passes 92/92.

- a gaussian response with no positive values still builds priors — the regression itself;
- the bounded families are unaffected by zeros in the response;
- **the count families still error when there is no scale to use** — the #210 behaviour has to survive, and this is the test that would catch over-correction;
- a supplied prior is not blocked by an unbuildable default.

`test-get_priors.R` (38) and `test-helpers.R` (37) also pass unchanged.

## Two notes for whoever writes tests near this code

Both cost real time here and are recorded in `06_review_run.md`:

- `validate_family()` dispatches on the **brms constructor name**, so it is `"Beta"`, not `"beta"`; the latter fails with `unused argument (link = "identity")`, which does not point at the cause.
- **Do not let a test reach `make_good_inits()` on a degenerate response.** The last test here originally ran `add_brm_defaults(skip_check = FALSE)` against an all-zero poisson response and hung for 27 minutes before being killed — no draw can put the curve inside a zero-width response range, so the search retries until it gives up. It now passes `init =` to skip the search, since the test is about prior construction. It runs in 0.0s.

## Related, not fixed here

**#232** — the #210 guard fires only on an exactly-zero quantile while the collapse is continuous, so the worst case sits just below the threshold. RF has settled the approach; it is implemented in a branch stacked on this one, because it rewrites the same lines.