### PR TITLE
Take the top/bot prior scale at a quantile rescaled by the zero fraction (#232)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bayesnec
 Title: A Bayesian No-Effect- Concentration (NEC) Algorithm
-Version: 2.1.3.12
+Version: 2.1.3.13
 Authors@R: c(person("Rebecca", "Fisher", email = "r.fisher@aims.gov.au", role = c("aut", "cre"),comment = c(ORCID = "0000-0001-5148-6731")), person("Diego R.","Barneche",role="aut",comment = c(ORCID = "0000-0002-4568-2362")), person("Gerard F.","Ricardo",role="aut",comment = c(ORCID = "0000-0002-2220-3971")), person("David R.","Fox",role="aut",comment = c(ORCID = "0000-0002-3178-7243")))
 Description: Implementation of No-Effect-Concentration estimation that uses 'brms' (see Burkner (2017)<doi:10.18637/jss.v080.i01>; Burkner (2018)<doi:10.32614/RJ-2018-017>; Carpenter 'et al.' (2017)<doi:10.18637/jss.v076.i01> to fit concentration(dose)-response data using Bayesian methods for the purpose of estimating 'ECx' values, but more particularly 'NEC' (see Fox (2010)<doi:10.1016/j.ecoenv.2009.09.012>), 'NSEC' (see Fisher and Fox (2023)<doi:10.1002/etc.5610>), and 'N(S)EC (see Fisher et al. 2023<doi:10.1002/ieam.4809>). A full description of this package can be found in Fisher 'et al.' (2024)<doi:10.18637/jss.v110.i05>. This package expands and supersedes an original version implemented in 'R2jags' (see Su and Yajima (2020)<https://CRAN.R-project.org/package=R2jags>; Fisher et al. (2020)<doi:10.5281/ZENODO.3966864>).
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 # bayesnec 2.1.4
 
+- The `top` and `bot` prior scales for `Gamma`, `poisson` and `negbinomial` are
+  now taken at a quantile rescaled by the zero fraction of the response, rather
+  than at the raw quantile with a fallback that triggered only once that
+  quantile hit exactly zero. A quantile of a zero-inflated response is a
+  quantile of the *mixture* and is pulled towards zero throughout its range, so
+  the previous guard left the worst case — just below the point where it fired —
+  entirely unguarded: on a `nec4param` response with a true `top` of 40, the
+  `top` prior mean ran 33.5 at no zeros, 6.8 at 72% zeros, then jumped back to
+  29.0 at 76%. It now holds between 28 and 35 across that whole range. **This
+  changes priors, and therefore results, for existing fits**: `poisson` and
+  `negbinomial` are long-released families, and a count response with a material
+  share of zeros reaches this code. A response containing no zeros is
+  unaffected, exactly — the rescaling reduces to the identity there. See #232.
+
+
 - The guard added for #210 is no longer evaluated for families whose priors do
   not use it. The gamma-scaled `top` and `bot` prior strings are read only by
   `Gamma`, `poisson` and `negbinomial`; every other family builds those priors

--- a/R/define_prior.R
+++ b/R/define_prior.R
@@ -1,26 +1,45 @@
-#' Quantile of a response, guarded against exact zeros
+#' Quantile of a response on the scale of its positive part
 #'
 #' The gamma priors for "top" and "bot" set their rate from a quantile of the
-#' response. Where a large share of the response is exactly zero those
-#' quantiles are zero, and the rate either collapses onto a fudge term or
-#' divides by zero outright -- \code{gamma(2, Inf)}. That is not a rare corner:
-#' the zero-inflated count families added under #104 exist precisely for
+#' response. Where a share of the response is exactly zero those quantiles are
+#' pulled down towards zero, and the prior collapses onto a scale that has
+#' nothing to do with the asymptote it is meant to locate. That is not a rare
+#' corner: the zero-inflated count families added under #104 exist precisely for
 #' responses where a quarter or more of the values are zero.
 #'
-#' The guard falls back to the same quantile of the \emph{positive} part of the
-#' response. That keeps the prior on the scale of the data actually carrying
-#' signal about the asymptotes, which is the quantity these priors are trying to
-#' locate, rather than on the scale of a structural-zero process that says
-#' nothing about them.
+#' \strong{Why the probability is rescaled rather than the vector.} A quantile
+#' of a zero-inflated response is a quantile of the \emph{mixture}, and it is
+#' biased downward by the zero fraction throughout its range -- reaching exactly
+#' zero only at the extreme. So testing for an exactly-zero quantile and
+#' substituting the positive part, as the first version of this guard did, is a
+#' step function applied to a continuous problem: it left the worst case, just
+#' below the threshold, entirely unguarded. On a `nec4param` response with a true
+#' `top` of 40 the `top` prior mean ran 33.5 at no zeros, 6.8 at 72\% zeros, and
+#' then jumped back to 29.0 at 76\% once the raw quantile finally hit zero.
+#'
+#' Level \code{p} of the distribution conditional on being positive sits at level
+#' \code{z + (1 - z)p} of the mixture, where \code{z} is the zero fraction: a
+#' share \code{z} of the mass has to be passed before any positive value is
+#' reached. Equivalently \code{1 - (1 - p)(1 - z)}. That is the quantile taken
+#' here. It reduces to the raw quantile exactly when \code{z} is zero, so a
+#' response with no zeros is untouched, and it degrades smoothly rather than in a
+#' jump.
+#'
+#' Note the multiplication. The dividing form \code{1 - (1 - p) / (1 - z)} moves
+#' the level the wrong way -- it returns 0.5 where the answer is 0.875 at
+#' \code{p = 0.75, z = 0.5} -- and goes negative past 75\% zeros, which is the
+#' regime this exists for.
 #'
 #' Deliberately not the same trick as \code{define_hurdle_prior()}, which
 #' computes the whole mu-block prior from the non-zero subset. That is exact for
 #' \code{hurdle_gamma}, because a Gamma has no mass at zero, so the non-zero
-#' subset *is* the mu process. Under zero-inflation it is not: the base
+#' subset \emph{is} the mu process. Under zero-inflation it is not: the base
 #' distribution emits zeros of its own, so conditioning on the positives draws
 #' from a truncated count distribution and biases the location upward. Here the
-#' positive part is used only to recover a *scale* when the raw quantile has
-#' collapsed, never as the estimate itself. See #210.
+#' positive part informs only a \emph{scale}, never the estimate itself.
+#'
+#' See #210 for the original three failure modes and #232 for why the guard
+#' became a rescaling.
 #'
 #' @param response A \code{\link[base]{numeric}} vector.
 #' @param probs A \code{\link[base]{numeric}} vector of length 1.
@@ -31,25 +50,27 @@
 #'
 #' @noRd
 positive_scale <- function(response, probs) {
-  q <- unname(quantile(response, probs = probs))
-  if (is.finite(q) && q > 0) {
-    return(q)
-  }
-  pos <- response[response > 0 & is.finite(response)]
+  finite <- response[is.finite(response)]
+  pos <- finite[finite > 0]
   if (!length(pos)) {
     stop("Cannot build priors for \"top\" and \"bot\": the response contains no",
          " positive values, so there is no scale to place them on. Check the",
          " response variable, and see ?bnec for the families bayesnec supports.",
          call. = FALSE)
   }
-  q_pos <- unname(quantile(pos, probs = probs))
-  # quantile(pos, 0) is min(pos), which is positive by construction, so this
-  # cannot itself return zero. The guard is kept anyway because probs is
-  # supplied by the caller and a future table could pass something else.
-  if (!is.finite(q_pos) || q_pos <= 0) {
+  zero_frac <- sum(finite <= 0) / length(finite)
+  # z == 0 leaves probs untouched, so a response with no zeros gets exactly the
+  # quantile it got before this guard existed.
+  probs_adj <- 1 - (1 - probs) * (1 - zero_frac)
+  q <- unname(quantile(finite, probs = probs_adj))
+  # The rescaled level can still land on a zero: at probs = 0 it stays at 0, and
+  # ties across the boundary can put it there too. min(pos) is the smallest
+  # scale the data actually supports, and is what the caller's fudge terms are
+  # already built around.
+  if (!is.finite(q) || q <= 0) {
     return(min(pos))
   }
-  q_pos
+  q
 }
 
 #' define_prior

--- a/tests/testthat/test-define_prior.R
+++ b/tests/testthat/test-define_prior.R
@@ -300,3 +300,74 @@ test_that("a supplied prior is not blocked by an unbuildable default", {
   expect_s3_class(out$prior, "brmsprior")
   expect_setequal(out$prior$nlpar, c("beta", "top", "bot", "nec"))
 })
+
+# #232: the #210 guard fired only on an exactly-zero quantile, while the
+# collapse it fixes is continuous. These tests constrain the prior to be on the
+# scale of the data across the whole zero-fraction range, which is what the
+# #210 tests above do not do -- they assert only that the rate is finite and
+# positive, and pass just as well on a prior centred at a sixth of the truth.
+
+test_that("the top prior stays on the scale of the data at every zero fraction", {
+  x <- as.numeric(rep(1:10, each = 15))
+  mu <- 40 * exp(-0.35 * pmax(x - 2, 0)) + 5   # true top 40, true bot 5
+  fam <- validate_family("zero_inflated_poisson")
+  gamma_rate <- function(prior_df, par) {
+    s <- prior_df$prior[prior_df$nlpar == par]
+    as.numeric(sub("^gamma\\([^,]+,\\s*([^)]+)\\)$", "\\1", s))
+  }
+  for (p in c(1, 0.5, 0.35, 0.3, 0.28, 0.25, 0.2)) {
+    set.seed(1)
+    y <- as.numeric(rpois(length(x), mu) * rbinom(length(x), 1, p))
+    pr <- define_prior("nec4param", fam, x, y)
+    top_mean <- 2 / gamma_rate(pr, "top")
+    # Within a factor of three of the true upper asymptote, both ways. Before
+    # #232 the worst case -- just under 75% zeros, where the guard did not fire
+    # -- was 6.8 against a true 40, which is outside this by a wide margin.
+    expect_gt(top_mean, 40 / 3)
+    expect_lt(top_mean, 40 * 3)
+  }
+})
+
+test_that("a response with no zeros gets exactly the unrescaled quantile", {
+  # The rescaling must be invisible when there is nothing to rescale for:
+  # zero_frac = 0 makes 1 - (1 - p)(1 - 0) equal to p identically.
+  set.seed(7)
+  y <- as.numeric(rpois(50, 20)) + 1
+  expect_equal(sum(y == 0), 0)
+  for (p in c(0, 0.25, 0.5, 0.75, 1)) {
+    expect_identical(bayesnec:::positive_scale(y, p),
+                     unname(quantile(y, p)),
+                     info = paste("probs =", p))
+  }
+})
+
+test_that("the rescaled level is the conditional quantile, not its inverse", {
+  # Pins the algebra. The dividing form 1 - (1 - p)/(1 - z) moves the level the
+  # wrong way and goes negative past 75% zeros; the multiplying form recovers
+  # the quantile of the positive part.
+  y <- c(rep(0, 50), 1:50)
+  expect_equal(mean(y == 0), 0.5)
+  # 75th percentile of the positive part
+  target <- unname(quantile(y[y > 0], 0.75))
+  expect_equal(bayesnec:::positive_scale(y, 0.75), target, tolerance = 0.01)
+  # and it is nowhere near what the dividing form would have given
+  expect_gt(bayesnec:::positive_scale(y, 0.75), 30)
+})
+
+test_that("the rescaling degrades smoothly rather than in a jump", {
+  # The specific defect: the old guard was a step function, so the prior was at
+  # its worst immediately below the threshold and recovered discontinuously
+  # above it. Asserted as monotone-ish stability rather than a pinned value.
+  x <- as.numeric(rep(1:10, each = 15))
+  mu <- 40 * exp(-0.35 * pmax(x - 2, 0)) + 5
+  scales <- vapply(c(0.5, 0.4, 0.35, 0.3, 0.28, 0.26, 0.24, 0.2), function(p) {
+    set.seed(1)
+    y <- as.numeric(rpois(length(x), mu) * rbinom(length(x), 1, p))
+    bayesnec:::positive_scale(y, 0.75)
+  }, numeric(1))
+  # no adjacent pair differs by more than a factor of two; the old guard's
+  # threshold crossing was a factor of four in one step (6.75 -> 29)
+  expect_true(all(scales > 0))
+  ratios <- scales[-1] / scales[-length(scales)]
+  expect_true(all(ratios > 0.5 & ratios < 2))
+})


### PR DESCRIPTION
**Release tier: 2.1.4.** Phase 1 of `notes/implementation/06_review_run.md`. **Stacked on #235** (#229), because it rewrites the same function.

Closes **#232**. Approach chosen by RF, 2026-08-22.

## The defect

#210's guard tested for an *exactly zero* quantile and substituted the same quantile of the positive part. But a quantile of a zero-inflated response is a quantile of the **mixture**, and it is pulled towards zero throughout its range — reaching exactly zero only at the extreme. So the guard was a step function applied to a continuous problem, and it left the worst case, immediately below the threshold, entirely unguarded.

Same setup as the issue: `nec4param`, `zero_inflated_poisson`, true `top` = 40, prior mean = `2 / rate`.

| zero frac | 0.00 | 0.24 | 0.54 | 0.60 | 0.67 | 0.71 | **0.72** | **0.76** | 0.87 |
|---|---|---|---|---|---|---|---|---|---|
| raw q75 | 33.5 | 27.8 | 14.8 | 11.0 | 9.0 | 7.0 | **6.8** | **0.0** | 0.0 |
| **before** | 33.5 | 27.8 | 14.8 | 11.0 | 9.0 | 7.0 | **6.8** | **29.0** | 28.3 |
| **after** | 33.5 | 35.0 | 28.9 | 29.1 | 28.8 | 29.0 | **29.0** | **29.0** | 28.0 |

At 72% zeros the prior was centred at roughly a sixth of the true upper asymptote, then recovered discontinuously by a factor of four one step later.

## The fix

Level `p` of the distribution conditional on being positive sits at level `z + (1 - z)p` of the mixture — a share `z` of the mass has to be passed before any positive value is reached. Equivalently `1 - (1 - p)(1 - z)`. That is the level the quantile is now taken at.

Two properties that matter:

- **It reduces to the identity when `z` is zero**, so a response with no zeros is untouched. Verified with `identical()` at `probs` of 0, 0.25, 0.5, 0.75 and 1 — not `expect_equal`, since the claim is exactness.
- **It degrades smoothly.** No adjacent pair in the sweep above differs by more than a factor of two; the old threshold crossing was a factor of four in one step.

### A correction to the formula as proposed

The issue's comment proposed `1 - (1 - probs) / (1 - zero_frac)`. That inverts an operator: it moves the level the *wrong way*, and goes negative past 75% zeros — the regime this exists for. On a vector that is 50% zeros with positives `1:50`, where the target `quantile(positives, 0.75)` is 37.75:

| | rescaled level | quantile recovered |
|---|---|---|
| `1-(1-p)/(1-z)` | 0.500 | **0.5** |
| `1-(1-p)*(1-z)` | 0.875 | **37.6** |

Recorded on the issue at the time. Correcting algebra to match a stated intent is implementation rather than a modelling decision, so it was self-resolved under the phase rule — but it is a change from what was written, so it is called out here for override.

## ⚠️ This changes results for existing fits

Flagged in its own `NEWS.md` sentence rather than folded into the entry. **`poisson` and `negbinomial` are long-released families** — `origin/master:R/define_prior.R:40-52` — and any count response with a material share of zeros reaches this code. It is *not* confined to the zero-inflated families added in 2.1.4.

A response containing **no** zeros is unaffected exactly, so the blast radius is "count fits with zeros", not "all count fits".

## Tests

Four added; `test-define_prior.R` passes **117/117**, `test-get_priors.R` 38, `test-helpers.R` 37.

Deliberately of a different kind from #210's, which assert only that the rate is finite and positive — **those pass just as well on a prior centred at a sixth of the truth**, which is why this defect survived them. The new ones constrain the prior to be on the scale of the data across the whole zero-fraction sweep, pin the algebra directly against the conditional quantile, and assert smoothness as a bound on adjacent ratios.

## Note on `zero_frac`

Computed as `sum(finite <= 0) / length(finite)`, not `== 0`. Only `Gamma`, `poisson` and `negbinomial` reach this function after #229, and all three are non-negative by construction, so the two are equivalent in practice — `<= 0` is defensive, since a negative value in a count response is invalid input rather than a scale worth trusting.