### PR TITLE
Check the vignettes in CI, and fail precompile on a chunk that errored

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -53,8 +53,13 @@ jobs:
           cmdstanr::check_cmdstan_toolchain(fix = TRUE)
         shell: Rscript {0}
 
+      # Vignettes ARE built and checked. They are precompiled -- precompile.R
+      # renders every .Rmd.orig to a .Rmd whose chunks are display-only -- so
+      # building them is markdown to HTML and costs ~16s, not a refit. Skipping
+      # them meant nothing in CI had ever checked a vignette, and the first
+      # check of them was the release precompile. See #190.
       - uses: r-lib/actions/check-r-package@v2
         with:
-          build_args: 'c("--no-manual", "--no-build-vignettes")'
-          args: 'c("--no-manual", "--as-cran", "--ignore-vignettes")'
+          build_args: 'c("--no-manual")'
+          args: 'c("--no-manual", "--as-cran")'
           upload-snapshots: true

--- a/vignettes/precompile.R
+++ b/vignettes/precompile.R
@@ -33,3 +33,22 @@ if (!all(success)) {
 } else {
   unlink(images)
 }
+
+# Fail on a vignette whose chunks errored ---------------------------------
+# knitr renders a failed chunk as `#> Error...` and carries on, so a run can
+# report success while emitting a vignette that is a cascade of errors --
+# which is exactly what happened to example8 on 2026-08-24, unnoticed until
+# someone read the output. R CMD check does not catch this either: the error
+# text is just text in a rendered .Rmd. Check it here, where it is produced.
+rendered <- dir("vignettes", pattern = "^example.*\\.Rmd$", full.names = TRUE)
+errored <- Filter(function(f) any(grepl("^#> Error", readLines(f, warn = FALSE))),
+                  rendered)
+if (length(errored)) {
+  detail <- vapply(errored, function(f) {
+    hits <- grep("^#> Error", readLines(f, warn = FALSE), value = TRUE)
+    paste0("  ", basename(f), " (", length(hits), "): ", hits[1])
+  }, character(1))
+  stop("Chunks errored while knitting:\n", paste(detail, collapse = "\n"),
+       "\nFix the vignette source and re-run; do not ship this output.",
+       call. = FALSE)
+}


### PR DESCRIPTION
Two related gaps, both surfaced by the example8 failure.

## 1. Nothing in CI had ever checked a vignette

`R-CMD-check.yaml` passed **both** `--no-build-vignettes` and `--ignore-vignettes`, so the first real check of a vignette was the release precompile (#190). That is a long way to carry an unchecked artefact.

The caution is unnecessary here. The vignettes are **precompiled** — `precompile.R` renders each `.Rmd.orig` to a `.Rmd` whose chunks are all display-only (`0` executable chunks in every rendered vignette) — so building them is markdown to HTML, not a refit.

Measured on `dev`:

```
* creating vignettes ... OK      real 0m16.4s
* checking files in ‘vignettes’ ............ OK
* checking package vignettes ............... OK
* checking re-building of vignette outputs . OK
Status: 1 NOTE       # .git, an artefact of building from a worktree
```

So both flags are dropped.

## 2. That checks structure, not content

`knitr` renders a failed chunk as `#> Error...` and carries on. A precompile run therefore reports success while emitting a vignette that is a cascade of errors, and `R CMD check` sees only text — it cannot tell an error message from prose.

That is exactly what happened to example8 on 2026-08-24: `bnec()` returned `Failed to fit model nec3param`, every later chunk cascaded on the missing object, the vignette produced no figures at all, and the run reported success. Nobody noticed until the output was read.

`precompile.R` now scans what it has just written and refuses to finish if any chunk errored, naming the file, the count and the first message.

Verified against that known-bad tree:

```
scanned: 9 vignettes
errored: example8.Rmd
  example8.Rmd - 8 error lines; first: #> Error: Failed to fit model nec3param.
```

It flags the one that is broken and passes the other eight.

## Notes

- **This touches `.github/`,** which the stack protocol reserves for #215. Doing it at your explicit request; flagging it so the exemption is on the record rather than assumed.
- **No NEWS or DESCRIPTION change.** This is CI and authoring tooling with no user-visible package behaviour, and touching either line would conflict with every branch in the open stack.
- Branched from `dev`, so it can merge independently of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)