### PR TITLE
Correct work queue item 7, and track the #148 spec

### DIFF
--- a/notes/implementation/01_work_queue.md
+++ b/notes/implementation/01_work_queue.md
@@ -276,67 +276,90 @@ which of the two you are building and why.
 
 ---
 
-## 7. #148 — `check_fit()`, `pp_check()` methods, LOO-PIT
+## 7. #148 — `check_fit()`, `pp_check()` methods, LOO-PIT, and Part D
 
-Fully scoped across two long comments, RF's decisions settled 2026-08-21. **Read
-both comments in full before starting** — the scoping comment carries a worked
-demonstration that is the whole justification for the design.
+> **CORRECTED 2026-08-23.** The entry that stood here was wrong in four ways and
+> everything downstream inherited them — PR #226 was built to it, and the phase 2
+> review validated #226 against *this file* rather than against the issue. Read
+> **`notes/tasks/148-model-fit-diagnostics.md`** — the authoritative spec, written
+> at scoping time and referenced from the issue thread — before doing anything
+> here. It is 23 KB and covers Parts A–D, the settled decisions, the hazards and
+> a definition of done. **Neither the previous queue entry nor the phase 2 review
+> consulted it.**
+>
+> What was wrong:
+>
+> 1. **"Three parts"** — there are **four**. Part D (sampler diagnostics and
+>    screening) was folded into #148 deliberately, with a stated rationale.
+> 2. **"Decision (d) RF flagged but did not answer"** — RF answered it *in*, in
+>    the Final decisions table, and then **prototyped it** in a later comment.
+> 3. **Decision (b) was omitted entirely** — a message at the end of `bnec()`
+>    **and** a line in `summary()`, thresholding on the ratio.
+> 4. **The `example2` doc fix that rides on (b)** was not mentioned.
 
-**Settled:** part B in scope and extended to control lack-of-fit; the averaged
-check built in `ggplot2` directly with **no `bayesplot` dependency**; require
-replication but **fall back to automatic binning with a warning**; **#56 folds
-in**, LOO-PIT via `pp_check`, **no `DHARMa`**; deliver **both** a numeric test and
-a plot; the two-block families need nothing special, because `posterior_predict`
-draws the full mixture including the point mass at zero.
+**Read the spec file first.** What follows is a map of it, not a substitute.
 
-**Three parts.**
+**Four parts, not three.**
 
-- **A — `pp_check()` methods.** `pp_check(pull_brmsfit(fit))` already works; what
-  is missing is dispatch. One-line delegation for `bayesnecfit`. `brms` is in
-  `Depends`, so `importFrom(brms, pp_check)` adds no dependency.
-  `bayesnechurdlefit` returns one result per component, following `dispersion()`.
-- **B — `check_fit()`, the substance.** Per concentration group, report observed
-  against model-simulated **location and scale**, with a posterior predictive
-  p-value, and the control row flagged. Name it `check_fit()`, not
-  `check_variance()` — it reports the fit against the data, sitting alongside
-  `check_chains()` (the sampler) and `check_priors()` (the priors).
-- **C — LOO-PIT** through the part A methods; `add_criterion(fit, "loo")` is
-  something `bnec()` already does.
+- **A — `pp_check()` methods.** Dispatch for the three classes; `brms` is in
+  `Depends` so `importFrom(brms, pp_check)` adds nothing. `bayesnechurdlefit`
+  returns one result per component, following `dispersion()`.
+- **B — `check_fit()`, the substance.** Per concentration group, observed against
+  model-simulated **location and scale**, a posterior predictive p-value, control
+  row flagged. Named `check_fit()`, sitting alongside `check_chains()` (sampler)
+  and `check_priors()` (priors). **Deliver both a numeric table and a plot.**
+- **C — LOO-PIT** through the part A methods.
+- **D — sampler diagnostics and screening.** *The independent half.* D1 a
+  per-model sampler diagnostic table (Rhat, divergences, ESS); D2 the ESS
+  decision — settled as *report the absolute, threshold at 400*; D3 the screening
+  helper, `check_sampling()` plus a thin wrapper that applies thresholds and
+  **messages what it dropped and why**; D4 an `amend(drop = )` guard.
 
-**The two findings that shape it, both from the scoping comment.**
+  **Part D depends on nothing else.** It needs no `loo` and does not depend on
+  PR #217, where A and B both do — the spec says it "can be built and merged
+  first, on its own". That makes it the natural separate PR.
 
-- **A global dispersion statistic cannot see this.** On `manec_example` the global
-  Pearson ratio is 1.011 [0.71, 1.44] — a clean bill of health — while the same
-  fit binned by `x` simulates 27% more variability than the data show in the
-  control region, which is exactly the quantity `nsec` keys off. The diagnostic
-  has to be **local**.
-- **The statistic must be residual-based, not raw.** Within a bin the raw SD of
-  `y` mixes residual variability with the slope of the curve across the bin. On
-  `manec_example` the top bin's raw SD is 1.72 against a residual SD of 0.88.
-  Getting this wrong makes every steep-region bin look overdispersed.
+**The four decisions, all settled.**
 
-**Report per-candidate-model rows for a `bayesmanecfit`, not just the averaged
-row.** Stacking weights come from a global `elpd`, so a candidate can hold high
-weight while fitting the control badly — it wins on the bulk of the curve and pays
-almost nothing for the control. Without per-model rows the table cannot say which
-model is doing the damage.
+| | |
+|---|---|
+| (a) | `check_fit()` — one function covering both statistics |
+| (b) | a message at the end of `bnec()` **and** a line in `summary()` |
+| (c) | keep `dispersion()` as well |
+| (d) | **combined hurdle simulation IN** — and prototyped on the issue |
 
-**Zero fraction.** For the four mixture families, report `mean(y == 0)` against
-`mean(yrep == 0)`. Whether the zero fraction is right is the whole question those
-families exist to answer (#104), and nothing currently reports it.
+**(b)'s threshold question is also settled:** threshold on the **ratio**, with
+the `ppp` reported alongside. A `ppp` threshold stayed silent on both test fits,
+and silence reads as a pass.
 
-**One decision RF flagged but did not answer — decision (d).** Whether
-`bayesnechurdlefit` also gets a **combined** check: draw alive/dead from the
-survival fit, then a growth value per survivor, reconstructing the full observed
-response including its zeros. It is the only check of the hurdle fit *as a model
-of the data the user handed in*, rather than of its two halves separately. RF
-leaned toward including it. **Build A, B, C without it; if time remains, add it
-behind an argument and flag it in the PR for a decision.** Do not let it hold up
-the rest.
+**(d) is already written.** The issue thread carries a working six-line
+prototype and its result. The one thing to get right is `newdata = d` rather than
+the growth fit's own data — the growth component is fitted on survivors only, so
+it must be predicted onto the full exposed set for the product to line up with
+the observed response.
 
-**Vignette.** The natural home is a model-checking section, but anything added to
-`example1.Rmd.orig` will not render until #190. Author the `.Rmd.orig`, note it in
-the PR, do not run `precompile.R`.
+**A doc error rides on (b).** `vignettes/example2.Rmd.orig:102` claims the
+summary warns about divergent transitions. It does not: `print.manecsummary`
+warns on Rhat only (`R/print.R:136`), at a hard-coded 1.05, while the same
+vignette recommends 1.01. Part D makes the claim true rather than requiring it to
+be deleted.
+
+**The two findings that shape B**, both verified on `manec_example`: a global
+dispersion statistic cannot see the problem, because a free dispersion parameter
+absorbs exactly what it measures (global Pearson ratio 1.011 [0.71, 1.44] while
+the control region is badly mis-stated) — so the diagnostic must be **local**;
+and the scale statistic must be **residual-based**, since a raw within-group SD
+mixes residual variability with the slope of the curve across the group.
+
+**Per-candidate-model rows for a `bayesmanecfit`**, and the **zero fraction** for
+the four mixture families.
+
+**Vignette.** Author the `.Rmd.orig`; it does not render until #190.
+
+**Status, 2026-08-23.** PR #226 delivers A, B (numeric only), C. Outstanding:
+the **plot** half of B (added under review), **(b)** the automatic surfacing,
+**(d)** the combined hurdle check, and **all of Part D**. #219 depends on Part D
+and its dependency claim was correct.
 
 ---
 

--- a/notes/implementation/06_review_run.md
+++ b/notes/implementation/06_review_run.md
@@ -1,0 +1,471 @@
+# Review run — the pre-CRAN loop
+
+> ## START HERE — handoff, 2026-08-23
+>
+> The session that ran phases 0–3 ended here. **Read this block, then
+> `notes/tasks/148-model-fit-diagnostics.md`, before anything else.**
+>
+> ### The correction that matters most
+>
+> `01_work_queue.md` item 7 (#148) was **wrong in four ways**, and everything
+> downstream inherited it: PR #226 was built to it, and the phase 2 review
+> validated #226 against the queue rather than against the issue. Item 7 has now
+> been corrected and carries the detail. In short: there are **four** parts not
+> three (Part D exists), decision **(d) was answered *in* and prototyped**,
+> decision **(b) was omitted entirely**, and a doc fix in `example2` rides on (b).
+>
+> **The authoritative source is `notes/tasks/148-model-fit-diagnostics.md`** —
+> 23 KB, written at scoping time, referenced from the issue thread, and never
+> consulted by the queue entry or the review. **`notes/tasks/` is untracked, so
+> this file is not in git. Commit it before anything else can be trusted.**
+>
+> ### The lesson, stated plainly
+>
+> Four of the five phase 2 findings were gaps between what code did and what was
+> *claimed* about it. The review then made the same mistake at one level up:
+> it validated PRs against a summary of the requirements instead of the
+> requirements. **Check claims against sources, including claims made by these
+> notes.**
+>
+> ### Work outstanding, all confirmed in scope pre-CRAN by RF
+>
+> | what | where | note |
+> |---|---|---|
+> | (b) automatic surfacing | into PR #226 | `bnec()` message + `summary()` line, threshold on the **ratio** |
+> | (d) combined hurdle check | into PR #226 | prototype already written on the #148 thread |
+> | **Part D** (D1–D4) | **its own PR** | needs no `loo`, does not depend on #217 — the spec says build it standalone |
+> | `example2.Rmd.orig:102` doc fix | with Part D | claims summary warns on divergences; it does not |
+> | rewrite PR #238 | after Part D | currently hand-rolls the screen because Part D was thought absent |
+> | phase 4 release gate | after merges | see below |
+>
+> ### State of the PRs
+>
+> Nine open, all MERGEABLE, all reviewed. Versions pinned monotonically along
+> the merge path so merging in this order costs no conflicts:
+>
+> ```
+> dev .14 → 235 .15 → 236 .16 → 237 .17 → 224 .18 → 225 .19
+>        → 226 .20 → 227 .21 → 228 .22 → 238 .23
+> ```
+>
+> **Delete each branch as it merges** — an undeleted merged base stops GitHub
+> retargeting the PR above it, which has already bitten twice in this run.
+>
+> ### Two things that changed late
+>
+> - **The machine is free.** Load 0.29 on 22 cores; the `negative-sgr` simulation
+>   study has finished. The 2-core budget in `00_protocol.md` no longer binds and
+>   **#190 is unblocked**.
+> - **A full-suite run to characterise the `WARN 10`** was launched and did not
+>   finish before the session ended. Re-run it; ten testthat warnings on every
+>   platform should be cleared before submission.
+>
+> ### The loop
+>
+> Ran in `/loop` dynamic mode and **does not survive the session**. Restart with
+> the same prompt to resume. Worktrees `/mnt/c/Rworking/bayesnec-review` and
+> `-review2` were created by that session and can be removed with
+> `git worktree remove`.
+
+
+How a Claude Code session works through the *review* of the stack `01_work_queue.md`
+built, and the issues that review generated. Read `00_protocol.md` first — every
+working rule in it still applies unchanged, in particular the machine budget, the
+scope boundaries, and the definition of done per issue.
+
+**Written 2026-08-22, after the 2.1.4 tier merged.** That tier (#220–#223) was
+merged on manual review only; an independent review afterwards found fourteen
+issues, two of them user-visible regressions (#229, #230). This file exists so
+that does not happen again to the remaining five PRs.
+
+---
+
+## The goal
+
+`bayesnec` CRAN-ready **before** the toxval migration, in **one release**
+containing every tier. RF reviews and cuts it. Ideally the only issues left open
+afterwards are the ones toxval resolves.
+
+## The three rules that govern the loop
+
+**The loop prepares; RF merges.** Unchanged from `00_protocol.md`. The loop may
+push branches, open PRs, comment, and fix. It may not merge to `dev`. #229 came
+from a merge that outran its review — that is the failure mode this rule exists
+for.
+
+**Self-resolve implementation, escalate statistics.** RF, 2026-08-22: pure
+programming decisions the session settles itself; anything that decides what the
+*correct statistical behaviour* is gets a comment on the issue recording the
+decision and its context, and the session moves on. This is the same boundary as
+`00_protocol.md`'s "when to stop rather than guess", stated as a positive rule.
+
+**Review is independent of authoring.** A PR is reviewed in a session with no
+authoring context, and the review is posted as a PR comment **before** any code is
+touched. A session that wrote the code does not review it.
+
+---
+
+## What "not changing existing fits" does and does not cover
+
+RF, 2026-08-22: most of what is on `dev` is new work in the current development
+phase, so prior changes do not disturb released results.
+
+**True for:** `zero_inflated_poisson`, `zero_inflated_negbinomial` (new in 2.1.4,
+#104), `hurdle_poisson`, `hurdle_negbinomial` (#209), everything behind
+`bnec_group()` (#33), the `rate()` aterm (#136), `check_fit()` (#148).
+
+**Not true for:** `poisson` and `negbinomial`, which are on CRAN today and route
+through the *same* `u_t_g` / `u_b_g` code that #210 changed and #232 proposes to
+change again — checked against `origin/master:R/define_prior.R:40-52`. A plain
+`poisson` response with 30–70% zeros is a released code path, and it is the regime
+#232's table covers. Also not true for `Gamma`, `gaussian`, `beta`, `binomial`,
+`beta_binomial`, `bernoulli`, `hurdle_gamma`, `zero_inflated_beta`.
+
+Do not use the phrase as a blanket exemption. It licenses #231 and the
+zero-inflated half of #232; it does not license changing the poisson prior path
+without saying so in `NEWS.md`.
+
+---
+
+## Phase 0 — make the stack coherent
+
+Nothing else can be trusted until this is done.
+
+1. **PR 224 retargeted to `dev`** — done by RF, 2026-08-22. It targeted
+   `issue-207-dispersion-priors`, which PR 223 had merged but not deleted, so
+   GitHub had not retargeted it and merging would have landed the work on a dead
+   branch. **Check the same thing for 225–228 before touching them**; the trap
+   recurs every time a base branch merges without being deleted.
+2. Delete merged branches: `issue-215-dev-vignette-ci`,
+   `issue-139-drc-nec-equivalence`, `issue-210-define-prior-zeros`,
+   `issue-207-dispersion-priors`.
+3. Close #215, #139, #210, #207 with a line pointing at the merging PR. All four
+   merged and all four are still open, which puts four false positives into the
+   remaining-issues list phase 3 works from.
+4. Triage **#219** (complete-analysis-workflow vignette, opened 2026-08-21). It is
+   the one open issue in neither `01_work_queue.md` nor `02_deferred.md`. RF,
+   2026-08-22: **build a first draft.** Author `.Rmd.orig` only — `precompile.R`
+   is #190's, per `00_protocol.md`.
+5. ~~Restack 224→228 onto current `dev`.~~ **Deferred to the end of phase 1**
+   (2026-08-22). Checked: all five are `MERGEABLE`, and the four commits they are
+   behind are only the tier merge commits, whose content is already in their base
+   — `issue-207-dispersion-priors` is an ancestor of all five. So each PR's diff
+   against `dev` is already exactly its own work, and restacking now buys nothing.
+   Phase 1 lands four more PRs on `dev`, which would force a second restack.
+   Restack **once**, at the end of phase 1, immediately before the phase 2 review.
+   Sequencing call, self-resolved.
+
+**Done when** all five PRs target the right base and the open-issue list contains
+only genuinely open work. (Being *current* with `dev` moves to the end of phase 1.)
+
+**Phase 0 outcome, 2026-08-22.** Bases checked: 224 → `dev` (RF), and 225–228 each
+target the live branch below it, so no dead-base problem today — but the trap
+recurs every time a base merges without being deleted, so re-check before each
+merge. Four merged branches deleted. #215, #139, #210, #207 closed with pointers
+to the merging PR and to the follow-ups they generated. #219 triaged and scheduled
+as a phase-1 branch. #232's decision recorded, with a correction: the proposed
+`1 - (1 - probs) / (1 - zero_frac)` inverts an operator and must be
+`1 - (1 - probs) * (1 - zero_frac)`; as written it moves the level the wrong way
+and goes negative past 75% zeros.
+
+**One blocker found, on #230 — see the phase 1 note below.**
+
+---
+
+## Phase 1 — clear `dev` before reviewing anything against it
+
+Three small branches cut from `dev`, each its own PR. Deliberately **before** the
+stack review: #229 is a live regression in the base all five PRs build on, and
+PR 224 touches the prior derivation next door to it. Reviewing five large PRs
+against knowingly-broken code wastes the reviews.
+
+| issue | what | kind |
+|---|---|---|
+| #229 | `define_prior()` errors on responses with no positive values, for families that never use the guarded quantiles; `add_brm_defaults()` builds defaults eagerly so there is no workaround | implementation — **self-resolve** |
+| #230 | pkgdown `mode: auto` resolves `master` to devel; plus the missing `permissions:` blocks, the no-op `~/.cmdstan` cache, and the no-op top-level `on.exit()` | implementation — **self-resolve** |
+| #231 | `get_priors()` drops a `zi` prior for the ZI count families | **split**: adding `"zi"`/`"hu"` to the kept classes is implementation, self-resolve. Whether bayesnec should *generate* a `zi` prior is statistics — comment and move on |
+| #232 | the #210 zero guard is a step function on a continuous collapse | **statistics — escalate.** Three candidate approaches, and per the section above one of them changes released `poisson` behaviour. Comment on the issue with the trade-off; do not choose |
+
+**#230 is on the critical path. It is not blocked — corrected 2026-08-22.**
+
+Two mechanisms were initially run together. Separated:
+
+*Publishing the `dev` site needs nothing on `master`.* `pkgdown.yaml` on `dev`
+triggers on push to `dev` and deploys with `clean: false`. RF's counter-examples
+(`ssdtools`, `ssddata`) are right and the earlier recommendation to carry the
+pkgdown files to `master` is withdrawn.
+
+*`workflow_dispatch` genuinely requires the default branch*, confirmed by
+GitHub's own error — `HTTP 404: workflow precompile-vignettes.yaml not found on
+the default branch`. That is specific to the precompile workflow and unrelated to
+pkgdown. **Resolved without touching `master`:** give it a `push` trigger on a
+dedicated `precompile/*` branch namespace alongside `workflow_dispatch`, so it can
+be exercised from `dev` now and becomes dispatchable normally once it reaches
+`master` at release. Self-resolved; no RF decision needed.
+
+*The pkgdown `mode: auto` defect is a versioning convention, not a code change.*
+`ssdtools` carries `2.6.0.9002` on `main` with `mode: auto`, and its `/dev/` site
+is built from `main` precisely because a four-component version resolves to devel;
+the root publishes on release, at a three-component version. `mode: auto` can only
+separate the two sites if **`master` carries a three-component version**.
+`master` is at `2.1.3.1`, which is why it resolves to devel. `bayesnec` has
+historically released four-component versions, and that is the incompatibility.
+Cutting 2.1.4 as `2.1.4` fixes it and keeps it fixed while releases stay
+three-component; a `2.1.4.1` on `master` would silently undo it. **A policy call
+for RF at release time**, recorded rather than decided here.
+
+`ssdtools` also declares `permissions: contents: write`, corroborating the missing
+`permissions:` finding.
+
+`.github/` is open for #230 only — the same narrow exemption #215 had.
+
+**Done when** `dev` has no known regressions, #232 is implemented, and the
+precompile workflow has demonstrably run.
+
+### Phase 1 progress, 2026-08-22
+
+| issue | branch / PR | state |
+|---|---|---|
+| #230 | `issue-230-ci-fixes` → **PR 233** | **done and verified.** Dry run 32579445161 succeeded through every step including PR creation, which settles the permissions question empirically. Throwaway artifacts cleaned up. |
+| #229 | `issue-229-prior-scope` | code + tests written; test run in progress |
+| #231 | `issue-231-zi-prior` | code + tests written, committed locally; untested |
+| #232 | `issue-232-zero-guard-rescale` → **PR 236** (on 235) | done; 117/117 in test-define_prior.R |
+| #231 | `issue-231-zi-prior` → **PR 237** | done; get_priors 47, inits_functions 260, helpers 37 |
+| #219 | `issue-219-workflow-vignette` → **PR 238 (draft)** | drafted on PR 226; **rescoped, see below** |
+
+**Phase 1 is complete as far as an unattended session can take it.** Five PRs
+are open and none is merged, per the loop-prepares rule. **R CMD check is green
+on every platform for all four non-draft PRs** (233: 10/10, 235: 9/9, 236: 8/8,
+237: 9/9 — 236 runs eight rather than nine because pkgdown does not trigger on a
+PR whose base is not `dev` or `master`).
+
+**The restack does not belong at the end of phase 1 after all.** It was moved
+here from phase 0 on the reasoning that phase 1 would land four more PRs on
+`dev`. It does not: the loop does not merge, so `dev` is still at 9ed1bb8c and
+there is nothing new to restack onto. All five stack PRs remain `MERGEABLE` with
+correct diffs. **The restack belongs at the start of phase 2, after RF has
+merged whatever they choose to merge from phase 1** — and it should be done
+once, then, against whatever `dev` has actually become.
+
+**#232's approach is settled** (RF, 2026-08-22): rescale the probability rather
+than the vector. One correction was needed and is recorded on the issue — the
+proposed `1 - (1 - probs) / (1 - zero_frac)` inverts an operator and must be
+`1 - (1 - probs) * (1 - zero_frac)`; as written it moves the level the wrong way
+(recovering 0.5 rather than 37.75 on a 50%-zero test vector) and goes negative
+past 75% zeros. Correcting algebra to match a stated intent is implementation,
+so it is self-resolved, but flagged for override.
+
+**#219 cannot be drafted as its issue specifies.** It gates steps 3–5 on a
+"Part D of #148" that `01_work_queue.md` never scoped and PR 226 does not
+deliver — 226 is `R/check_fit.R` and `R/pp_check.R` and nothing else. Not fatal:
+`rhat()`, `check_chains()` and `amend(drop = )` are already on `dev` and cover
+steps 3 and 5; a Part D would be convenience, not capability. Two consequences,
+both recorded on #219: the draft branches from `issue-148-check-fit` rather than
+`dev`, because step 4 genuinely needs `check_fit()`; and **whether a Part D
+should exist as package API is now an open question**, not a settled dependency.
+Also carry it into PR 226's phase 2 review.
+
+### Carry into the phase 2 review
+
+**"Do the tests constrain the thing that matters, or the thing that is easy to
+assert?"** is now an explicit review question. The #210 tests asserted only that
+the prior rate was finite and positive — every row of the broken sweep, including
+the prior centred at a sixth of the true asymptote, passes them. That is why the
+defect survived review and merge. #232's tests constrain the prior to be on the
+scale of the data instead.
+
+**#226 does not deliver a "Part D"** and does not say so. Whether one is wanted
+is open — see #219.
+
+### Two test-authoring traps hit in this phase, worth not repeating
+
+- `validate_family()` dispatches on the **brms constructor name**, so it is
+  `"Beta"`, not `"beta"` — the latter errors with `unused argument
+  (link = "identity")`, which does not obviously point at the cause.
+- **Do not let a test reach `make_good_inits()` on a degenerate response.** A
+  test that called `add_brm_defaults(skip_check = FALSE)` on an all-zero poisson
+  response ran for 27 minutes before being killed: no draw can put the curve
+  inside a zero-width response range, so the search retries until it gives up.
+  Pass `init =` to skip the search when the test is about something else.
+- Related: an all-zero response is not realistic input for the bounded families
+  and trips a pre-existing `min()` warning in `response_link_scale()`. Test
+  those with a response containing zeros, not one that is entirely zeros.
+
+---
+
+## Phase 2 — review the stack, read-only
+
+### Phase 2 outcome, 2026-08-23 — complete
+
+All five reviewed, read-only, one comment each. No code was changed on any of
+them, per the phase rule.
+
+| PR | issue | verdict | finding |
+|---|---|---|---|
+| 224 | #136 | sound | `?bayesnecformula` overstates the family check — it is skipped when `make_brmsformula()` is called without a family |
+| 225 | #209 | sound; better than scoped | `?ecx`/`?nsec` still say `dpar` applies only to `hurdle_gamma`/`zero_inflated_beta`; it now applies to the count hurdles too |
+| 226 | #148 | sound | the **plot** half of part B is missing and is not declared; `skip_if(NOT_CRAN == "")` deviates from `skip_on_cran()` used by 17 other files |
+| 227 | #33 | boundary correct | **real defect** — the pseudo-BMA identity is documented but not enforced, and `loo_controls` passes through `...`, so stacking weights silently produce a wrong crossed table |
+| 228 | #6/#33 | complete | filename collision with PR 238 — resolved by renaming 238's vignette to `example9` |
+
+**Both hazard-verifications the queue asked for came out clean**, checked
+empirically rather than by reading: the `retrieve_var()`/`bnec_pop` lockstep
+holds across six formula shapes including `rate+group`, and #33's stop
+condition is not triggered — PR 227 touches none of `ecx`/`nsec`/`nec`/
+`bnec_newdata`.
+
+**The pattern worth carrying forward.** Four of the five findings are gaps
+between what the code does and what is *claimed* about it — stale docs, an
+undeclared omission, an unenforced caveat — rather than defects in the code
+itself. The single real defect (227) is of the same family: a caveat that was
+written down instead of being checked. This tier's code is careful; its
+declarations drift.
+
+**Two hypotheses were checked and retired before being reported**, recorded so
+nobody repeats the work: the `check_fit` fitting tests *do* run in CI
+(`SKIP 3 | PASS 1600` on `issue-148-check-fit`, 62 more than the branch below),
+and PR 228's `library(dplyr)` is already declared (`Imports`), so it is not an
+undeclared vignette dependency.
+
+**For phase 4:** `WARN 10` appears on every platform on every stack branch —
+pre-existing, but ten testthat warnings should be cleared before submission.
+Also note `R-CMD-check.yaml` passes `--ignore-vignettes`, so nothing in CI
+checks the vignettes; the first real check of them is #190.
+
+## Phase 2 — the original plan
+
+PRs **224 → 225 → 226 → 227 → 228**, oldest first. One review comment per PR.
+**No code is touched in this phase.**
+
+Review all five before fixing any. Fixing as you go means five rebases, five
+rounds of invalidated CI, and review comments written against a base that moved
+underneath them — and it forecloses the case where a finding on 226 changes what
+should happen to 224.
+
+Each review comment covers: correctness against the issue's stated scope, the
+hazards named in that item's `01_work_queue.md` entry (they are specific and were
+written for this purpose), test coverage of the edge cases, and whether anything
+crossed a scope boundary — `ecx()`/`nsec()`/`ecnsec()`/`zero_crossings()` above
+all.
+
+Findings are classified as they are written:
+
+- **in scope, straightforward** → fixed in phase 3 on the existing PR;
+- **out of scope, straightforward** → one new issue, with a reprex and the steps to
+  resolve. Prefer folding several small findings into one issue over opening
+  several; #230 carries three that way;
+- **statistics** → comment on the PR and on the issue, no code.
+
+**Done when** five review comments are posted and every finding is classified.
+
+---
+
+## Phase 3 — one fix pass, one restack
+
+Bottom-to-top: 224, then 225, and so on. Fix the in-scope findings on the existing
+PR, comment on the PR saying what changed, and only restack the branches above
+when a fix actually touches shared files. One restack at the end of the phase, not
+one per PR.
+
+Then reassess the issue list — #229–#232, anything phase 2 opened, and #219 — and
+work it in dependency order rather than numeric order.
+
+**Done when** every PR is either merge-ready with a review comment saying why, or
+explicitly parked with a reason.
+
+---
+
+## Phase 3 outcome, 2026-08-23 — complete
+
+All four findings fixed on their own PRs; no new issues opened, which was the
+goal of minimising them.
+
+| PR | fix | tests |
+|---|---|---|
+| 224 | `?bayesnecformula` no longer overstates the rate family check | doc only |
+| 225 | `?ecx`/`?nsec` list all four two-block families | doc only |
+| 226 | `plot.checkfit` implemented; all 11 skips normalised to `skip_on_cran()` | 48/48 |
+| 227 | **pseudo-BMA enforced** rather than documented | 30/30 |
+| 228 | restacked over the four | — |
+
+**Why 227 had to capture the method at fit time:** a `bayesmanecfit` does not
+record which weighting method produced its `wi` — its fields are `mod_fits`,
+`success_models`, `mod_stats`, `sample_size`, the `w_*` slots and `ne_type`.
+So it cannot be recovered afterwards; `bnec_group()` reads it off
+`loo_controls` and stores it, and `crossed_group_weights()` refuses anything
+else. An error, not a warning: under stacking there is no correct crossed table
+to return.
+
+### Version conflicts are structural, not accidental
+
+Every branch that targets `dev` independently and bumps `Version` will conflict
+on that line — unavoidable with parallel branches, and the reason the 224–228
+stack does not suffer it. After #233 merged, #235, #237 and #224 all conflicted
+at once. Versions are now pinned monotonically along the intended merge path:
+
+```
+dev .14 → 235 .15 → 236 .16 → 237 .17 → 224 .18 → 225 .19
+       → 226 .20 → 227 .21 → 228 .22 → 238 .23
+```
+
+Merging in that order costs no further resolves. Out of order costs one line
+each time.
+
+**Delete each branch as it merges.** `issue-230-ci-fixes` was merged and left in
+place, which is the same dead-base trap that left PR 224 targeting a deleted
+branch in phase 0. An undeleted merged base stops GitHub retargeting the PR
+above it.
+
+### Two process failures worth not repeating
+
+- **A resolved conflict was reported as fixed before it was pushed.** #235 was
+  resolved locally and left unpushed; GitHub still showed it conflicting. Verify
+  against the remote, not the working tree.
+- **A resolve script assumed its `git checkout` had succeeded.** It had not —
+  the target branch was checked out in another worktree — so the script rewrote
+  the *previous* branch's `DESCRIPTION`. Nothing was committed, but it was one
+  step from corrupting a just-fixed branch. **Work detached** when scripting
+  across branches; `--detach` cannot collide with another worktree.
+
+## Phase 4 — the release gate
+
+Not reached until RF has reviewed and merged the stack.
+
+1. `R CMD check --as-cran` clean, on the platforms the workflow covers.
+2. `NEWS.md`: the three tier headings collapsed into the single release RF is
+   cutting. **RF sets `DESCRIPTION` `Version`** — `00_protocol.md`, unchanged.
+3. **#190, the full `precompile.R` run.** **The machine is free as of
+   2026-08-23** — load average 0.29 on 22 cores, down from ~18; the simulation
+   study in `/mnt/c/Rworking/negative-sgr` has finished. The 2-core budget in
+   `00_protocol.md` no longer binds, and #190 is unblocked. Re-check `uptime`
+   before starting in case another run has begun. One release means this runs **once**, which is the saving RF's
+   answer to (a) buys.
+4. Confirm the published site: `master` at the root, `dev` under `/dev/`, per the
+   fix to #230. Verify by looking at the deployed site, not at the config.
+5. Re-read `02_deferred.md` and confirm every remaining open issue is either
+   toxval's or deliberately deferred with a reason.
+
+---
+
+## Open decision
+
+**(b) Are #33 and #6 (PRs 227, 228) in the pre-migration release?** Put to RF
+2026-08-22, not yet answered.
+
+Stage 1 is additive — `bnec_group()` and `bayesnecgroupfit` are a new entry point
+and a new class; `bnec()` and every existing class are untouched. So shipping it
+does not constrain stage 2's design much: stage 2 arrives as a formula or argument
+on `bnec()`, and `bnec_group()` stays a coherent thing to have.
+
+What remains is expectation risk — "supports factor covariates" will be read as the
+joint model unless NEWS and `?bnec_group` say *independently fitted levels* plainly
+— and the naming overlap with #6's existing `ogl()`/`pgl()`/`(par | group)`
+vocabulary, which the #6/#33 vignette has to resolve.
+
+**Recommendation: include them**, with those two obligations written into the
+review standard for PRs 227 and 228. If RF prefers not to, the cheaper alternative
+is to merge them to `dev` and cut the release from a tag below them, rather than
+leaving the PRs to drift unmerged across the whole migration.
+
+Until this is answered, phases 0–2 proceed unchanged; only the review *standard*
+for 227 and 228 depends on it, and phase 3 for those two PRs.

--- a/notes/tasks/148-model-fit-diagnostics.md
+++ b/notes/tasks/148-model-fit-diagnostics.md
@@ -1,0 +1,472 @@
+# Task — bayesnec #148: model fit diagnostics
+
+**Point a Claude Code session at this file from the `bayesnec` repo root.**
+Read `notes/implementation/00_protocol.md` first for the working rules, then
+this. Self-contained otherwise.
+
+Issue: https://github.com/open-AIMS/bayesnec/issues/148
+Absorbs: https://github.com/open-AIMS/bayesnec/issues/56 (closed 2026-08-21)
+Absorbs: the diagnostic helpers originally listed on #219 (Part D below)
+Blocks: https://github.com/open-AIMS/bayesnec/issues/219 (workflow vignette)
+
+---
+
+## The gap
+
+Every existing diagnostic is about the sampler (`check_chains()`, `rhat()`),
+the priors (`check_priors()`), or *relative* model ranking (`loo`/`waic` in
+`mod_stats`). The one exception, `dispersion()`, is restricted to Poisson and
+Binomial (`R/dispersion.R:53`), so eight of the ten supported families have no
+variance diagnostic at all.
+
+Nothing asks whether the fitted model's implied variability, or its fitted
+level at the control, matches the data. Both land on `nsec`.
+
+## Why it lands on `nsec`
+
+`nsec` sets its reference at `R/nsec.R:155`:
+
+```r
+reference <- quantile(p_samples[, 1], sig_val)
+```
+
+`p_samples` is `posterior_epred`, and with the default `x_range = NA`
+`bnec_newdata()` builds the grid as `seq(min(x_vec), max(x_vec), ...)`
+(`R/bnec_newdata.R:48`). So column 1 is the fitted curve **at `min(x)`** — the
+same rows `check_data.R:76` already calls the control. Therefore:
+
+- mis-stated control **variance** biases the reference in *spread*;
+- a curve **pulled away from the control data** biases it in *location*.
+
+The location half is the worse of the two: it is a bias in the point estimate,
+not in the interval. `ecx` is comparatively insulated — it is read relative to
+the curve's own asymptotes.
+
+D6 in `03_decisions.md` records the empirical case: on the `example1`
+simulation `nsec` moved 0.93 [0.43, 1.32] to 1.09 [0.50, 1.53] under
+`disp("power")` while `ecx` tightened. Same estimator, different variance model.
+
+## Why a global statistic cannot do it
+
+For any family with a free dispersion parameter (`gaussian`, `Gamma`,
+`negbinomial`, `Beta`, `beta_binomial`) that parameter absorbs exactly what a
+global Pearson-ratio statistic measures.
+
+Measured on the packaged `manec_example` (gaussian, `nec4param`):
+
+| | |
+|---|---|
+| global Pearson ratio | **1.011 [0.71, 1.44]** — a clean bill of health |
+
+The same fit, residual SD in six quantile bins of `x`:
+
+| bin | 0.03–0.34 | 0.34–0.61 | 0.61–0.88 | 0.88–1.36 | 1.36–1.77 | 1.77–3.22 |
+|---|---|---|---|---|---|---|
+| obs resid SD | 0.412 | 0.292 | 0.430 | 0.548 | 0.320 | 0.876 |
+| sim resid SD | 0.525 | 0.510 | 0.503 | 0.508 | 0.508 | 0.525 |
+| ratio | **0.79** | 0.57 | 0.86 | 1.08 | 0.63 | **1.67** |
+
+The constant-`sigma` model simulates a flat ~0.51. In the control region it
+simulates 27% more variability than the data show, and the global statistic
+reported 1.01. **The diagnostic has to be local.**
+
+## Two facts that shape the implementation
+
+**Statistics must be residual-based, not raw.** Within a bin the raw SD of `y`
+mixes residual variability with the slope of the curve across the bin. On
+`manec_example` the top bin's raw SD is 1.72 against a residual SD of 0.88 —
+the difference is entirely curve. Raw grouped SD flags every steep region as
+over-dispersed.
+
+**Model averaging does not protect against control misfit.** Stacking weights
+come from a global `elpd`. The control is a handful of rows out of many, so a
+candidate can hold high weight while fitting the control badly — it wins on the
+bulk of the curve and pays almost nothing for the control. The table must
+therefore report per-candidate-model rows as well as the averaged row for a
+`bayesmanecfit`.
+
+---
+
+## Scope
+
+### Part A — `pp_check()` methods
+
+`importFrom(brms, pp_check)`. `brms` is in `Depends`, so **no new dependency**.
+
+| class | behaviour |
+|---|---|
+| `bayesnecfit` | delegate to `pull_brmsfit()` |
+| `bayesmanecfit` | model-averaged `yrep`, rendered in `ggplot2` (already in `Depends`) — **not** `bayesplot`, and **not** faceted by candidate model, which never shows the object being used for inference |
+| `bayesnechurdlefit` | one result per component, following `dispersion()`'s precedent, **plus** a combined simulation (below) |
+
+Document the LOO-PIT recipe here — this is what #56 becomes.
+
+### Part B — `check_fit()`
+
+One exported generic across the three classes. A table, one row per group:
+
+| column | |
+|---|---|
+| `obs_mean`, `sim_mean`, `ratio`, `ppp` | location — does the curve go through the data here |
+| `obs_sd`, `sim_sd`, `ratio`, `ppp` | scale — is the simulated variance representative |
+| `p_zero_obs`, `p_zero_sim`, `ppp` | two-block families only |
+| `control` | flag on the `x == min(x)` row |
+
+Plus `plot`/`autoplot` methods.
+
+Generalises `dispersion()` past Poisson/Binomial as a side effect. `dispersion()`
+**stays** — it is documented in `example1` and appears in `mod_stats`. Keep the
+global Pearson statistic where it is informative (the two families with no free
+dispersion parameter) and have the docs say when each applies.
+
+### Part C
+
+Folded into A.
+
+### Part D — sampler diagnostics and screening
+
+Folded in from #219. `check_fit()` asks *does this model reproduce the data*;
+Part D asks *did this model sample properly*. Both answer the same downstream
+question — which candidates belong in the averaged set — and both feed the same
+`amend(drop = )` step and the same `summary()` block, so they are designed once.
+
+**D1. `check_sampling()`** — one data frame, one row per candidate model:
+
+| model | max_rhat | min_ess_ratio | n_divergent | failed |
+|---|---|---|---|---|
+
+Sits with `check_chains()` / `check_priors()` / `check_fit()`. `rhat()` stays
+unchanged — it is documented in `example2` and in the JSS paper.
+
+**D2. Implementation routes — both verified on `manec_example`.**
+
+- Divergences: `brms::nuts_params(x, pars = "divergent__")`, then `sum(np$Value)`.
+  Exported, backend-agnostic, **no new dependency**. Do *not* use
+  `rstan::get_num_divergent(x$fit)` as the project scripts do — `rstan` is only
+  in `Suggests`, and that route assumes the rstan backend.
+- ESS: `brms::neff_ratio()` is exported and free. Measured on `nec4param` from
+  `manec_example` (`ndraws` = 100), it is **`min(ess_bulk, ess_tail) / ndraws`**
+  in every row:
+
+  | parameter | `ess_bulk` | `ess_tail` | `neff_ratio` |
+  |---|---|---|---|
+  | `b_bot_Intercept` | 10.16 | 34.54 | 0.102 |
+  | `b_top_Intercept` | 94.78 | 75.57 | 0.756 |
+  | `b_beta_Intercept` | 13.30 | 44.04 | 0.133 |
+  | `b_nec_Intercept` | 57.97 | 32.96 | 0.330 |
+
+  The project screen instead used `posterior::summarise_draws()` to threshold on
+  **bulk** ESS specifically. That reports bulk and tail separately but adds
+  `posterior` to `Imports`. **Settled: `neff_ratio()`, multiplied back by
+  `ndraws()` to give an absolute `min_ess`** — no dependency, and since
+  `neff_ratio` is `min(bulk, tail)/ndraws`, `min_ess > 400` is exactly Vehtari's
+  "both bulk and tail exceed 100 per chain". See the settled block below.
+
+**D3. The screening helper.** Table as primitive, thin wrapper on top: apply the
+thresholds, `amend(drop = )`, and **message what was dropped and why** — that
+message is what a methods section cites, not decoration.
+
+**D4. The guard lives in the screening function, not in `amend()`.** The union
+of failure lists can name a model that was never fitted or was already dropped,
+so the wrapper does `intersect(remove_fits, names(x$mod_fits))` before calling
+`amend()`. `amend()` itself is **not** modified — its behaviour was measured and
+the case that matters is narrower than the project comment claims; see the
+verified table below.
+
+**D5. Merges with the `summary()` decision.** The settled decision to add a
+`summary()` line for the control fit check becomes **one** summary block covering
+both axes rather than two independent additions. Also the moment to deal with the
+hard-coded 1.05 in `print.manecsummary` (`R/print.R:136`) and to add divergences,
+which the summary never mentions. That in turn makes
+`vignettes/example2.Rmd.orig:102` true — it currently claims the summary warns
+about divergent transitions, and it does not.
+
+**Sequencing: Part D is the independent half.** It touches no posterior
+predictive machinery, needs no `loo`, and **does not depend on PR #217** — the
+diagnostics are per candidate model, so nothing needs a reproducible averaged
+draw. A and B both do. Build and merge D first while A and B wait on #217; that
+also gets screening into the package before #219 is written.
+
+## Settled decisions — Part D
+
+| | |
+|---|---|
+| D1 | `check_sampling()`, one data frame, one row per candidate model |
+| D2 | `brms::neff_ratio()` x `ndraws()` -> **`min_ess`** (screened) plus `min_ess_ratio` (reported). No new dependency, backend-agnostic |
+| D3a | Rhat **1.01** (aligned across `rhat()`, `summary()` and the new functions), ESS **400**, divergences **10**; every threshold an argument, those as defaults only |
+| D3b | The screen acts on sampler diagnostics only, **not** on `check_fit()` |
+| D4 | Guard lives in the screening function; **`amend()` is not touched** |
+| D5 | One `summary()` block covering sampler and fit |
+
+Signature, `*_cutoff` matching `rhat()`'s existing naming:
+
+```r
+check_sampling(x, rhat_cutoff = 1.01, ess_cutoff = 400, divergence_cutoff = 10)
+```
+
+The screening function takes the same four and passes them through.
+No open decisions remain on Part D.
+
+**Reference for 1.01.** Vehtari, A., Gelman, A., Simpson, D., Carpenter, B., &
+Bürkner, P.-C. (2021). Rank-normalization, folding, and localization: An improved
+R̂ for assessing convergence of MCMC (with discussion). *Bayesian Analysis*,
+16(2), 667–718. doi:10.1214/20-BA1221. — "at convergence, Rhat <= 1.01". Already
+the reference the project methods text cites. Add to the docs.
+
+**Divergences at 10 has no literature behind it.** Stan's guidance is that *any*
+divergence indicates the sampler failed to explore the posterior and estimates
+may be biased. 10 is pragmatic, from practice with these non-linear models, which
+routinely produce a handful near the boundary. **The docs must say that plainly**
+— it will be quoted in methods sections, and the honest version is more
+defensible than an implied citation.
+
+**The dependency rule was downgraded.** `00_protocol.md` "no new package
+dependencies" was a stop-and-ask rule for autonomous sessions, not a package or
+CRAN constraint, and should not have appeared in a definition of done. Amended
+2026-08-21. Part D needs no dependency regardless.
+
+**Backend agnosticism — the reason to avoid the obvious route.** `nuts_params()`
+and `neff_ratio()` are `brmsfit` generics and work under either backend.
+`rstan::get_num_divergent(x$fit)` reaches past `brms` into the `stanfit` slot and
+`rstan` is `Suggests`-only. Put that reasoning in a comment at the point of
+choice — `get_num_divergent()` is the obvious thing to reach for and works often
+enough to look correct.
+
+### ESS — settled: report the absolute, threshold at 400
+
+`neff_ratio()` is `min(ess_bulk, ess_tail) / ndraws`, so multiplying back gives
+the absolute with no dependency and no arithmetic left for the user:
+
+```r
+min_ess <- min(brms::neff_ratio(x)) * brms::ndraws(x)
+```
+
+That is the minimum over parameters of `min(bulk-ESS, tail-ESS)`. Vehtari
+recommends **both** bulk and tail ESS exceed 100 per chain, so `min_ess > 400` at
+four chains is exactly the recommendation.
+
+Columns: **`min_ess`** (screened on) and **`min_ess_ratio`** (reported). Both fall
+out of the same call, and the ratio separates "passed 400 because we drew 8000"
+from "passed 400 efficiently".
+
+**Document, do not let it be discovered:** at 3 chains / `thin = 3` / ~999
+retained draws, ESS 400 needs a ratio of 0.40 — demanding for these correlated
+non-linear parameterisations. Under `bayesnec` defaults (8000 draws) it is a
+ratio of 0.05 and trivially met. So the recommendation will fail some heavily
+thinned fits that the old 0.1 ratio passed. **The correct response is to retain
+more draws, not lower the cutoff** — thinning lowers ESS by construction. Say so
+in the help page, because the tempting fix is the wrong one.
+
+### Rhat 1.01 — aligned everywhere, and `summary()` does not compute Rhat
+
+`summary()` builds `rhat_issues` at `R/summary.R:146` as
+`map(x$mod_fits, "fit") |> map(has_r_hat_warnings)`, and `has_r_hat_warnings()`
+at `R/helpers.R:262` is:
+
+```r
+any(grepl("some Rhats are > 1.05", x, fixed = TRUE))
+```
+
+It greps **brms's captured warning text for a literal string**. The summary's
+threshold was never `bayesnec`'s to set, and aligning it to 1.01 means replacing
+the mechanism with a real `rhat(x, rhat_cutoff = )` call — not changing a number.
+
+Good change regardless of the threshold: `brms (>= 2.23.0)` is a floor, not a
+ceiling, so if brms rewords or retunes that warning `has_r_hat_warnings()`
+returns `FALSE` for every model, silently, and the summary stops warning.
+Verified it currently works (`manec_example`: both `TRUE`, warning fires), so
+this is latent fragility, not a live bug — but it is the failure mode where
+**silence reads as a pass**, the same argument that settled the `bnec()` message
+threshold.
+
+Touchpoints:
+
+| | |
+|---|---|
+| `R/rhat.R:41`, `R/rhat.R:62` | `rhat.bayesnecfit` / `rhat.bayesmanecfit` defaults 1.05 → 1.01 |
+| `R/bayesnechurdlefit-methods.R:470` | `rhat.bayesnechurdlefit` default, same |
+| `R/summary.R:146` | replace `has_r_hat_warnings` with a computed `rhat()` verdict |
+| `R/print.R:136` | message hard-codes "Rhats > 1.05"; report the cutoff in use |
+| `R/helpers.R:262` | `has_r_hat_warnings()` becomes unused — `summary.R` is its only caller, delete it |
+| `man/rhat.Rd`, `man/rhat.bayesnechurdlefit.Rd` | regenerate |
+| `NEWS.md` | user-facing behaviour change |
+
+Tests are low risk: `test-bayesmanec_methods.R:32-36` uses the default and
+`rhat_cutoff = 1`, and `manec_example` fails at both 1.05 and 1.01, so no
+expectation changes.
+
+### `example2` rewrite, same PR
+
+`example2.Rmd.orig:146-158` exists entirely to contrast a permissive default with
+a conservative override, and the rendered output shows it working — `rhat(exp_5)`
+all 8 `FALSE`, `rhat(exp_5, rhat_cutoff = 1.01)` gives `ecx4param TRUE`. With the
+default at 1.01 the two chunks become **identical** and the prose is wrong.
+Rewrite: default is 1.01, cite Vehtari, contrast against the looser 1.05 if a
+contrast is still wanted.
+
+Fix the same sentence while it is open: "Here we get a message because none of our
+models failed the default Rhat criterion" has it backwards — no message appears
+in the rendered output, and `rhat.bayesmanecfit` only messages when **all** models
+fail (`R/rhat.R:69-71`).
+
+**Gating:** the `.Rmd.orig` edit lands with the PR but the rendered `.Rmd` stays
+stale until the #190 precompile run, so the published vignette shows old prose
+against the new default in the interim. Call it out in the PR body.
+
+### `amend()` behaviour — verified, and it is not what the project comment claims
+
+The script comment says `amend()` "errors/warns if asked to drop models that
+don't exist". Measured:
+
+| call | result |
+|---|---|
+| `amend(manec_example, drop = "notamodel")` | two messages, **returns the fit unchanged**. No error |
+| `amend(manec_example, drop = c("nec4param", "notamodel"))` | works — drops `nec4param`, returns a `bayesnecfit` |
+| `amend(manec_example, drop = c("nec4param", "ecx4param"))` | **error** — "All models removed, nothing to return" |
+
+The mixed case, which is the common one, already works. `amend()` never errors on
+an absent name; it silently returns unchanged when *every* named model is absent
+(`handle_set()` at `R/helpers.R:154` hits `identical(sort(x), sort(tmp))` and
+returns the `"wrong_model_output"` sentinel, which `amend_model_set()` at
+`R/amend.R:222` turns into a message and the original object).
+
+So the screening wrapper owns three cases, all of which it needs anyway:
+
+1. **nothing failed** — do not call `amend()`; return unchanged, message that all
+   models passed;
+2. **some failed** — `intersect()` against `names(x$mod_fits)`, then
+   `amend(drop = )`;
+3. **all failed** — `amend()` errors; catch it and say something more useful than
+   "All models removed, nothing to return".
+
+Part D touches no existing exported function.
+
+### CRAN and fixtures
+
+Examples go in `\dontrun{}` — already the pattern in 22 of 85 `man/*.Rd`,
+`rhat()` among them. The #219 vignette is precompiled from `.Rmd.orig` and does
+not run at build or check time. **Nothing in Part D adds to CRAN check time.**
+
+Consequence: the tests carry the verification, and **a fixture that does not yet
+exist is needed**. `manec_example` exercises case 3 perfectly (both models fail at
+any cutoff) but nothing in the package exercises case 2 — a set where some models
+pass and some fail — which is the whole point of the feature. Build a small
+stored fixture.
+
+## Settled decisions
+
+| | |
+|---|---|
+| Scope | Part B is in scope; `pp_check` alone does not close the issue |
+| Averaged check | built in `ggplot2` directly; no `bayesplot` dependency |
+| Grouping | replicate levels of `x` where they exist; **automatic binning with a warning** where they do not. `check_data.R:76` already uses `length(ctl) >= 3` as its usability threshold — reuse it as the trigger |
+| #56 | closed into this issue. LOO-PIT, not `DHARMa` |
+| Output | both a numeric test and a plot |
+| Name | **`check_fit()`** — one function covering both statistics, sitting with `check_chains()` (sampler) and `check_priors()` (priors) |
+| Surfacing | a message at the end of `bnec()` **and** a line in `summary()` |
+| `dispersion()` | keep both |
+| Hurdle | include the combined simulation |
+
+## The combined hurdle simulation
+
+For `bayesnechurdlefit`, simulate the joint response — draw alive/dead from the
+survival fit, then a growth value for each survivor — reconstructing the full
+observed response including its zeros. This is the only check of the hurdle fit
+*as a model of the data the user handed in*, rather than of its two halves
+separately.
+
+Draws may be paired row-wise: the two posteriors are independent (the hurdle
+likelihood factorises, the components share no parameters), which is the same
+argument `hurdle_component_preds()` already rests on in
+`R/bayesnechurdlefit-class.R`. Truncate both to the smaller draw count, as that
+function does.
+
+**Prototyped and verified.** It is about six lines:
+
+```r
+alive <- posterior_predict(sb)                 # bernoulli, every exposed row
+grow  <- posterior_predict(gb, newdata = d)    # full data, not the survivors subset
+n     <- min(nrow(alive), nrow(grow))
+comb  <- alive[seq_len(n), ] * grow[seq_len(n), ]
+```
+
+`newdata = d` rather than the growth fit's own data is the point to get right —
+the growth component is fitted on survivors only (48 of 90 rows in the test
+case), so it must be predicted onto the full exposed set for the product to
+align with the observed response.
+
+On the test fit the result is a 400 x 90 matrix matching the observed response,
+giving: zero fraction obs 0.467 vs sim 0.483 (ppp 0.605); mean obs 1.903 vs sim
+1.747 (ppp 0.252); sd obs 2.301 vs sim 2.270 (ppp 0.44).
+
+The extrapolation concern noted in `hurdle_component_preds()` — growth is
+extrapolated past the highest concentration where anything survived — is benign
+here, as that function's comment predicts. At the top concentration the
+simulated survival probability was 0.167 against 1 survivor of 6 observed,
+i.e. exactly 0.167, so the product is carried by the survival term as intended.
+
+## Verified before writing this
+
+Checked against `brms` 2.23.0 source and a live `hurdle_gamma` fit, not assumed:
+
+- **The two-block families need no special handling.** `posterior_predict` for
+  `hurdle_gamma`, `zero_inflated_beta`, `zero_inflated_poisson` and
+  `zero_inflated_negbinomial` all draw the **full mixture including the point
+  mass at zero** (`brms:::posterior_predict_hurdle_gamma` and friends). `yrep`
+  is a draw of the response as observed. The reason `disp()` refuses these
+  families is a modelling problem — a variance function on a *component's*
+  dispersion parameter does not describe a *mixture's* dispersion — and has no
+  bearing on checking.
+- On a live `hurdle_gamma` `bnec()` fit: `pp_check`, `pp_check(type =
+  "stat_grouped", stat = "sd")` and `pp_check(type = "loo_pit_overlay")` all
+  return a ggplot. `bf$criteria` holds `loo,waic`, confirming `bnec()` already
+  attaches the criterion at `R/add_criteria.R`.
+- Zero-fraction statistic on that fit: obs 0.467, simulated 0.495, ppp 0.675.
+- Control row on that fit (n = 6): obs mean 4.50 vs sim 5.53 (ppp 0.82); obs sd
+  1.53 vs sim 2.58 (ppp 0.82). Both statistics compute cleanly on a two-block
+  family with no special-casing.
+
+## Hazards
+
+- **LOO-PIT recomputes `loo` on every call.** `brms:::pp_check.brmsfit` calls
+  `do_call(loo, c(pred_args, save_psis = TRUE))` unconditionally in the
+  `loo_pit*` path — it ignores the stored criterion, and passing
+  `save_psis = TRUE` to `add_criterion()` does not help (it does not retain a
+  `psis_object`). On a `bayesmanecfit` that is a fresh `loo` per candidate model
+  per call. **Keep LOO-PIT on demand only.** The `bnec()` end-of-fit message
+  must use the posterior-predictive statistic, which is cheap.
+- **Posterior predictive p-values are conservative** — the data are used twice,
+  so they under-detect. Document `ppp` as a flag, not a test; LOO-PIT is the
+  calibrated companion, which is a further reason to ship them together.
+- **Control power is low when control replication is low.** With n = 6 at the
+  control the `ppp` has very little power. This is the same constraint that
+  drives the binning decision, and the message should not imply more confidence
+  than the design supports.
+
+  This was measured twice, on two independently fitted parameterisations of the
+  same simulated data — a single `hurdle_gamma` `bnec()` fit and a
+  `bnec_hurdle()` pair. Both put the simulated control mean at 5.5-5.6 against
+  an observed 4.50 and a true value of 4.77, so roughly an 18% overshoot that
+  reproduces across fits and is a property of the `ecxexp` shape rather than
+  noise. Neither `ppp` came near flagging (both ~0.82). **This is the case for
+  thresholding the automatic message on the ratio rather than on the `ppp`.**
+- **Do not cache the check on the fitted object.** #180 / PR #205 went the other
+  way — `pred_vals$posterior` was removed precisely to stop caching prediction
+  matrices. Recompute in `summary()`.
+- **Depends on PR #217.** Without it the model-averaged `yrep` is redrawn on
+  every call and neither the plot nor the table is reproducible.
+- **`manec_example` cannot be used to demonstrate screening.** Both its models
+  return `failed = TRUE` at `rhat_cutoff = 1.05`, and `b_bot_Intercept` has an
+  `ess_bulk` of 10 out of 100 draws. It is a deliberately tiny stored object, so
+  this is not a bug, but a screen run on it drops everything and leaves no
+  averaged set. Part D tests and examples need a different fixture, and so does
+  #219.
+- **Vignettes are gated on #190.** Anything added to `example1.Rmd.orig` will
+  not render until the next full `precompile.R` run. Do not run it.
+
+## Definition of done
+
+Per `00_protocol.md`, plus: no new package dependency in `DESCRIPTION`
+(Part D needs none; the rule itself was downgraded to stop-and-ask on
+2026-08-21), and the
+`bnec()` message must be one line and must not fire on a fit that is fine.

--- a/notes/tasks/216-model-averaging-reproducibility.md
+++ b/notes/tasks/216-model-averaging-reproducibility.md
@@ -1,0 +1,100 @@
+# Task — bayesnec #216: model-averaged output is not reproducible
+
+**Point a Claude Code session at this file from the `bayesnec` repo root.**
+Read `notes/implementation/00_protocol.md` first for the working rules, then
+this. Self-contained otherwise.
+
+Issue: https://github.com/open-AIMS/bayesnec/issues/216
+
+---
+
+## The bug
+
+Anything going through the model-averaged posterior of a `bayesmanecfit`
+returns a different answer on every call:
+
+```r
+library(bayesnec)
+nd <- bnec_newdata(manec_example, resolution = 20)
+predict(manec_example, newdata = nd)[1, "Estimate"]   #> 2.183761
+predict(manec_example, newdata = nd)[1, "Estimate"]   #> 2.229868
+```
+
+No seed is set by the user and none internally. It propagates to `plot()`,
+`autoplot()`, `summary()`, `ecx()` and `nsec()`. Over six replicate calls the
+`nsec` lower bound spanned 0.702–0.954 while the median moved by ~0.5%: the
+instability lands almost entirely on the interval, which is the end used to set
+a protective concentration.
+
+## Cause
+
+Model averaging resamples each component's draws in proportion to its stacking
+weight, with an unseeded `sample()`, **independently at each site**:
+
+| | |
+|---|---|
+| `R/helpers.R:90` | `w_nec_calc()` — averaged no-effect posterior |
+| `R/helpers.R:105` | `w_post_pred_calc()` — averaged predicted curve |
+| `R/helpers.R:112` | `w_pred_list_calc()` |
+| `R/ecx.R:294` | `sample_ecx()` |
+| `R/nsec.R:233-234` | `sample_nsec()` — **two** separate `sample()` calls |
+
+The method is not wrong — this is `weighted_samples`, as used and recommended in
+`ssdtools`. What is wrong is that the randomness is redrawn, independently, at
+every site and on every call.
+
+## Scope
+
+**In scope — fix here:** the three sites in `R/helpers.R`. That is
+model-averaging code and it **stays** in `bayesnec`.
+
+**Out of scope — do not touch:** `R/ecx.R` and `R/nsec.R`. Those files are
+migrating to `toxval` and `sample_ecx()` / `sample_nsec()` are expected to be
+deleted rather than fixed. If the `helpers.R` fix makes their behaviour
+inconsistent, **say so in the PR** rather than editing them.
+
+## Suggested fix
+
+Draw the component index **once** and reuse it, so realisation *i* means
+"component `m[i]`, iteration `j[i]`" for every quantity:
+
+```r
+idx <- sample(seq_along(models), n, replace = TRUE, prob = weights)   # once
+```
+
+`sample_size` and `mod_stats$wi` are already stored on the `bayesmanecfit`, so
+the cleanest option is probably to **store the realised index on the object when
+it is built** — then every later call reuses it and no `seed` argument is
+needed. A user-facing `seed` would also work but leaves the default
+irreproducible.
+
+This is not a change of averaging method. Only where the randomness is drawn.
+
+## Hazards
+
+- **Numbers will change**, and there is no "before" to match — the current
+  values are not reproducible. Expect to rewrite any test that pins a
+  model-averaged estimate. Say in the PR which ones and why.
+- Two quantities that should be paired currently are not (`nsec` and its
+  `ecnsec` come from different `sample()` calls). Fixing the index fixes that
+  too. Do not present it as a separate change.
+- Check whether `predict()`, `plot()`, `autoplot()` and `summary()` all become
+  deterministic. If any is still not, that is a finding worth reporting.
+
+## Working rules for this repo
+
+- **Work in your own worktree** — `git worktree add /mnt/c/Rworking/bayesnec-216 dev`
+  — not the main checkout, which other sessions share.
+- Branch `issue-216-<slug>` off `dev`, PR `--base dev`. Never branch from
+  another issue's branch.
+- **No `air`.** `bayesnec` has no `air.toml` and formatting is forbidden.
+- **Do not touch `vignettes/example7*`** — #193 is being worked in another
+  session.
+- `devtools::document()` if roxygen changed; commit the regenerated `man/`.
+- A `NEWS.md` entry.
+
+## Done when
+
+Repeated identical calls to `predict()`, `ecx()` and `nsec()` on
+`manec_example` return identical values; a test asserts it; the full suite
+passes; `R CMD check` is clean.


### PR DESCRIPTION
Notes only — no R code, no tests, nothing that affects the package.

## Why

RF asked me to re-read the #148 thread against `01_work_queue.md` item 7. **The entry was wrong in four ways, and everything downstream inherited it**: PR #226 was built to it, and the phase 2 review validated #226 against the queue rather than against the issue.

1. **"Three parts"** — there are four. Part D (sampler diagnostics and screening) was folded into #148 deliberately, with a stated rationale.
2. **"Decision (d) RF flagged but did not answer"** — RF answered it *in*, in the Final decisions table, and prototyped it in a later comment.
3. **Decision (b) omitted entirely** — a message at the end of `bnec()` **and** a line in `summary()`, thresholding on the ratio.
4. **The `example2` doc fix that rides on (b)** was not mentioned.

## What is in here

- **`01_work_queue.md` item 7 rewritten**, carrying a correction notice, all four settled decisions, the four parts, and the note that Part D is the independent half — it needs no `loo` and does not depend on PR #217, so the spec says build it standalone.
- **`notes/tasks/` is now tracked.** `notes/tasks/148-model-fit-diagnostics.md` is the authoritative 23 KB spec, written at scoping time and referenced from the issue thread — **and it was untracked, so it was not in git**. Neither the queue entry nor the review consulted it. It is the single most useful file for whoever picks this up.
- **`06_review_run.md` gains a START HERE handoff block** — outstanding work, PR state, merge order, and the two things that changed late (the machine is free, so #190 is unblocked; a full-suite run to characterise the `WARN 10` did not finish).

## The lesson, recorded rather than glossed

Four of the five phase 2 findings were gaps between what code did and what was *claimed* about it. The review then made the same mistake one level up — validating PRs against a summary of the requirements instead of the requirements. That is now written into the handoff block.

## Outstanding, all confirmed in scope pre-CRAN by RF

| what | where |
|---|---|
| (b) automatic surfacing | into #226 |
| (d) combined hurdle check | into #226 — prototype already on the thread |
| **Part D (D1–D4)** | its own PR |
| `example2.Rmd.orig:102` doc fix | with Part D |
| rewrite #238 against Part D | after Part D |