### PR TITLE
Record the CI tidy-up, the preserved precompile run, and the example8 findings

### DIFF
--- a/notes/implementation/06_review_run.md
+++ b/notes/implementation/06_review_run.md
@@ -469,3 +469,155 @@ leaving the PRs to drift unmerged across the whole migration.
 
 Until this is answered, phases 0–2 proceed unchanged; only the review *standard*
 for 227 and 228 depends on it, and phase 3 for those two PRs.
+
+---
+
+# Phase 3b — the CI tidy-up, 2026-08-24
+
+A fresh session picked the run up here. **All seven open PRs were red, and not
+one of them was red for a reason to do with its own subject matter.** Every
+platform reported `FAIL 0`; the red X in each case was
+`Error: R CMD check found WARNINGs` from one of two roxygen slips.
+
+| cause | PRs affected | fixed on |
+|---|---|---|
+| `check_sampling.Rd` / `screen_models.Rd` link to `check_fit`, which does not exist until 226 | 240, 224, 225 | **240**, the base |
+| `@param` missing for `combined` (`check_fit`), `fit_ratio_cutoff` and `check_fit` (`summary`) | 226, 227, 228, 238 | **226** |
+
+Both were introduced by the phase 3 fixes themselves — decision (b) added two
+`summary()` arguments and decision (d) added one to
+`check_fit.bayesnechurdlefit()`, and neither carried a roxygen entry. The
+`\link{check_fit}` references are demoted to `\code{check_fit()}` at the base of
+the stack and **restored on 226**, the branch that introduces the function, so
+the documentation is correct at every point along the merge path rather than
+only at the end.
+
+**Versions were deliberately not bumped.** The pinning
+`dev .17 → 240 .18 → 224 .19 → 225 .20 → 226 .21 → 227 .22 → 228 .23 → 238 .24`
+is what makes the merge path conflict-free, and a doc fix on an open PR does not
+earn a new development version. The restack merged with zero conflicts on all
+six branches.
+
+## The `WARN 10` is one line
+
+The handoff asked for this to be characterised. All ten testthat warnings, on
+every platform on every branch, come from **`R/autoplot.R:188`** —
+`select(.data$x_e, ...)`. `.data` in a *tidyselect* expression was deprecated in
+tidyselect 1.2.0. Every other `.data$` in the package sits in a data-masking
+context (`aes()`, `filter()`, `mutate()`, `arrange()`) and is correct.
+
+Replaced with quoted names. `test-expand_classes.R` went from ten warnings to
+none. Fixed at the base of the stack so it propagates to all seven PRs.
+
+## Four issues were merged but never closed
+
+#229, #230, #231 and #232 were fixed by #235, #233, #237 and #236, all merged to
+`dev`, but the PR bodies referenced them as `(#230)` rather than with a closing
+keyword. Closed with a pointer to the merging PR.
+
+**Worth adopting:** write `Closes #n` in the PR body, not `(#n)`.
+
+## The precompile rehearsal of 2026-08-24
+
+`/mnt/c/Rworking/bayesnec-precompile` was found holding **an uncommitted,
+unpushed, detached-HEAD tree with 39 modified files** — a full precompile run
+across example1–6, 8 and 9 on an integration branch merging the 224–238 stack,
+executed 23 Aug 21:50 – 24 Aug 01:53. A stray `git checkout` there would have
+destroyed about four hours of fitting.
+
+Preserved on **`precompile-rehearsal-2026-08-24`**. It is *not* a #190 run:
+
+- **example7 is absent** — `negsgr-cens-vignette` is not merged into that tree.
+- **example8 does not execute at all** (see below).
+- It predates the R CMD check fixes above.
+- It was killed before `precompile.R` reached its figure-move step, leaving 29
+  images stranded in the repository root. That move has been completed as the
+  script would have done it.
+
+### Two findings came out of it, and neither is an artefact
+
+**1. A `Beta` response that reaches exactly zero can fail the whole candidate
+set.** The rehearsal carried an uncommitted edit to `example9.Rmd.orig` moving
+the beta example off `irgarol`, which has **eight of its twelve
+top-concentration replicates at exactly zero**, onto `simazine`, which spans
+0.16–0.71 and never touches a boundary. Zeros by herbicide:
+
+| herbicide | n | zeros | at the top concentration |
+|---|---|---|---|
+| ametryn | 96 | 12 | 7 of 12 |
+| irgarol | 72 | 10 | 8 of 12 |
+| hexazinone | 76 | 1 | 1 of 5 |
+| atrazine, diuron, simazine, tebuthiuron | — | 0 | — |
+
+The boundary handling `check_data()` applies is evidently not rescuing these
+fits, which is worth knowing before any vignette leans on `herbicide` + `Beta`.
+
+**2. That is very likely why example8's `bnec_group()` call fails.**
+`bnec_group()` fits all seven herbicides, so it takes in all three of the
+zero-carrying ones. So the example8 failure is a **data-and-family question, not
+a `bnec_group()` defect** — but that should be confirmed by fitting one clean
+level and one zero-carrying level singly before #33 is judged on it.
+
+## example8 does not execute — both halves
+
+The rendered rehearsal output shows the vignette is a sequence of errors:
+
+```
+fit_ogl <- bnec(suc | trials(tot) ~ crf(dose, "nec3param") + ogl(tank), ...)
+#> Error: Failed to fit model nec3param.
+
+fit_grp <- bnec_group(fvfm ~ crf(log(concentration), "decline"), herbicide, ...)
+#> Error in expand_manec(...): None of the models fit successfully
+```
+
+Every later chunk then cascades on `object 'fit_ogl' not found`, and the
+vignette produced **no figures at all**.
+
+The rewrite at `0eea2b55` answered the conditioning objection correctly — it
+moved Part 1 from nassarius *growth* to nassarius *survival*, so no animal is
+filtered out. But survival turns out not to be modellable either:
+
+- **There is almost no concentration-response in survival.** Contaminant A runs
+  12% dead at the control, then 0–6% dead across seven doses spanning
+  0.01–1.25, then 83% at 2.5 and 100% at 20. That is a step, not a curve — and
+  the control has *higher* mortality than the next six doses.
+- **The levels are not comparable.** The four contaminants sit on largely
+  non-overlapping dose grids: A 0–2.5 (11 doses), **B 0.02/0.05/0.1 (3 doses)**,
+  C 0.02–15 (12), D 0.001–15 (13). Three dose levels will not support a
+  four-parameter model, let alone crossed weights over a 23-model set.
+
+So `nassarius` fails for **both** halves of the vignette, for two unrelated
+reasons, and the failure is not the one the PR thread diagnosed.
+
+### `cr_modelling_training` ships data built for this
+
+Cloned at `/mnt/c/Rworking/cr_modelling_training`. Its
+`vignettes/8Factor_covariates_and_groupings.Rmd` uses three CSVs, one per thing
+this vignette has to teach:
+
+| file | n | structure | teaches |
+|---|---|---|---|
+| `example_ogl.csv` | 100 | coral tile % colour change, grouped by tile colour | `ogl()` — intercept only |
+| `example_pgl.csv` | 176 | `log_x`, `y`, `plateRep` | `pgl()` — slope and intercept |
+| `example_fi.csv` | 151 | Chlorella / Zn across hardness × pH | the factor interaction (#33) |
+
+**The open decision is whether to bring one or more of these into the package as
+data** — which needs provenance, documentation and permission — or to keep
+looking in the packaged data. RF's call.
+
+## Also standing, and not yet acted on
+
+- **`R-CMD-check.yaml` passes `--ignore-vignettes`.** Nothing in CI has ever
+  checked a vignette; #190 is the first real check of them. Do not read a green
+  stack as evidence that the vignettes build.
+- **example7** (`negsgr-cens-vignette`, 8 commits) is pushed with no PR. It
+  commits the *rendered* `example7.Rmd` and its figures, edits `R/nsec.R`, and
+  edits the rendered `example1.Rmd` and `example6.Rmd` — all three of which
+  cross rules this stack has been keeping. Needs review and a targeting
+  decision.
+- **Vignette numbering**, settled but previously unrecorded: **7** negative
+  growth (#193), **8** grouping (#6/#33), **9** workflow (#219).
+- Stale worktrees `bayesnec-review` and `bayesnec-review2` can be removed.
+- **The open decision from phase 3 is still open:** are #33 and #6 (PRs 227,
+  228) in the pre-migration release? It now matters more, because example8's
+  data problem sits on 228.

--- a/notes/vignette_numbering.md
+++ b/notes/vignette_numbering.md
@@ -37,3 +37,59 @@ number can be taken without being visible anywhere a new session would look.
    output, the figure names under `vignette-fig-`, every `vignette("exampleN")`
    cross-reference, and any published URL all carry the number.
 4. `2b` is a historical exception. Do not create further letter suffixes.
+
+---
+
+# Writing style — scientific report, not blog post
+
+**RF, 2026-08-24.** The vignettes drafted in August drifted into a conversational
+register that reads as machine-written. Corrected across example1, 7, 8 and 9;
+this section records the convention so it does not have to be corrected again.
+
+The reference is the published vignettes, not an abstract style guide. Their
+headings are **noun phrases**: *Background*, *Installation*, *The scale of the
+predictor*, *Preparing the response*, *Censoring*, *Non-constant dispersion*,
+*Choosing a variance function*, *Model definitions*, *Model suitability for
+response types*. Match that.
+
+## The five patterns that were corrected
+
+| pattern | example found | replaced with |
+|---|---|---|
+| question as heading | *Which kind of grouping is it?* | *Types of grouping* |
+| | *Does model averaging rescue the floored approaches?* | *Model averaging* |
+| conversational what/where clause | *Where these numbers come from* | *Provenance of the reported results* |
+| | *What saturation costs* | *Limits of the censored likelihood* |
+| | *What to take from this* | *Interpretation* |
+| em-dash or colon appositive | ``ogl()` --- an offset shared by a group`` | ``Group-level offsets: `ogl()``` |
+| | *A second family: a continuous response* | *A continuous response* |
+| comma-and tail | *Failure modes, and being honest about them* | *Failure modes* |
+| | *Exclusion, and what it does to the answer* | *Exclusion and its effect on the estimates* |
+| definite article plus count | *The eight approaches* | *Zero-handling approaches* |
+| | *The twelve scenarios* | *Simulation scenarios* |
+
+## In the body text
+
+The same register shows up in prose. These were removed rather than reworded
+wherever they carried no information:
+
+- *it is worth stating / worth noting / worth being explicit that* — say the thing;
+- *Read in order.* / *Two things follow, and the second is not what one would guess.*
+  — announce structure only where the reader needs it, and without the flourish;
+- *actually*, *plainly*, *honest* as intensifiers;
+- bold lead-ins phrased as questions (**Why the link is identity.**) rather than
+  as claims (**The link is the identity.**).
+
+A residual count remains in example7 (*deliberate*, 13 occurrences) that is
+mostly legitimate — a simulation study does need to say which choices were
+deliberate — but it is worth a look on the next pass.
+
+## Two structural rules
+
+1. **Do not let a heading make an argument the body then contradicts.** example7
+   carried *Why `nec4param` and not a model-averaged set*, and a later section
+   model-averaged. State the scope of the main comparison and forward-reference
+   the section that relaxes it.
+2. **Say a thing once.** The same justification appeared three times in
+   example7's Methods. If a point needs restating, the first statement was in
+   the wrong place.

--- a/notes/vignette_numbering.md
+++ b/notes/vignette_numbering.md
@@ -1,0 +1,39 @@
+# Vignette numbering — the register
+
+**Check this file before creating a new `vignettes/exampleN.Rmd.orig`, and add
+your row to it in the same commit that creates the file.**
+
+This register exists because two parallel sessions both claimed `example8` in
+August 2026 — the #6/#33 grouping vignette and the #219 workflow vignette — and
+the collision was only caught at review, on PR #228. Branch names do not reveal
+a number, and `dev` does not carry a vignette until its branch merges, so a
+number can be taken without being visible anywhere a new session would look.
+
+## Allocated
+
+| # | file | subject | issue | where it lives |
+|---|---|---|---|---|
+| 1 | `example1` | response types and distributions | — | `dev` |
+| 2 | `example2` | model averaging and multi-model inference | — | `dev` |
+| 2b | `example2b` | the model set, and theoretical curves | — | `dev` |
+| 3 | `example3` | priors | — | `dev` |
+| 4 | `example4` | comparing posteriors | — | `dev` |
+| 5 | `example5` | *NEC*, NSEC and ECx | — | `dev` |
+| 6 | `example6` | hurdle families and zero-inflation | — | `dev` |
+| 7 | `example7` | negative growth rates and the zero boundary | #193 | `negsgr-cens-vignette` |
+| 8 | `example8` | grouping and factor covariates | #6, #33 | `issue-6-33-grouping-vignette` |
+| 9 | `example9` | a complete analysis workflow | #219 | `issue-219-workflow-vignette` |
+
+**Next free number: 10.**
+
+## Rules
+
+1. **Claim the number here first**, on a branch that goes to `dev` quickly, or in
+   the same PR that adds the vignette. A number claimed only on a long-lived
+   feature branch is invisible to everyone else.
+2. **A number is not free just because `dev` has no such file.** Four of the ten
+   rows above live on unmerged branches. Check this table, not `ls vignettes/`.
+3. **Renumbering is expensive** once a vignette is rendered: `precompile.R`
+   output, the figure names under `vignette-fig-`, every `vignette("exampleN")`
+   cross-reference, and any published URL all carry the number.
+4. `2b` is a historical exception. Do not create further letter suffixes.


### PR DESCRIPTION
Notes only — no package code.

Appends a **Phase 3b** section to `notes/implementation/06_review_run.md` covering the tidy-up done on 2026-08-24.

## What it records

- **All seven PRs were red for two roxygen slips, not for their own subject matter.** Every platform reported `FAIL 0`; the red X was `R CMD check found WARNINGs` — a `\link{check_fit}` that does not resolve until 226, and three `@param` entries missing for arguments that decisions (b) and (d) added. Fixed at the base of each propagation range and restacked with zero conflicts. Versions were deliberately left on the existing monotone pinning.
- **The `WARN 10` is one line** — `R/autoplot.R:188`, `.data` in a tidyselect expression, deprecated in tidyselect 1.2.0. `test-expand_classes.R` now runs with none.
- **#229–#232 were merged but never closed** because their PR bodies said `(#n)` rather than `Closes #n`. Now closed.
- **A four-hour precompile run was sitting uncommitted on a detached HEAD** in `/mnt/c/Rworking/bayesnec-precompile`. Preserved on `precompile-rehearsal-2026-08-24`. It is not a #190 run — example7 is absent and example8 does not execute.
- **Two findings from that run.** A `Beta` response reaching exactly zero can fail the whole candidate set (`irgarol` has 8 of 12 top-concentration replicates at zero), which is very likely why example8's `bnec_group()` call fails on the full `herbicide` set — a data-and-family question rather than a `bnec_group()` defect.
- **example8 does not execute, and the reason is not the one PR #228's thread diagnosed.** The rewrite correctly stopped conditioning on survival, but nassarius *survival* has almost no concentration-response, and the four contaminants sit on non-overlapping dose grids with one level carrying three doses. It fails for both halves, for two unrelated reasons.
- The three purpose-built grouping datasets in `cr_modelling_training`, and the open decision about bringing them into the package.

## Still standing

`R-CMD-check.yaml` passes `--ignore-vignettes`, so a green stack is not evidence the vignettes build; example7 is pushed with no PR and crosses three of this stack's rules; and the phase 3 question — are #33 and #6 in the pre-migration release? — is still open and now matters more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)