### PR TITLE
Reconcile the notes with dev, and close #148

### DIFF
--- a/notes/implementation/01_work_queue.md
+++ b/notes/implementation/01_work_queue.md
@@ -22,19 +22,30 @@ Branches stack: each is cut from the one above it, and its PR targets the one
 above it. See `00_protocol.md`. Order is least-risky first, so a stall late in
 the run still leaves a clean, mergeable run of PRs at the bottom.
 
-| # | issue | what | size | tier |
-|---|---|---|---|---|
-| 0 | #79, #212, #166 | close, no PR | — | — |
-| 1 | #215 | publish `dev` vignettes from CI | S | 2.1.4 |
-| 2 | #139 | document the `drc` NEC equivalence | S | 2.1.4 |
-| 3 | #210 | `define_prior()` collapse on many zeros | S | 2.1.4 |
-| 4 | #207 | dispersion priors; fill incomplete prior sets | M | 2.1.4 |
-| 5 | #136 | `rate()` aterm for Poisson / negbinomial | M | 2.1.4 |
-| 6 | #209 | `hurdle_poisson`, `hurdle_negbinomial` | M–L | 2.1.4 (on hold) |
-| 7 | #148 | `check_fit()`, `pp_check()` methods, LOO-PIT | L | 2.1.4 |
-| 8 | #33 | factor covariate, stage 1 | XL | 2.2.0 |
-| 9 | #6 + #33 | the grouping vignette | L | 2.2.0 |
-| — | #190 | full `precompile.R` | L | **attended, per release** |
+**Status column refreshed 2026-08-25.** Every PR in this stack targets `dev`,
+not the default branch, so `Closes #n` never fires on merge and the issues have
+to be closed by hand. Do that as each one merges. Status here is the truth as of
+`dev` at `879ab53f`; the tracker was reconciled against it on 2026-08-25.
+
+| # | issue | what | size | tier | status |
+|---|---|---|---|---|---|
+| 0 | #79, #212, #166 | close, no PR | — | — | **done** — all three closed |
+| 1 | #215 | publish `dev` vignettes from CI | S | 2.1.4 | **merged** #220 · issue closed |
+| 2 | #139 | document the `drc` NEC equivalence | S | 2.1.4 | **merged** #221 · issue closed |
+| 3 | #210 | `define_prior()` collapse on many zeros | S | 2.1.4 | **merged** #222 · issue closed |
+| 4 | #207 | dispersion priors; fill incomplete prior sets | M | 2.1.4 | **merged** #223 · issue closed |
+| 5 | #136 | `rate()` aterm for Poisson / negbinomial | M | 2.1.4 | **merged** #224 (also #247) · both closed |
+| 6 | #209 | `hurdle_poisson`, `hurdle_negbinomial` | M–L | 2.1.4 (on hold) | **PR #225 open, blocked** on a `brms` bug — see #249 |
+| 7 | #148 | `check_fit()`, `pp_check()` methods, LOO-PIT | L | 2.1.4 | **merged** #226 (A/B/C + b + d) and #240 (Part D) · issue closed |
+| 8 | #33 | factor covariate, stage 1 | XL | 2.2.0 | **stage 1 merged** #227 · issue **stays open** for stage 2 |
+| 9 | #6 + #33 | the grouping vignette | L | 2.2.0 | **PR #228 open** · #6 and #33 both held open by it |
+| — | #190 | full `precompile.R` | L | **attended, per release** | **outstanding** — the release gate; #248 rides on it |
+
+**Two merged branches must not be deleted.** `issue-136-rate-aterm` is the base of
+PR #225 and `issue-148-check-fit` is the base of PR #238; deleting a merged base
+closes the PR stacked on it and it cannot be reopened until the branch is
+restored. Both are still on the remote. Everything else in this stack can be
+deleted as it merges.
 
 ---
 
@@ -208,6 +219,15 @@ That is the intended fix, but it is not a silent one. Say so in the PR.
 
 ## 5. #136 — `rate()` aterm for Poisson and negative binomial
 
+> **MERGED 2026-08-25, PR #224. #136 and #247 are both closed.** Both of RF's
+> calls are implemented: `rate()` is refused on the zero-inflated count families
+> with its own message, and an unvalidated aterm is now an **error** (its own
+> `**Breaking:**` NEWS bullet). The PR also carries #247 — `dispersion()` was
+> applying the family's *default* link inverse rather than the identity link
+> `bnec()` actually fits with, so every `poisson` and `binomial` dispersion value
+> changes. The tier is **2.1.4**, not the 2.2.0 this entry was written against.
+> Nothing outstanding. What follows is the original scope, kept for the record.
+
 Fully scoped in the issue comments; **RF settled both open calls on 2026-08-21**:
 refuse `rate()` on the zero-inflated count families with a clear message, and make
 unrecognised aterms an **error** rather than a message.
@@ -248,6 +268,12 @@ error.
 ---
 
 ## 6. #209 — `hurdle_poisson` and `hurdle_negbinomial`
+
+> **ON HOLD, 2026-08-25.** PR #225 is open and blocked on a `brms` bug: `trunc()`
+> on counts is right in the Stan code and wrong in `log_lik`/`posterior_epred`,
+> which blocks the factorised count hurdle. Tracked as **#249**. The branch
+> `issue-209-hurdle-counts` sits on `issue-136-rate-aterm`, which has merged —
+> **do not delete that base branch**, it would close #225 irrecoverably.
 
 **Scope.** The count analogues of `hurdle_gamma`. Add both to `hurdle_fams` and
 `hurdle_mu_fams` in `data-raw/sysdata.R`, extend the `switch()` in
@@ -356,14 +382,35 @@ the four mixture families.
 
 **Vignette.** Author the `.Rmd.orig`; it does not render until #190.
 
-**Status, 2026-08-23.** PR #226 delivers A, B (numeric only), C. Outstanding:
-the **plot** half of B (added under review), **(b)** the automatic surfacing,
-**(d)** the combined hurdle check, and **all of Part D**. #219 depends on Part D
-and its dependency claim was correct.
+**Status, 2026-08-25 — COMPLETE, #148 closed.** All four parts are on `dev`.
+PR #226 delivered A, B (numeric *and* plot), C, plus decision **(b)** — the
+end-of-`bnec()` message and the `summary()` line, thresholding on the **ratio**
+with `fit_ratio_cutoff = 1.15`, confirmed by RF 2026-08-24 — and decision **(d)**,
+the combined hurdle check. PR #240 delivered **Part D**: `check_sampling()`,
+`screen_models()`, and the Rhat default moved to 1.01. Verified on `dev` at
+`879ab53f`: `check_fit`, `check_sampling`, `screen_models` and the three
+`pp_check` methods are exported.
+
+Two things ride on it and are **not** done:
+
+- The `example2` doc fix is in the `.Rmd.orig`, but the **rendered** vignette
+  still documents the 1.05 default — that is **#248**, under #190.
+- **PR #238 (#219) still needs rewriting.** It hand-rolls a model screen because
+  Part D was thought absent; it can now call `screen_models()`. Its base branch
+  `issue-148-check-fit` has merged — **do not delete it** while #238 is open.
 
 ---
 
 ## 8. #33 — factor covariate, stage 1 only
+
+> **STAGE 1 MERGED 2026-08-25, PR #227.** `bnec_group()`, `bayesnecgroupfit`,
+> `crossed_group_weights()`, and per-level `print`/`nec`/`ecx`/`plot`. Both
+> readings of the crossed table are reported, and the `23^G` array is never
+> materialised. **#33 stays open** — stage 2 (the joint dummy-coded refit) is
+> still toxval-gated, and the vignette at item 9 is still a PR. The gate was
+> re-verified rather than assumed at merge time: `toxval` still `Imports`
+> `bayesnec` and registers seven colliding methods. `02_deferred.md` now records
+> the method surface #227 adds.
 
 Feasibility assessed in the issue comment; RF cleared it for the stack on
 2026-08-21. **Stage 1 only.**
@@ -409,6 +456,10 @@ place, which is a finding worth more than a partial implementation.
 ---
 
 ## 9. #6 + #33 — the grouping vignette
+
+> **PR #228 open, 2026-08-25.** Its dependency — #33 stage 1 — is now on `dev`,
+> so it is unblocked. **#6 and #33 are both held open by this PR alone**; #6 has
+> no other outstanding work.
 
 **One vignette covering both**, per RF on both issues (2026-08-21): they are two
 ways of dealing with data grouping and belong together. Cut this branch from #33's,
@@ -494,4 +545,7 @@ another session's.
 | #218 | the three unseeded permutations. Documentation-and-constraint outcome, not a code fix — see the issue. Cheap; add to a later stack. |
 | #184 | `future_apply`. **Attended, and blocked on the machine.** RF has had trouble with `future_apply` on WSL and wants a testing pass with the findings posted as a comment before any implementation. Must wait until the simulation study finishes — it is the same resource. |
 | #139 option C | the Pires et al. (2002) two-component model, conditional on reading *Environmetrics* 13:15–27. |
-| #148 decision (d) | the combined hurdle check — see item 7. |
+| ~~#148 decision (d)~~ | **done** — shipped in PR #226. |
+| #245 | group-level terms with bounded families. PR #250 open, another session's. |
+| #249 | the factorised count hurdle, blocked on `brms`. Holds #209 / PR #225. |
+| #248, #190 | the release precompile and the stale `example2` Rhat text it fixes. |

--- a/notes/implementation/05_run_log.md
+++ b/notes/implementation/05_run_log.md
@@ -285,3 +285,60 @@ other two #240 guards in that file -- the `NA` index test and the
 held. Worth recording because a branch cut before a test exists cannot fail it
 until the two meet, and this is the second time that shape of thing has bitten
 this stack.
+
+---
+
+# MERGE RECORD — 2026-08-25
+
+Written when the tracker was reconciled against `dev` at `879ab53f`. **These PRs
+all target `dev`, so `Closes #n` does not fire on merge** — every issue below was
+closed by hand, and any future PR in this run needs the same treatment.
+
+| merged | PR | issue(s) closed | note |
+|---|---|---|---|
+| 08-24 | #240 | — (#148 Part D) | landed before its sibling; #148 stayed open until #226 |
+| 08-24 | #241, #242 | — | notes, and the first CI check of a vignette |
+| 08-24 | #246 | #244 | also fixed `sample_priors(plot = NA)`, found in passing |
+| 08-24 | #226 | **#148** | closed 2026-08-25 once verified on `dev` |
+| 08-25 | #252 | #251 | vignette precompile fanned out, one job per vignette |
+| 08-25 | #224 | #136, #247 | breaking: an unvalidated aterm is now an error |
+| 08-25 | #227 | — (#33 **stage 1**) | #33 left open on purpose |
+
+## Item 8 — #33 stage 1, `bnec_group()`
+
+Merged as PR #227. `bnec_group()` fits the model set independently within each
+level of a factor, model-averages within level, and returns a `bayesnecgroupfit`
+with per-level `print` / `nec` / `ecx` / `plot`. Crossed model weights come off
+the per-level vectors as an outer product under pseudo-BMA, and **both** readings
+of the crossed table are reported — the unrestricted maximum, and the diagonal
+maximum that asks which single equation describes every level. The `23^G` array is
+never materialised.
+
+**Restacked on 2026-08-25 and that mattered.** The branch had been sitting on
+#226 and carrying #225's hurdle-count work through the old stack; #225 is on hold,
+so it was rebased onto #224 alone. The result is #33's own six commits — 14 files,
++1373 lines, with no `hurdle_poisson` / `hurdle_negbinomial` content.
+
+**Release tiers were revised in the same pass.** `2.1.4` is now everything up to
+and including the feature work (#136, #148); **`2.2.0` is the factor covariate
+release**, since `bnec_group()` is functionality that never existed. The `2.3.0`
+tier that briefly existed for `bnec_group()` is gone.
+
+**#33 was not closed.** Stage 2 — the joint dummy-coded refit — is still
+toxval-gated, and the gate was re-verified rather than assumed: `toxval` still
+`Imports` `bayesnec` and registers seven colliding methods. Building only stage 2's
+formula assembly would yield a fit no per-level estimate can be read from, because
+`nec()`/`nsec()` read `b_nec_Intercept` by fixed name and `bnec_newdata()` /
+`fitted()` / `predict()` carry no group handling. The grouping vignette (item 9,
+PR #228) also still references this issue.
+
+## What the merges left open
+
+- **PR #238** (#219) must be rewritten before it can go in: it hand-rolls a model
+  screen because Part D was thought absent, and can now call `screen_models()`.
+- **PR #228** (#6, #33) is unblocked — its dependency is on `dev`.
+- **PR #225** (#209) is blocked on `brms`, tracked as **#249**.
+- **#190** — the release precompile — is the remaining gate, and **#248** (the
+  rendered `example2` still documenting the 1.05 Rhat default) rides on it.
+- **Do not delete `issue-136-rate-aterm` or `issue-148-check-fit`.** They are the
+  bases of PRs #225 and #238; deleting a merged base closes the PR above it.

--- a/notes/implementation/06_review_run.md
+++ b/notes/implementation/06_review_run.md
@@ -1,6 +1,50 @@
 # Review run — the pre-CRAN loop
 
-> ## START HERE — handoff, 2026-08-23
+> ## START HERE — state of the tracker, 2026-08-25
+>
+> **The 2026-08-23 handoff block below is superseded on the PR-state question.**
+> Read this first; everything in the older block that is not about PR state
+> still applies, in particular the lesson about checking claims against sources.
+>
+> `dev` is at `879ab53f`. **Every PR in this run targets `dev`, not the default
+> branch, so `Closes #n` never fires — issues have to be closed by hand.** The
+> tracker was reconciled against `dev` on 2026-08-25 and is now correct.
+>
+> ### Merged, issues closed
+>
+> | PR | issue(s) | what |
+> |---|---|---|
+> | #220–#223 | #215, #139, #210, #207 | the original 2.1.4 tier |
+> | #233, #235, #236, #237 | #230, #229, #232, #231 | phase 1, the review's own findings |
+> | #240 | #148 Part D | `check_sampling()`, `screen_models()`, Rhat on 1.01 |
+> | #226 | #148 (A/B/C + b + d), #56 | `check_fit()`, `pp_check()` — **#148 closed 2026-08-25** |
+> | #246 | #244 | `constant()` priors through `bnec()` |
+> | #224 | #136, #247 | the `rate()` aterm; `dispersion()`'s link |
+> | #252 | #251 | vignette precompilation fanned out and unbroken |
+> | #227 | #33 **stage 1** | `bnec_group()` — **#33 deliberately left open**, see below |
+> | #239, #241, #242 | — | notes, and the CI vignette check |
+>
+> ### Still open, and why
+>
+> | | |
+> |---|---|
+> | **#33** | stage 1 merged; **stage 2 is still toxval-gated** and the vignette is PR #228. Do not close. |
+> | **#6** | held open by PR #228 alone. Nothing else outstanding on it. |
+> | **PR #228** (#6, #33) | open, and now unblocked — its dependency #33 stage 1 is on `dev`. |
+> | **PR #238** (#219) | open, **needs rewriting**: it hand-rolls a screen because Part D was thought absent. Call `screen_models()`. |
+> | **PR #225** (#209) | blocked on a `brms` bug — `trunc()` on counts is right in Stan, wrong in `log_lik`/`posterior_epred`. Tracked as **#249**. |
+> | **PR #250** (#245) | another session's. Group-level terms with bounded families. See `notes/tasks/245-and-example8-overnight.md`. |
+> | **PR #243** (#193) | another session's. `example7`, negative growth rates. |
+> | **#190** | the release gate: the full `precompile.R` run. **#248** (stale `example2` Rhat text) rides on it. |
+>
+> ### Two merged branches must not be deleted
+>
+> `issue-136-rate-aterm` is the base of PR #225 and `issue-148-check-fit` is the
+> base of PR #238. Deleting a merged base closes the PR stacked on it, and it
+> cannot be reopened until the branch is restored. Both are still on the remote.
+> Every other merged branch in this run can go.
+
+> ## Handoff, 2026-08-23 — superseded on PR state, see above
 >
 > The session that ran phases 0–3 ended here. **Read this block, then
 > `notes/tasks/148-model-fit-diagnostics.md`, before anything else.**


### PR DESCRIPTION
Notes only — no package code, no tests, nothing that affects the build.

Every PR in this run targets `dev` rather than the default branch, so `Closes #n`
never fires on merge and issues have to be closed by hand. That had drifted again:
five PRs merged on 24–25 August and the notes still described the state before
them.

## Tracker reconciled

Checked every issue referenced by a merged PR against its actual state. All of
#215, #139, #210, #207, #229–#232, #230, #244, #251, #136, #247 and #56 were
already closed. Two were not:

- **#148 — closed.** Verified on `dev` at `879ab53f` before closing:
  `check_fit`, `check_sampling`, `screen_models` and the three `pp_check` methods
  are all exported in `NAMESPACE`. Delivered by **#226** (Parts A, B, C, plus
  decision (b) — the `bnec()` message and `summary()` line thresholding on the
  ratio at `fit_ratio_cutoff = 1.15` — and decision (d), the combined hurdle
  check) and **#240** (Part D). Closing comment records both, and the two things
  that ride on the issue and are *not* done: the rendered `example2` still shows
  the 1.05 Rhat default (#248, under #190), and PR #238 still hand-rolls a screen
  that `screen_models()` now provides.
- **#33 — deliberately left open**, with a status comment. Stage 1 is merged
  (#227); stage 2 is still toxval-gated, and the gate was re-verified rather than
  assumed — `toxval` still `Imports` `bayesnec` and registers seven colliding
  methods. The grouping vignette (PR #228) also still references it.

## Notes updated

- **`01_work_queue.md`** — the stack table gains a **status** column, so the
  merged/blocked/outstanding split is readable without cross-checking the
  tracker. Items 5, 6, 8 and 9 gain a status block at the top; item 7's stale
  "Status, 2026-08-23" is replaced. The *Open, not in this stack* table now
  carries #245, #248, #249 and #190, and strikes out #148 decision (d).
- **`06_review_run.md`** — a current **START HERE** block replaces the
  2026-08-23 handoff at the top of the file (the old block is kept below, marked
  superseded, since its lesson about checking claims against sources still
  stands). It tabulates what merged and what each open PR is waiting on.
- **`05_run_log.md`** — a merge record for 24–25 August, and an item 8 entry
  covering the #227 restack and the release-tier revision (`2.1.4` is now
  everything through the feature work; **`2.2.0` is the factor covariate
  release**; the short-lived `2.3.0` tier is gone).

## The one thing most likely to bite a future session

All three files now say it in their own words: **`issue-136-rate-aterm` and
`issue-148-check-fit` must not be deleted.** They have merged, but they are the
base branches of PRs #225 and #238, and deleting a merged base closes the PR
stacked on it — which cannot be reopened until the branch is restored. Both are
still on the remote.

## Not included

`notes/tasks/245-and-example8-overnight.md` is untracked in the working tree and
belongs to the session working #245 / PR #250. Left alone rather than committed
here.
