### PR TITLE
Report and round trip a zi prior for the zero-inflated count families (#231)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bayesnec
 Title: A Bayesian No-Effect- Concentration (NEC) Algorithm
-Version: 2.1.3.11
+Version: 2.1.3.15
 Authors@R: c(person("Rebecca", "Fisher", email = "r.fisher@aims.gov.au", role = c("aut", "cre"),comment = c(ORCID = "0000-0001-5148-6731")), person("Diego R.","Barneche",role="aut",comment = c(ORCID = "0000-0002-4568-2362")), person("Gerard F.","Ricardo",role="aut",comment = c(ORCID = "0000-0002-2220-3971")), person("David R.","Fox",role="aut",comment = c(ORCID = "0000-0002-3178-7243")))
 Description: Implementation of No-Effect-Concentration estimation that uses 'brms' (see Burkner (2017)<doi:10.18637/jss.v080.i01>; Burkner (2018)<doi:10.32614/RJ-2018-017>; Carpenter 'et al.' (2017)<doi:10.18637/jss.v076.i01> to fit concentration(dose)-response data using Bayesian methods for the purpose of estimating 'ECx' values, but more particularly 'NEC' (see Fox (2010)<doi:10.1016/j.ecoenv.2009.09.012>), 'NSEC' (see Fisher and Fox (2023)<doi:10.1002/etc.5610>), and 'N(S)EC (see Fisher et al. 2023<doi:10.1002/ieam.4809>). A full description of this package can be found in Fisher 'et al.' (2024)<doi:10.18637/jss.v110.i05>. This package expands and supersedes an original version implemented in 'R2jags' (see Su and Yajima (2020)<https://CRAN.R-project.org/package=R2jags>; Fisher et al. (2020)<doi:10.5281/ZENODO.3966864>).
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # bayesnec 2.1.4
 
+- `get_priors()` now reports and round trips a prior on `zi` or `hu` for the
+  families where those are ordinary `brms` parameters. For
+  `zero_inflated_poisson` and `zero_inflated_negbinomial`, which `bayesnec` fits
+  as a single parameter block, `zi` carries a class of its own and sat on the
+  `brms` default `beta(1, 1)` with nothing in the reported prior set to say so —
+  the same gap that 2.1.4 closed for `sigma`, `shape` and `phi`, and arguably a
+  more important one, since for those two families `zi` is the zero-inflation
+  probability the family exists to estimate. `hurdle_gamma` and
+  `zero_inflated_beta` are unaffected: their second block is carried as class
+  `"b"` with a prefixed `nlpar`, so no class-`zi` row is ever generated. See
+  #231.
+
+
 - `bnec()` now accepts a prior on the family's own dispersion parameter —
   `sigma`, `shape` or `phi`. Supplying one previously failed in the
   initial-value search, because it compared the prior's parameter names against

--- a/R/get_priors.R
+++ b/R/get_priors.R
@@ -224,14 +224,14 @@ usable_prior <- function(prior) {
     return(prior)
   }
   # class "b" is the curve's own coefficients and the parameters a route B
-  # disp() term adds. The dispersion classes are kept too, so that a prior the
-  # user supplied on sigma/shape/phi round trips and get_priors() is a complete
-  # record of the fit rather than a record of everything except dispersion.
-  # `source == "user"` is what makes that safe: a dispersion prior brms chose
-  # for itself is still dropped, because reporting it would suggest bayesnec had
-  # made a choice it did not make. See #207.
+  # disp() term adds. The parameter classes are kept too, so that a prior the
+  # user supplied on sigma/shape/phi/zi/hu round trips and get_priors() is a
+  # complete record of the fit rather than a record of everything except those.
+  # `source == "user"` is what makes that safe: a prior brms chose for itself is
+  # still dropped, because reporting it would suggest bayesnec had made a choice
+  # it did not make. See #207 and #231.
   keep <- prior$source == "user" & prior$coef == "" &
-    (prior$class == "b" | prior$class %in% dispersion_classes())
+    (prior$class == "b" | prior$class %in% auxiliary_classes())
   out <- prior[keep, , drop = FALSE]
   for (bound in c("lb", "ub")) {
     if (bound %in% names(out)) {
@@ -242,19 +242,36 @@ usable_prior <- function(prior) {
   out
 }
 
-#' Classes brms uses for a family's own dispersion parameter
+#' Classes brms uses for a family parameter that is not part of the mean curve
 #'
-#' The parameter that is not part of the mean curve but describes the spread
-#' around it: \code{sigma} for gaussian, \code{shape} for Gamma, negbinomial
-#' and their hurdle/zero-inflated forms, \code{phi} for Beta and beta_binomial.
-#' Poisson, binomial and bernoulli have none. \code{zi} and \code{hu} are
-#' deliberately absent: bayesnec models those as a second parameter block, so a
-#' prior on them carries class "b" with a prefixed \code{nlpar}, not a class of
-#' their own.
+#' Two kinds, kept together because \code{usable_prior()} treats them the same
+#' way -- a user may set a prior on either, and neither takes an initial value
+#' from the curve's own search.
+#'
+#' \emph{Dispersion}: the spread around the mean. \code{sigma} for gaussian,
+#' \code{shape} for Gamma, negbinomial and their hurdle/zero-inflated forms,
+#' \code{phi} for Beta and beta_binomial. Poisson, binomial and bernoulli have
+#' none.
+#'
+#' \emph{Mixing}: \code{zi} and \code{hu}, the probability of the second
+#' component. These are here only for the families bayesnec fits as a
+#' \emph{single} block -- \code{zero_inflated_poisson} and
+#' \code{zero_inflated_negbinomial}, added under #104 -- where brms carries the
+#' parameter with a class of its own and a default \code{beta(1, 1)}. For
+#' \code{hurdle_gamma} and \code{zero_inflated_beta}, which bayesnec fits as
+#' two parameter blocks, the second block's priors carry class "b" with a
+#' prefixed \code{nlpar} and no class-\code{zi} row is ever generated, so
+#' including these names is a no-op there rather than a conflict.
+#'
+#' Reporting \code{zi} matters more than it might look: for the two count
+#' families it is the zero-inflation probability, which is the quantity those
+#' families exist to estimate. Leaving it out of \code{\link{get_priors}} made
+#' the returned set silently incomplete in exactly the case the user cares
+#' about. See #231.
 #'
 #' @return A \code{\link[base]{character}} vector.
 #'
 #' @noRd
-dispersion_classes <- function() {
-  c("sigma", "shape", "phi")
+auxiliary_classes <- function() {
+  c("sigma", "shape", "phi", "zi", "hu")
 }

--- a/R/inits_functions.R
+++ b/R/inits_functions.R
@@ -49,16 +49,20 @@ make_inits <- function(model, fct_args, priors, chains) {
   priors <- blank_bounds_to_na(as.data.frame(priors))
   priors <- priors[priors$prior != "", ]
   # Only the curve's own coefficients are the business of the initial-value
-  # search. A prior on the family's dispersion parameter -- sigma, shape, phi --
-  # carries class "sigma"/"shape"/"phi" rather than "b", describes no part of
-  # the mean curve, and previously made the name check below fail outright, so a
-  # user simply could not supply one. Dropping it here is the same move
-  # add_brm_defaults() already makes for the parameters a disp() variance
-  # function introduces, and it has the second effect the fix needs: no initial
-  # value is generated for the dispersion parameter, which is correct. Stan
-  # random-initialises any parameter absent from an init list, and bayesnec has
-  # never given sigma an init, so nothing downstream needs teaching. The prior
-  # itself still reaches brm(); only the init search ignores it. See #207.
+  # search. Any prior carrying a class other than "b" describes no part of the
+  # mean curve -- the family's dispersion parameter (sigma, shape, phi), the
+  # mixing probability of a single-block zero-inflated family (zi, hu), a
+  # group-level standard deviation (sd) -- and previously made the name check
+  # below fail outright, so a user simply could not supply one. Note the filter
+  # is general, not a list of dispersion classes: anything that is not "b" is
+  # out, which is the correct rule and needs no maintenance as families are
+  # added. Dropping them here is the same move add_brm_defaults() already makes
+  # for the parameters a disp() variance function introduces, and it has the
+  # second effect the fix needs: no initial value is generated for them, which
+  # is correct. Stan random-initialises any parameter absent from an init list,
+  # and bayesnec has never given sigma an init, so nothing downstream needs
+  # teaching. The priors themselves still reach brm(); only the init search
+  # ignores them. See #207 and #231.
   priors <- priors[priors$class == "b", ]
   par_names <- character(length = nrow(priors))
   for (j in seq_along(par_names)) {

--- a/tests/testthat/test-get_priors.R
+++ b/tests/testthat/test-get_priors.R
@@ -197,3 +197,66 @@ test_that("a user prior makes the two entry points disagree", {
                           family = gaussian())
   expect_false(identical(sort(got$prior), sort(generated$prior)))
 })
+
+# #231: `zi` is a genuine class-"zi" brms parameter for the zero-inflated COUNT
+# families, which bayesnec fits as a single block -- unlike hurdle_gamma and
+# zero_inflated_beta, whose second block carries class "b" with a prefixed
+# nlpar. usable_prior() dropped it, so get_priors() reported a set that was
+# silently incomplete for the one parameter those families exist to estimate.
+
+test_that("a user prior on zi round trips for a zero-inflated count family", {
+  set.seed(1)
+  x <- as.numeric(rep(1:10, each = 5))
+  y <- as.numeric(rpois(50, 20) * rbinom(50, 1, 0.6))
+  gp <- get_priors(y ~ crf(x, "nec4param"), data = data.frame(x = x, y = y),
+                   family = "zero_inflated_poisson")
+  with_zi <- gp + brms::prior_string("beta(2, 5)", class = "zi")
+  out <- bayesnec:::usable_prior(with_zi)
+  expect_true("zi" %in% out$class)
+  expect_identical(out$prior[out$class == "zi"], "beta(2, 5)")
+  # the curve's own rows are untouched
+  expect_setequal(out$nlpar[out$class == "b"], c("beta", "top", "bot", "nec"))
+})
+
+test_that("a brms default on zi is still dropped", {
+  # source == "user" is what keeps this safe: reporting a prior brms chose for
+  # itself would suggest bayesnec had made a choice it did not make.
+  pr <- data.frame(prior = c("normal(0, 5)", "beta(1, 1)"),
+                   class = c("b", "zi"), coef = "", group = "", resp = "",
+                   dpar = "", nlpar = c("beta", ""), lb = NA_character_,
+                   ub = NA_character_, source = c("user", "default"),
+                   stringsAsFactors = FALSE)
+  out <- bayesnec:::usable_prior(pr)
+  expect_false("zi" %in% out$class)
+})
+
+test_that("a zi prior does not disturb the initial-value search", {
+  # make_inits() filters to class "b", so the zi row reaches brm() but plays no
+  # part in the init search and gets no initial value -- Stan draws it.
+  set.seed(2)
+  x <- as.numeric(rep(1:10, each = 5))
+  y <- as.numeric(rpois(50, 20) * rbinom(50, 1, 0.6))
+  gp <- get_priors(y ~ crf(x, "nec4param"), data = data.frame(x = x, y = y),
+                   family = "zero_inflated_poisson")
+  with_zi <- gp + brms::prior_string("beta(2, 5)", class = "zi")
+  fct_args <- c("b_top", "b_beta", "b_bot", "b_nec")
+  out <- bayesnec:::make_inits("nec4param", fct_args, with_zi, chains = 2)
+  expect_length(out, 2)
+  expect_setequal(names(out[[1]]), fct_args)
+  expect_false(any(grepl("zi", names(out[[1]]))))
+})
+
+test_that("the two-block families are unaffected", {
+  # zero_inflated_beta carries its second block as class "b" with a prefixed
+  # nlpar, so adding "zi" to the kept classes is a no-op there rather than a
+  # conflict. Asserted so the no-op claim in auxiliary_classes() is not just an
+  # assertion in a comment.
+  pr <- data.frame(prior = rep("normal(0, 5)", 3), class = "b", coef = "",
+                   group = "", resp = "", dpar = "",
+                   nlpar = c("top", "zitop", "zinec"), lb = NA_character_,
+                   ub = NA_character_, source = "user",
+                   stringsAsFactors = FALSE)
+  out <- bayesnec:::usable_prior(pr)
+  expect_equal(nrow(out), 3)
+  expect_setequal(out$nlpar, c("top", "zitop", "zinec"))
+})


### PR DESCRIPTION
**Release tier: 2.1.4.** Phase 1 of `notes/implementation/06_review_run.md`. Branched from `dev`, independent of #233, #235 and the 224–228 stack — touches only `R/get_priors.R` and a comment in `R/inits_functions.R`.

Closes **#231** (the implementation half — see *Left open*, below). Found by the post-merge review of #223 (#207).

## The gap

#207 widened `usable_prior()` to keep the family's dispersion classes so a supplied prior round trips, and its `NEWS.md` entry says the result was that "a fit's prior set was a complete record of everything except dispersion". For `zero_inflated_poisson` and `zero_inflated_negbinomial` — added in the *same* 2.1.4 tier, under #104 — it still was not.

`dispersion_classes()` justified omitting `zi` and `hu` like this:

> `zi` and `hu` are deliberately absent: bayesnec models those as a second parameter block, so a prior on them carries class "b" with a prefixed `nlpar`, not a class of their own.

**That is true for `hurdle_gamma` and `zero_inflated_beta`, and false for the two count families**, which are single-block fits. For those, `zi` is an ordinary `brms` parameter with a class of its own, on the `brms` default:

```r
brms::get_prior(bf, data = d, family = validate_family("zero_inflated_poisson"))
#>        prior class nlpar  source
#> 1 beta(1, 1)    zi        default
#> 2                b  beta default
```

So `get_priors()` reported nothing for it, and `usable_prior()` dropped a supplied one — asymmetric with `shape`, which #207 made round trip. For these families `zi` is the zero-inflation probability, which is the quantity the family exists to estimate.

## Scope: this is a reporting gap, not a rejection

Worth stating plainly, because the issue's title could suggest otherwise. #223's other half already fixed the *input* side by accident: `make_inits()` filters to `class == "b"`, which drops **every** non-`"b"` class rather than only the dispersion ones, so a supplied `zi` prior already reached `brm()` and correctly got no initial value. It simply could not be discovered or round tripped.

## The fix

- `usable_prior()` keeps `zi` and `hu` alongside `sigma`/`shape`/`phi`.
- `dispersion_classes()` → **`auxiliary_classes()`**, since it is no longer only dispersion, with roxygen distinguishing the two kinds and recording why including `zi`/`hu` is a **no-op** for the two-block families rather than a conflict — their second block carries class `"b"` with a prefixed `nlpar`, so no class-`zi` row is ever generated.
- `source == "user"` still does the work of not reporting a `brms` default as though `bayesnec` had chosen it.
- The `make_inits()` comment is corrected: it described the `class == "b"` filter as being about dispersion, when the filter is general. That generality is the right rule and needs no maintenance as families are added, but the comment claimed something narrower than the code does.

## Tests

Four added to `test-get_priors.R`. Full runs: `test-get_priors.R` **47**, `test-inits_functions.R` **260**, `test-helpers.R` **37**, `test-define_prior.R` **75** — all passing.

- a user prior on `zi` round trips for a zero-inflated count family;
- **a brms *default* on `zi` is still dropped** — the test that would catch over-widening;
- a `zi` prior does not disturb the initial-value search and gets no init;
- **the two-block families are unaffected** — asserts the no-op claim rather than leaving it as a comment.

## Left open, deliberately

Whether `bayesnec` should **generate** a weakly informative `zi` prior rather than leaving `beta(1, 1)` is a modelling decision, not an implementation one, and is escalated rather than settled here — per the phase rule in `06_review_run.md`. #207's hazard note ruled generating a default *dispersion* prior out of scope because it would change every existing fit; the same argument applies less forcefully, since these two families are new in this release and have no existing fits to change. Recorded on #231 for RF.