### PR TITLE
Add test files for check_data(), plot() and autoplot()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Suggests:
     knitr,
     rmarkdown,
     R.utils,
-    testthat (>= 3.1.7)
+    testthat (>= 3.1.8)
 VignetteBuilder: knitr
 URL: https://open-aims.github.io/bayesnec/
 BugReports: https://github.com/open-aims/bayesnec/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Suggests:
     knitr,
     rmarkdown,
     R.utils,
-    testthat (>= 3.0.0)
+    testthat (>= 3.1.7)
 VignetteBuilder: knitr
 URL: https://open-aims.github.io/bayesnec/
 BugReports: https://github.com/open-aims/bayesnec/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bayesnec
 Title: A Bayesian No-Effect- Concentration (NEC) Algorithm
-Version: 2.1.3.25
+Version: 2.1.3.26
 Authors@R: c(person("Rebecca", "Fisher", email = "r.fisher@aims.gov.au", role = c("aut", "cre"),comment = c(ORCID = "0000-0001-5148-6731")), person("Diego R.","Barneche",role="aut",comment = c(ORCID = "0000-0002-4568-2362")), person("Gerard F.","Ricardo",role="aut",comment = c(ORCID = "0000-0002-2220-3971")), person("David R.","Fox",role="aut",comment = c(ORCID = "0000-0002-3178-7243")))
 Description: Implementation of No-Effect-Concentration estimation that uses 'brms' (see Burkner (2017)<doi:10.18637/jss.v080.i01>; Burkner (2018)<doi:10.32614/RJ-2018-017>; Carpenter 'et al.' (2017)<doi:10.18637/jss.v076.i01> to fit concentration(dose)-response data using Bayesian methods for the purpose of estimating 'ECx' values, but more particularly 'NEC' (see Fox (2010)<doi:10.1016/j.ecoenv.2009.09.012>), 'NSEC' (see Fisher and Fox (2023)<doi:10.1002/etc.5610>), and 'N(S)EC (see Fisher et al. 2023<doi:10.1002/ieam.4809>). A full description of this package can be found in Fisher 'et al.' (2024)<doi:10.18637/jss.v110.i05>. This package expands and supersedes an original version implemented in 'R2jags' (see Su and Yajima (2020)<https://CRAN.R-project.org/package=R2jags>; Fisher et al. (2020)<doi:10.5281/ZENODO.3966864>).
 Depends:

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -50,7 +50,7 @@ transformed_response_fit <- function(fit, model) {
 }
 
 # The same fixture for a model set. Both plotting paths read the formula off
-# mod_fits[[1]] alone (R/plot.R:258, R/autoplot.R:346), so that is the only
+# mod_fits[[1]] alone (R/plot.R:258, R/autoplot.R:347), so that is the only
 # element that has to change.
 transformed_response_manec <- function(manec) {
   mod <- names(manec$mod_fits)[1]

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -53,9 +53,12 @@ transformed_response_fit <- function(fit, model) {
 # whether a variable was transformed, and it is not safe for reading posterior
 # quantities off the fit. Do not reuse it for anything else.
 
-# The same fixture for a model set. Both plotting paths read the formula off
+# The same fixture for a model set. On the model-average branch, which is the
+# one the pinning tests use, both plotting paths read the formula off
 # mod_fits[[1]] alone (R/plot.R:258, R/autoplot.R:347), so that is the only
-# element that has to change.
+# element that has to change. Not so with all_models = TRUE: plot() then draws
+# each candidate through plot.bayesnecfit, which reads that candidate's own
+# formula at R/plot.R:118. Do not use this fixture on that branch.
 transformed_response_manec <- function(manec) {
   mod <- names(manec$mod_fits)[1]
   manec$mod_fits[[1]] <- transformed_response_fit(manec$mod_fits[[1]], mod)

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -48,6 +48,10 @@ transformed_response_fit <- function(fit, model) {
   )
   fit
 }
+# NB: the returned object states a formula its stored fit was not fitted with.
+# That is safe for the plotting paths, which read the formula only to decide
+# whether a variable was transformed, and it is not safe for reading posterior
+# quantities off the fit. Do not reuse it for anything else.
 
 # The same fixture for a model set. Both plotting paths read the formula off
 # mod_fits[[1]] alone (R/plot.R:258, R/autoplot.R:347), so that is the only

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -28,3 +28,39 @@ nec4param <- pull_out(manec_example, model = "nec4param") |>
 ecx4param <- pull_out(manec_example, model = "ecx4param") |>
   suppressMessages() |>
   suppressWarnings()
+
+# Give a stored fit a formula that transforms its RESPONSE and nothing else.
+# This is the fixture that reproduces #268 without fitting anything: no packaged
+# fit transforms its response, and find_transformations() answers for the
+# formula as a whole, so a transformation here is enough to make the plotting
+# paths treat the untransformed predictor as transformed. exp() rather than
+# log(): manec_example's response reaches -6.9 and log() of it is NaN, and only
+# the presence of a transformation matters.
+#
+# Shared by test-plot.R and test-autoplot.R, which pin the same defect on the
+# base-graphics and ggplot2 paths and would otherwise define it twice.
+transformed_response_fit <- function(fit, model) {
+  # The model name is substituted into the formula text rather than referenced:
+  # crf() evaluates its model argument where the formula is used, not where it
+  # is written, so a variable reference is out of scope by then.
+  fit$bayesnecformula <- bayesnecformula(
+    stats::as.formula(paste0("exp(y) ~ crf(x, model = \"", model, "\")"))
+  )
+  fit
+}
+
+# The same fixture for a model set. Both plotting paths read the formula off
+# mod_fits[[1]] alone (R/plot.R:258, R/autoplot.R:346), so that is the only
+# element that has to change.
+transformed_response_manec <- function(manec) {
+  mod <- names(manec$mod_fits)[1]
+  manec$mod_fits[[1]] <- transformed_response_fit(manec$mod_fits[[1]], mod)
+  manec
+}
+
+# The largest predictor value the ggplot2 path put in its plotting frame. Used
+# by test-autoplot.R, and by test-plot.R to compare the two paths' xform
+# decisions against each other.
+gg_x_max <- function(obj, ...) {
+  max(suppressMessages(ggbnec_data(obj, ...))$x_e, na.rm = TRUE)
+}

--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -41,6 +41,13 @@ test_that("ggbnec_data returns the same frame shape for a model set", {
   skip_on_cran()
   d <- suppressMessages(ggbnec_data(manec_example))
   expect_true(all(c("x_e", "y_e", "y_ci", "x_r", "y_r") %in% names(d)))
+  # add_nec on the model-set branch, R/autoplot.R:356. Asserted here rather
+  # than in a block of its own so the frame above is computed once: making that
+  # condition unconditional failed nothing until this line was added, while its
+  # bayesnecfit twin at :312 was already observed.
+  expect_true("nec_vals" %in% names(d))
+  without <- suppressMessages(ggbnec_data(manec_example, add_nec = FALSE))
+  expect_false("nec_vals" %in% names(without))
 })
 
 test_that("the nec annotation is present by default and suppressible", {
@@ -73,8 +80,16 @@ test_that("xform is applied to the predictor axis of a single fit", {
 
 test_that("xform is applied to the predictor axis of a model set", {
   skip_on_cran()
-  expect_equal(gg_x_max(manec_example, xform = function(x) x * 100),
-               gg_x_max(manec_example) * 100, tolerance = 1e-8)
+  plain <- suppressMessages(ggbnec_data(manec_example))
+  scaled <- suppressMessages(ggbnec_data(manec_example,
+                                         xform = function(x) x * 100))
+  expect_equal(max(scaled$x_e, na.rm = TRUE),
+               max(plain$x_e, na.rm = TRUE) * 100, tolerance = 1e-8)
+  # And the raw data column, R/autoplot.R:354. Dropping x_r from that mutate()
+  # failed nothing until this line was added, while its bayesnecfit twin at
+  # :310 was already observed.
+  expect_equal(max(scaled$x_r, na.rm = TRUE),
+               max(plain$x_r, na.rm = TRUE) * 100, tolerance = 1e-8)
 })
 
 test_that("xform reaches the raw data as well as the fitted curve", {

--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -1,0 +1,149 @@
+# autoplot() and ggbnec_data() had no test file of their own in any release.
+# The eleven plot-related lines scattered through test-bayesnec_methods.R,
+# test-bayesmanec_methods.R and test-expand_classes.R assert that a ggplot
+# comes back, and nothing else -- in particular xform, which exists so that a
+# fit on a transformed predictor can be drawn on the recorded scale, has never
+# been asserted anywhere on the plotting path. It is asserted only on the
+# estimators, in test-ecx.R, test-nec.R, test-nsec.R, test-ecnsec.R and
+# test-average_estimates.R.
+#
+# That gap is #268: the decision to apply xform is made with an all-or-nothing
+# guard on the formula as a whole, so a transformation on the RESPONSE
+# suppresses xform on the PREDICTOR axis. The issue records that it could only
+# be read from source, because no packaged fit transforms its response. It can
+# in fact be reproduced without fitting anything, by giving a stored fit a
+# formula that transforms its response, and that is done below.
+#
+# Nothing here fits a model. Every assertion runs off manec_example.
+
+ap_fit <- function() {
+  data(manec_example, package = "bayesnec")
+  suppressMessages(pull_out(manec_example, model = "nec4param"))
+}
+
+ap_manec <- function() {
+  data(manec_example, package = "bayesnec")
+  manec_example
+}
+
+# Give a stored fit a formula that transforms its response and nothing else.
+# exp() is used rather than log() because manec_example's response reaches
+# -6.9, and log() of it is NaN; the point is only that a transformation is
+# present on the response, not which one.
+ap_transform_response <- function(fit) {
+  fit$bayesnecformula <- bayesnecformula(exp(y) ~ crf(x, model = "nec4param"))
+  fit
+}
+
+ap_x_max <- function(obj, ...) {
+  max(suppressMessages(ggbnec_data(obj, ...))$x_e, na.rm = TRUE)
+}
+
+
+# ---- what ggbnec_data returns -----------------------------------------------
+
+test_that("ggbnec_data returns the columns autoplot draws from", {
+  d <- suppressMessages(ggbnec_data(ap_fit()))
+  expect_true(all(c("x_e", "y_e", "y_ci", "x_r", "y_r") %in% names(d)))
+  expect_gt(nrow(d), 0)
+})
+
+test_that("ggbnec_data returns the same frame shape for a model set", {
+  d <- suppressMessages(ggbnec_data(ap_manec()))
+  expect_true(all(c("x_e", "y_e", "y_ci", "x_r", "y_r") %in% names(d)))
+})
+
+test_that("the nec annotation is present by default and suppressible", {
+  with_nec <- suppressMessages(ggbnec_data(ap_fit()))
+  without <- suppressMessages(ggbnec_data(ap_fit(), add_nec = FALSE))
+  expect_true("nec_vals" %in% names(with_nec))
+  expect_false("nec_vals" %in% names(without))
+})
+
+test_that("ggbnec_data takes add_nec, and absorbs nec = FALSE into dots", {
+  # autoplot() takes nec = and forwards it as add_nec =. ggbnec_data() is
+  # exported and documented separately, and the obvious transfer of the
+  # autoplot argument name does nothing at all: nec = FALSE is swallowed by
+  # ... and the annotation is still computed and returned. Pinned as current
+  # behaviour rather than asserted to be correct.
+  swallowed <- suppressMessages(ggbnec_data(ap_fit(), nec = FALSE))
+  expect_true("nec_vals" %in% names(swallowed))
+})
+
+
+# ---- xform on the predictor axis --------------------------------------------
+
+test_that("xform is applied to the predictor axis of a single fit", {
+  f <- ap_fit()
+  expect_equal(ap_x_max(f, xform = function(x) x * 100),
+               ap_x_max(f) * 100, tolerance = 1e-8)
+})
+
+test_that("xform is applied to the predictor axis of a model set", {
+  m <- ap_manec()
+  expect_equal(ap_x_max(m, xform = function(x) x * 100),
+               ap_x_max(m) * 100, tolerance = 1e-8)
+})
+
+test_that("xform reaches the raw data as well as the fitted curve", {
+  f <- ap_fit()
+  plain <- suppressMessages(ggbnec_data(f))
+  scaled <- suppressMessages(ggbnec_data(f, xform = function(x) x * 100))
+  expect_equal(max(scaled$x_r, na.rm = TRUE),
+               max(plain$x_r, na.rm = TRUE) * 100, tolerance = 1e-8)
+})
+
+test_that("the transformation predicate answers per variable", {
+  f <- ap_transform_response(ap_fit())
+  bdat <- model.frame(f$bayesnecformula, data = f$fit$data,
+                      run_par_checks = TRUE)
+  # The predictor is not transformed in this formula and the per-variable
+  # predicate says so; find_transformations(), which the plotting paths read,
+  # answers for the formula as a whole and reports the response.
+  expect_false(pop_var_is_transformed(bdat, "x_var"))
+  expect_true(pop_var_is_transformed(bdat, "y_var"))
+  expect_identical(find_transformations(bdat), "y")
+})
+
+test_that("a transformed response suppresses xform on the predictor axis", {
+  # PINS THE #268 DEFECT, on the autoplot path (R/autoplot.R:306 and :350).
+  # xform is accepted and silently ignored, so the axis is drawn on the fitted
+  # scale while the caller asked for the recorded one. The estimates nec() and
+  # ecx() return are unaffected; this is the plot alone.
+  #
+  # INVERT THIS TEST WHEN #268 IS FIXED: the two should then be equal, as they
+  # are in "xform is applied to the predictor axis of a single fit" above.
+  f <- ap_transform_response(ap_fit())
+  expect_equal(ap_x_max(f, xform = function(x) x * 100), ap_x_max(f),
+               tolerance = 1e-8)
+})
+
+test_that("a transformed response suppresses xform for a model set too", {
+  # PINS THE #268 DEFECT on the bayesmanecfit branch. Same inversion applies.
+  m <- ap_manec()
+  # The model name has to be substituted into the formula text rather than
+  # referenced: crf() evaluates its model argument where the formula is used,
+  # not where it is written, so a variable reference is out of scope by then.
+  mod <- names(m$mod_fits)[1]
+  m$mod_fits[[1]]$bayesnecformula <- bayesnecformula(
+    stats::as.formula(paste0("exp(y) ~ crf(x, model = \"", mod, "\")"))
+  )
+  expect_equal(ap_x_max(m, xform = function(x) x * 100), ap_x_max(m),
+               tolerance = 1e-8)
+})
+
+
+# ---- autoplot itself --------------------------------------------------------
+
+test_that("autoplot returns a ggplot for both fit classes", {
+  expect_s3_class(suppressMessages(autoplot(ap_fit())), "ggplot")
+  expect_s3_class(suppressMessages(autoplot(ap_manec())), "ggplot")
+})
+
+test_that("autoplot accepts xform without error on both classes", {
+  expect_s3_class(
+    suppressMessages(autoplot(ap_fit(), xform = function(x) x * 100)), "ggplot")
+  expect_s3_class(
+    suppressMessages(autoplot(ap_manec(), xform = function(x) x * 100)),
+    "ggplot")
+})

--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -139,12 +139,13 @@ test_that("the nec annotation is transformed while the axis is not", {
   # whichever scale the fix settles on. A fix that changes only the guard, or
   # only these lines, fails one of the two tests and leaves the other passing,
   # which is the point of asserting both.
+  #
+  # The axis half of the contrast is asserted in the sibling test above and is
+  # not repeated here; this asserts the annotation alone.
   skip_on_cran()
   f <- transformed_response_fit(nec4param, "nec4param")
   plain <- suppressMessages(ggbnec_data(f))
   scaled <- suppressMessages(ggbnec_data(f, xform = function(x) x * 100))
-  expect_equal(max(scaled$x_e, na.rm = TRUE), max(plain$x_e, na.rm = TRUE),
-               tolerance = 1e-8)
   expect_equal(max(scaled$nec_vals, na.rm = TRUE),
                max(plain$nec_vals, na.rm = TRUE) * 100, tolerance = 1e-8)
 })

--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -131,8 +131,9 @@ test_that("the nec annotation is transformed while the axis is not", {
   # R/autoplot.R:313-318 pass xform to bind_nec() and to ecx() unconditionally,
   # outside the guard, so the annotation column and the curve column come back
   # on scales that differ by whatever xform does. Measured on nec4param with
-  # xform = x * 100: max(x_e) is 3.22 with and without xform, while nec_vals
-  # changes from 1.46 to 146.
+  # xform = x * 100: max(x_e) is 3.22 with and without xform, while the largest
+  # nec_vals -- the upper bound, which is what the assertion below reads --
+  # changes from 1.53 to 152.8.
   #
   # INVERT THIS TEST WHEN #268 IS FIXED: the two columns must then agree,
   # whichever scale the fix settles on. A fix that changes only the guard, or

--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -151,6 +151,26 @@ test_that("the nec annotation is transformed while the axis is not", {
 })
 
 
+test_that("the model set returns its nec annotation on the other scale too", {
+  # The bayesmanecfit branch has the same split: R/autoplot.R:352 guards the
+  # curve and R/autoplot.R:357 passes xform to bind_nec() unconditionally.
+  # Asserted separately from the bayesnecfit case above for the same reason:
+  # correcting one pair of lines and not the other is the half-fix this file
+  # exists to catch.
+  #
+  # Measured on manec_example with xform = x * 100: max(x_e) is 3.22 with and
+  # without xform, while the largest nec_vals changes from 1.53 to 152.7.
+  #
+  # INVERT THIS TEST WHEN #268 IS FIXED, with the sibling above it.
+  skip_on_cran()
+  m <- transformed_response_manec(manec_example)
+  plain <- suppressMessages(ggbnec_data(m))
+  scaled <- suppressMessages(ggbnec_data(m, xform = function(x) x * 100))
+  expect_equal(max(scaled$nec_vals, na.rm = TRUE),
+               max(plain$nec_vals, na.rm = TRUE) * 100, tolerance = 1e-8)
+})
+
+
 # ---- autoplot itself --------------------------------------------------------
 
 test_that("autoplot returns a ggplot for both fit classes", {

--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -171,6 +171,29 @@ test_that("the model set returns its nec annotation on the other scale too", {
 })
 
 
+test_that("the ecx annotation is transformed while the curve is not", {
+  # The other annotation. R/autoplot.R:316 passes xform to ecx() outside the
+  # guard, exactly as :313 does to bind_nec(), and until this assertion was
+  # added the ecx half of the claim made at the top of this file was not read:
+  # gating ecx() alone left every assertion in the branch passing.
+  #
+  # add_ecx is asserted nowhere else in the suite either, so this is also the
+  # only observer of R/autoplot.R:315-318 and of bind_ecx().
+  #
+  # Measured on nec4param with xform = x * 100: max(x_e) is 3.22 with and
+  # without xform, while the largest ecx_vals changes from 1.56 to 156.4.
+  #
+  # INVERT THIS TEST WHEN #268 IS FIXED, with its siblings above.
+  skip_on_cran()
+  f <- transformed_response_fit(nec4param, "nec4param")
+  plain <- suppressMessages(ggbnec_data(f, add_ecx = TRUE))
+  scaled <- suppressMessages(ggbnec_data(f, add_ecx = TRUE,
+                                         xform = function(x) x * 100))
+  expect_equal(max(scaled$ecx_vals, na.rm = TRUE),
+               max(plain$ecx_vals, na.rm = TRUE) * 100, tolerance = 1e-8)
+})
+
+
 # ---- autoplot itself --------------------------------------------------------
 
 test_that("autoplot returns a ggplot for both fit classes", {

--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -1,7 +1,10 @@
 # autoplot() and ggbnec_data() had no test file of their own in any release.
-# The eleven plot-related lines scattered through test-bayesnec_methods.R,
-# test-bayesmanec_methods.R and test-expand_classes.R assert that a ggplot
-# comes back, and nothing else -- in particular xform, which exists so that a
+# Nine plot-related lines are scattered through test-bayesnec_methods.R,
+# test-bayesmanec_methods.R and test-expand_classes.R, and only one of them,
+# test-expand_classes.R:323, concerns autoplot() at all: it asserts that a
+# ggplot comes back, and nothing else. The other eight assert that base plot()
+# returns NULL invisibly and silently, which is test-plot.R's subject. In
+# particular xform, which exists so that a
 # fit on a transformed predictor can be drawn on the recorded scale, has never
 # been asserted anywhere on the plotting path. It is asserted only on the
 # estimators, in test-ecx.R, test-nec.R, test-nsec.R, test-ecnsec.R and
@@ -188,6 +191,21 @@ test_that("the ecx annotation is transformed while the curve is not", {
   f <- transformed_response_fit(nec4param, "nec4param")
   plain <- suppressMessages(ggbnec_data(f, add_ecx = TRUE))
   scaled <- suppressMessages(ggbnec_data(f, add_ecx = TRUE,
+                                         xform = function(x) x * 100))
+  expect_equal(max(scaled$ecx_vals, na.rm = TRUE),
+               max(plain$ecx_vals, na.rm = TRUE) * 100, tolerance = 1e-8)
+})
+
+
+test_that("the model set returns its ecx annotation on the other scale too", {
+  # R/autoplot.R:360 passes xform to ecx() on the bayesmanecfit branch, outside
+  # the guard at :352. The single-fit pin above does not observe it.
+  #
+  # INVERT THIS TEST WHEN #268 IS FIXED, with its siblings above.
+  skip_on_cran()
+  m <- transformed_response_manec(manec_example)
+  plain <- suppressMessages(ggbnec_data(m, add_ecx = TRUE))
+  scaled <- suppressMessages(ggbnec_data(m, add_ecx = TRUE,
                                          xform = function(x) x * 100))
   expect_equal(max(scaled$ecx_vals, na.rm = TRUE),
                max(plain$ecx_vals, na.rm = TRUE) * 100, tolerance = 1e-8)

--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -7,55 +7,43 @@
 # estimators, in test-ecx.R, test-nec.R, test-nsec.R, test-ecnsec.R and
 # test-average_estimates.R.
 #
-# That gap is #268: the decision to apply xform is made with an all-or-nothing
-# guard on the formula as a whole, so a transformation on the RESPONSE
-# suppresses xform on the PREDICTOR axis. The issue records that it could only
-# be read from source, because no packaged fit transforms its response. It can
-# in fact be reproduced without fitting anything, by giving a stored fit a
-# formula that transforms its response, and that is done below.
+# That gap is #268, and the defect is not that xform is ignored. The decision
+# to apply it is made with an all-or-nothing guard on the formula as a whole
+# (R/autoplot.R:308 and :352), so a transformation on the RESPONSE suppresses
+# xform on the PREDICTOR axis -- but the nec and ecx annotations are
+# transformed unconditionally at R/autoplot.R:313-318, outside that guard. The
+# curve and its annotation therefore come back on different scales. Both halves
+# are asserted below, because a fix that corrects either one alone leaves the
+# figure wrong.
 #
-# Nothing here fits a model. Every assertion runs off manec_example.
-
-ap_fit <- function() {
-  data(manec_example, package = "bayesnec")
-  suppressMessages(pull_out(manec_example, model = "nec4param"))
-}
-
-ap_manec <- function() {
-  data(manec_example, package = "bayesnec")
-  manec_example
-}
-
-# Give a stored fit a formula that transforms its response and nothing else.
-# exp() is used rather than log() because manec_example's response reaches
-# -6.9, and log() of it is NaN; the point is only that a transformation is
-# present on the response, not which one.
-ap_transform_response <- function(fit) {
-  fit$bayesnecformula <- bayesnecformula(exp(y) ~ crf(x, model = "nec4param"))
-  fit
-}
-
-ap_x_max <- function(obj, ...) {
-  max(suppressMessages(ggbnec_data(obj, ...))$x_e, na.rm = TRUE)
-}
+# The issue records that this could only be read from source, because no
+# packaged fit transforms its response. It is reproduced here with no fitting,
+# using transformed_response_fit() from setup.R.
+#
+# Nothing here fits a model. Every assertion runs off nec4param and
+# manec_example, both built in setup.R. gg_x_max() is defined there too,
+# because test-plot.R needs it to compare the two paths.
 
 
 # ---- what ggbnec_data returns -----------------------------------------------
 
 test_that("ggbnec_data returns the columns autoplot draws from", {
-  d <- suppressMessages(ggbnec_data(ap_fit()))
+  skip_on_cran()
+  d <- suppressMessages(ggbnec_data(nec4param))
   expect_true(all(c("x_e", "y_e", "y_ci", "x_r", "y_r") %in% names(d)))
   expect_gt(nrow(d), 0)
 })
 
 test_that("ggbnec_data returns the same frame shape for a model set", {
-  d <- suppressMessages(ggbnec_data(ap_manec()))
+  skip_on_cran()
+  d <- suppressMessages(ggbnec_data(manec_example))
   expect_true(all(c("x_e", "y_e", "y_ci", "x_r", "y_r") %in% names(d)))
 })
 
 test_that("the nec annotation is present by default and suppressible", {
-  with_nec <- suppressMessages(ggbnec_data(ap_fit()))
-  without <- suppressMessages(ggbnec_data(ap_fit(), add_nec = FALSE))
+  skip_on_cran()
+  with_nec <- suppressMessages(ggbnec_data(nec4param))
+  without <- suppressMessages(ggbnec_data(nec4param, add_nec = FALSE))
   expect_true("nec_vals" %in% names(with_nec))
   expect_false("nec_vals" %in% names(without))
 })
@@ -66,7 +54,8 @@ test_that("ggbnec_data takes add_nec, and absorbs nec = FALSE into dots", {
   # autoplot argument name does nothing at all: nec = FALSE is swallowed by
   # ... and the annotation is still computed and returned. Pinned as current
   # behaviour rather than asserted to be correct.
-  swallowed <- suppressMessages(ggbnec_data(ap_fit(), nec = FALSE))
+  skip_on_cran()
+  swallowed <- suppressMessages(ggbnec_data(nec4param, nec = FALSE))
   expect_true("nec_vals" %in% names(swallowed))
 })
 
@@ -74,76 +63,106 @@ test_that("ggbnec_data takes add_nec, and absorbs nec = FALSE into dots", {
 # ---- xform on the predictor axis --------------------------------------------
 
 test_that("xform is applied to the predictor axis of a single fit", {
-  f <- ap_fit()
-  expect_equal(ap_x_max(f, xform = function(x) x * 100),
-               ap_x_max(f) * 100, tolerance = 1e-8)
+  skip_on_cran()
+  expect_equal(gg_x_max(nec4param, xform = function(x) x * 100),
+               gg_x_max(nec4param) * 100, tolerance = 1e-8)
 })
 
 test_that("xform is applied to the predictor axis of a model set", {
-  m <- ap_manec()
-  expect_equal(ap_x_max(m, xform = function(x) x * 100),
-               ap_x_max(m) * 100, tolerance = 1e-8)
+  skip_on_cran()
+  expect_equal(gg_x_max(manec_example, xform = function(x) x * 100),
+               gg_x_max(manec_example) * 100, tolerance = 1e-8)
 })
 
 test_that("xform reaches the raw data as well as the fitted curve", {
-  f <- ap_fit()
-  plain <- suppressMessages(ggbnec_data(f))
-  scaled <- suppressMessages(ggbnec_data(f, xform = function(x) x * 100))
+  skip_on_cran()
+  plain <- suppressMessages(ggbnec_data(nec4param))
+  scaled <- suppressMessages(ggbnec_data(nec4param,
+                                         xform = function(x) x * 100))
   expect_equal(max(scaled$x_r, na.rm = TRUE),
                max(plain$x_r, na.rm = TRUE) * 100, tolerance = 1e-8)
 })
 
-test_that("the transformation predicate answers per variable", {
-  f <- ap_transform_response(ap_fit())
+
+# ---- #268, pinned on both halves of the frame -------------------------------
+
+test_that("find_transformations reports the response for this fixture", {
+  # The premise the four pinning tests below rest on: the predictor is not
+  # transformed in this formula, and the predicate the plotting paths read
+  # answers for the formula as a whole and so reports the response. That is
+  # what makes the guard fire on a predictor nobody transformed.
+  #
+  # Only the fixture property is asserted here. pop_var_is_transformed() itself
+  # is specified in test-fit_bayesnec.R.
+  skip_on_cran()
+  f <- transformed_response_fit(nec4param, "nec4param")
   bdat <- model.frame(f$bayesnecformula, data = f$fit$data,
                       run_par_checks = TRUE)
-  # The predictor is not transformed in this formula and the per-variable
-  # predicate says so; find_transformations(), which the plotting paths read,
-  # answers for the formula as a whole and reports the response.
-  expect_false(pop_var_is_transformed(bdat, "x_var"))
-  expect_true(pop_var_is_transformed(bdat, "y_var"))
   expect_identical(find_transformations(bdat), "y")
 })
 
 test_that("a transformed response suppresses xform on the predictor axis", {
-  # PINS THE #268 DEFECT, on the autoplot path (R/autoplot.R:306 and :350).
-  # xform is accepted and silently ignored, so the axis is drawn on the fitted
-  # scale while the caller asked for the recorded one. The estimates nec() and
-  # ecx() return are unaffected; this is the plot alone.
+  # PINS THE #268 DEFECT on the autoplot path for a bayesnecfit (the guard at
+  # R/autoplot.R:308). xform is accepted and silently dropped from the axis,
+  # so the curve comes back on the fitted scale while the caller asked for the
+  # recorded one. The estimates nec() and ecx() return are unaffected; this is
+  # the plot alone.
   #
-  # INVERT THIS TEST WHEN #268 IS FIXED: the two should then be equal, as they
-  # are in "xform is applied to the predictor axis of a single fit" above.
-  f <- ap_transform_response(ap_fit())
-  expect_equal(ap_x_max(f, xform = function(x) x * 100), ap_x_max(f),
+  # INVERT THIS TEST WHEN #268 IS FIXED: the two should then differ by the
+  # factor xform applies, as in "xform is applied to the predictor axis of a
+  # single fit" above.
+  skip_on_cran()
+  f <- transformed_response_fit(nec4param, "nec4param")
+  expect_equal(gg_x_max(f, xform = function(x) x * 100), gg_x_max(f),
                tolerance = 1e-8)
 })
 
 test_that("a transformed response suppresses xform for a model set too", {
-  # PINS THE #268 DEFECT on the bayesmanecfit branch. Same inversion applies.
-  m <- ap_manec()
-  # The model name has to be substituted into the formula text rather than
-  # referenced: crf() evaluates its model argument where the formula is used,
-  # not where it is written, so a variable reference is out of scope by then.
-  mod <- names(m$mod_fits)[1]
-  m$mod_fits[[1]]$bayesnecformula <- bayesnecformula(
-    stats::as.formula(paste0("exp(y) ~ crf(x, model = \"", mod, "\")"))
-  )
-  expect_equal(ap_x_max(m, xform = function(x) x * 100), ap_x_max(m),
+  # PINS THE #268 DEFECT on the bayesmanecfit branch (the guard at
+  # R/autoplot.R:352). Same inversion applies.
+  skip_on_cran()
+  m <- transformed_response_manec(manec_example)
+  expect_equal(gg_x_max(m, xform = function(x) x * 100), gg_x_max(m),
                tolerance = 1e-8)
+})
+
+test_that("the nec annotation is transformed while the axis is not", {
+  # PINS THE OTHER HALF OF #268, which the issue does not state.
+  # R/autoplot.R:313-318 pass xform to bind_nec() and to ecx() unconditionally,
+  # outside the guard, so the annotation column and the curve column come back
+  # on scales that differ by whatever xform does. Measured on nec4param with
+  # xform = x * 100: max(x_e) is 3.22 with and without xform, while nec_vals
+  # changes from 1.46 to 146.
+  #
+  # INVERT THIS TEST WHEN #268 IS FIXED: the two columns must then agree,
+  # whichever scale the fix settles on. A fix that changes only the guard, or
+  # only these lines, fails one of the two tests and leaves the other passing,
+  # which is the point of asserting both.
+  skip_on_cran()
+  f <- transformed_response_fit(nec4param, "nec4param")
+  plain <- suppressMessages(ggbnec_data(f))
+  scaled <- suppressMessages(ggbnec_data(f, xform = function(x) x * 100))
+  expect_equal(max(scaled$x_e, na.rm = TRUE), max(plain$x_e, na.rm = TRUE),
+               tolerance = 1e-8)
+  expect_equal(max(scaled$nec_vals, na.rm = TRUE),
+               max(plain$nec_vals, na.rm = TRUE) * 100, tolerance = 1e-8)
 })
 
 
 # ---- autoplot itself --------------------------------------------------------
 
 test_that("autoplot returns a ggplot for both fit classes", {
-  expect_s3_class(suppressMessages(autoplot(ap_fit())), "ggplot")
-  expect_s3_class(suppressMessages(autoplot(ap_manec())), "ggplot")
+  skip_on_cran()
+  expect_s3_class(suppressMessages(autoplot(nec4param)), "ggplot")
+  expect_s3_class(suppressMessages(autoplot(manec_example)), "ggplot")
 })
 
 test_that("autoplot accepts xform without error on both classes", {
+  skip_on_cran()
   expect_s3_class(
-    suppressMessages(autoplot(ap_fit(), xform = function(x) x * 100)), "ggplot")
+    suppressMessages(autoplot(nec4param, xform = function(x) x * 100)),
+    "ggplot")
   expect_s3_class(
-    suppressMessages(autoplot(ap_manec(), xform = function(x) x * 100)),
+    suppressMessages(autoplot(manec_example, xform = function(x) x * 100)),
     "ggplot")
 })

--- a/tests/testthat/test-check_data.R
+++ b/tests/testthat/test-check_data.R
@@ -256,16 +256,27 @@ test_that("is_censored returns a scalar FALSE that recycles", {
 
 test_that("get_priors builds its priors from the corrected response", {
   # R/get_priors.R:163. The Gamma zero shift must reach the prior, or top and
-  # bot are derived from a response the fit will never see.
+  # nec are derived from a response the fit will never see.
+  #
+  # Asserted by equality against the same data with the shift applied by hand,
+  # which is the only form of the assertion that discriminates. A finiteness
+  # check does not: the prior is finite either way. Measured, the top prior is
+  # gamma(2, 0.3077) from the corrected response and gamma(2, 0.25) from the
+  # uncorrected one, so the two frames differ if and only if the correction is
+  # bypassed.
   d <- cd_data_zero()
+  d_shifted <- d
+  # min(y[y > 0]) is 3, so check_data() shifts the zeros to 0.3.
+  d_shifted$y[d_shifted$y == 0] <- 0.3
   pr <- suppressMessages(
     get_priors(y ~ crf(x, model = "nec3param"), data = d,
                family = Gamma(link = "identity"))
   )
+  pr_shifted <- get_priors(y ~ crf(x, model = "nec3param"), data = d_shifted,
+                           family = Gamma(link = "identity"))
   expect_s3_class(pr, "brmsprior")
-  expect_true(all(is.finite(as.numeric(
-    gsub(".*\\(|,.*|\\)", "", pr$prior[pr$nlpar == "bot"])
-  ))))
+  expect_identical(pr$prior, pr_shifted$prior)
+  expect_identical(pr$nlpar, pr_shifted$nlpar)
 })
 
 test_that("has_family_changed reports a correction it then discards", {

--- a/tests/testthat/test-check_data.R
+++ b/tests/testthat/test-check_data.R
@@ -275,8 +275,10 @@ test_that("get_priors builds its priors from the corrected response", {
   pr_shifted <- get_priors(y ~ crf(x, model = "nec3param"), data = d_shifted,
                            family = Gamma(link = "identity"))
   expect_s3_class(pr, "brmsprior")
+  # The prior column alone. nlpar is decided by the model and the family, not
+  # by the five shifted values, so comparing it passes under the mutation this
+  # block exists to catch and asserts nothing the prior comparison does not.
   expect_identical(pr$prior, pr_shifted$prior)
-  expect_identical(pr$nlpar, pr_shifted$nlpar)
 })
 
 test_that("has_family_changed reports a correction it then discards", {

--- a/tests/testthat/test-check_data.R
+++ b/tests/testthat/test-check_data.R
@@ -283,8 +283,8 @@ test_that("has_family_changed reports a correction it then discards", {
   # has_family_changed() takes d by value and cannot alter it.
   #
   # INVERT THIS TEST WHEN #274 IS FIXED: either the message is no longer
-  # emitted from this route, or the return carries the corrected data frame and
-  # is no longer a bare logical.
+  # emitted from this route, or the return includes the corrected data frame
+  # and is no longer a bare logical.
   skip_on_cran()
   f <- nec4param
   d <- f$fit$data

--- a/tests/testthat/test-check_data.R
+++ b/tests/testthat/test-check_data.R
@@ -12,6 +12,8 @@
 #
 # What is deliberately NOT duplicated here, and where it lives:
 #   the write-back into brm()'s data frame  tests/testthat/test-fit_bayesnec.R
+#   the integer predictor guard             tests/testthat/test-fit_bayesnec.R
+#   pop_var_is_transformed()                tests/testthat/test-fit_bayesnec.R
 #   the censoring exemptions                tests/testthat/test-cens.R
 #   zeros preserved for a hurdle family     tests/testthat/test-hurdle_family.R
 #   check_normalisation()                   tests/testthat/test-check_normalisation.R
@@ -89,13 +91,6 @@ test_that("a hormesis model is exempt from the decline warning", {
   d$y <- rev(d$y)
   expect_no_warning(cd_run(y ~ crf(x, model = "nechorme"), d, gaussian(),
                            model = "nechorme"))
-})
-
-test_that("an integer predictor is refused from the data check", {
-  d <- cd_data_zero()
-  d$x <- as.integer(d$x * 10)
-  expect_error(cd_run(y ~ crf(x, model = "nec3param"), d, gaussian()),
-               "does not currently support integer concentration")
 })
 
 
@@ -275,23 +270,32 @@ test_that("get_priors builds its priors from the corrected response", {
 
 test_that("has_family_changed reports a correction it then discards", {
   # PINS THE #274 DEFECT. update() with newdata runs check_data() through
-  # has_family_changed(), which keeps only the family and drops the corrected
-  # data frame, so the user is told their data was repaired and the fit then
-  # fails on the condition that was reported repaired -- the #258 symptom on a
-  # route #258 did not cover.
+  # has_family_changed() (R/bnecfit-methods.R:171), which keeps only the family
+  # and drops the corrected data frame, so the user is told their data was
+  # repaired and the fit then fails on the condition that was reported
+  # repaired -- the #258 symptom on a route #258 did not cover.
   #
-  # INVERT THIS TEST WHEN #274 IS FIXED: the message should no longer be
-  # emitted from this route, or the correction should reach the caller.
+  # Two assertions, both of which can fail. The first is that the message is
+  # emitted from this route at all. The second is that the whole of what comes
+  # back is a length-one logical, which is what makes the correction
+  # unreachable by the caller: there is nowhere for the repaired data frame to
+  # go. Asserting the state of the local d instead would be a tautology --
+  # has_family_changed() takes d by value and cannot alter it.
+  #
+  # INVERT THIS TEST WHEN #274 IS FIXED: either the message is no longer
+  # emitted from this route, or the return carries the corrected data frame and
+  # is no longer a bare logical.
   skip_on_cran()
-  data(manec_example, package = "bayesnec")
-  f <- suppressMessages(pull_out(manec_example, model = "nec4param"))
+  f <- nec4param
   d <- f$fit$data
   d$y <- abs(d$y)
   d$y[1:3] <- 0
+  res <- NULL
   msgs <- capture.output(
-    invisible(has_family_changed(list(f), d, Gamma(link = "identity"))),
+    res <- has_family_changed(list(f), d, Gamma(link = "identity")),
     type = "message"
   )
   expect_true(any(grepl("shifted", msgs)))
-  expect_identical(sum(d$y == 0), 3L)
+  expect_type(res, "logical")
+  expect_length(res, 1)
 })

--- a/tests/testthat/test-check_data.R
+++ b/tests/testthat/test-check_data.R
@@ -128,6 +128,27 @@ test_that("a numeric group-level column errors from model.frame, not check_data"
 })
 
 
+test_that("check_custom_name is called and its result discarded", {
+  # R/check_data.R:211 assigns custom_name <- check_custom_name(family) and
+  # nothing reads it; custom_name occurs once in the file. check_custom_name()
+  # is pure (R/helpers.R:18-24), so the call has no effect at all. The same
+  # dead assignment is at R/plot.R:93, R/plot.R:263 and R/autoplot.R:178.
+  #
+  # Asserted by making the call return a value nothing could sensibly use and
+  # showing the result is unchanged, which pins the discard rather than the
+  # call. This is the third site of its kind in check_data(), after the two
+  # unreachable branches above, and it has no issue either.
+  d <- cd_data_zero()
+  plain <- cd_run(y ~ crf(x, model = "nec3param"), d, gaussian())
+  local_mocked_bindings(
+    check_custom_name = function(...) "a value no caller reads",
+    .package = "bayesnec"
+  )
+  expect_identical(cd_run(y ~ crf(x, model = "nec3param"), d, gaussian()),
+                   plain)
+})
+
+
 # ---- the response boundary corrections --------------------------------------
 #
 # The arithmetic and the messaging are asserted separately, because they do not

--- a/tests/testthat/test-check_data.R
+++ b/tests/testthat/test-check_data.R
@@ -1,0 +1,297 @@
+# check_data() had no test file of its own until this one, in any release. It
+# was exercised only from the side, as a step on the way to testing
+# fit_bayesnec(), get_priors(), inits_functions(), cens and hurdle_family, and
+# five defects have been found in it in two weeks: #258, #265, #269, #271 and
+# #274. Four of the five are the same shape -- a branch that cannot be reached,
+# or a correction that reaches one caller and not another -- which is what a
+# test written from the caller's side cannot see.
+#
+# So this file specifies check_data() as a function rather than as a step: its
+# guards, the arithmetic and the messaging of each correction it makes, the
+# shape of what it returns, and what each of its callers does with the result.
+#
+# What is deliberately NOT duplicated here, and where it lives:
+#   the write-back into brm()'s data frame  tests/testthat/test-fit_bayesnec.R
+#   the censoring exemptions                tests/testthat/test-cens.R
+#   zeros preserved for a hurdle family     tests/testthat/test-hurdle_family.R
+#   check_normalisation()                   tests/testthat/test-check_normalisation.R
+
+# Build the model frame the way bnec() does, which is the only route any caller
+# uses. Asserting through it rather than on a hand-built data frame is what
+# makes the two unreachable-branch tests below meaningful.
+cd_bdat <- function(formula, data) {
+  model.frame(bayesnecformula(formula), data = data, run_par_checks = TRUE)
+}
+
+cd_run <- function(formula, data, family, model = "nec3param") {
+  check_data(cd_bdat(formula, data), family, model)
+}
+
+# The messages check_data() emits, as a character vector. Several corrections
+# are silent, and asserting the absence of a message is half of what this file
+# is for, so the helper returns them rather than swallowing them.
+cd_messages <- function(formula, data, family, model = "nec3param") {
+  capture.output(invisible(cd_run(formula, data, family, model)),
+                 type = "message")
+}
+
+# A declining Gamma-shaped response whose top concentration is all zeros.
+cd_data_zero <- function() {
+  data.frame(x = rep(c(0.1, 1, 10, 100), each = 5),
+             y = c(rep(c(8, 6, 3), each = 5), rep(0, 5)))
+}
+
+# A proportion response touching both boundaries of the Beta support.
+cd_data_bounded <- function() {
+  data.frame(x = rep(c(0.1, 1, 10, 100), each = 5),
+             y = c(rep(1, 5), rep(0.6, 5), rep(0.3, 5), rep(0, 5)))
+}
+
+
+# ---- guards -----------------------------------------------------------------
+
+test_that("a non-finite predictor is refused, naming the predictor", {
+  d <- cd_data_zero()
+  d$x[1] <- Inf
+  expect_error(cd_run(y ~ crf(x, model = "nec3param"), d, gaussian()),
+               "predictor column contains values that are not finite")
+})
+
+test_that("a non-finite response is refused, naming the response", {
+  d <- cd_data_zero()
+  d$y[1] <- Inf
+  expect_error(cd_run(y ~ crf(x, model = "nec3param"), d, gaussian()),
+               "response column contains values that are not finite")
+})
+
+test_that("an NA or NaN row is dropped by model.frame, not caught by the check", {
+  # The finiteness guard sees only what model.frame() passes it, and
+  # model.frame() drops incomplete cases first. So Inf reaches the guard and is
+  # refused, while NA and NaN are removed silently and the fit proceeds on
+  # fewer rows than the user supplied. Pinned because the two behave
+  # differently and neither is announced; it is the same class of gap as #271,
+  # where a disp() sub-model is not checked for finiteness at all.
+  d <- cd_data_zero()
+  d$y[1] <- NaN
+  res <- cd_run(y ~ crf(x, model = "nec3param"), d, gaussian())
+  expect_identical(nrow(res$mod_dat), nrow(d) - 1L)
+})
+
+test_that("a response that increases with the predictor warns", {
+  d <- cd_data_zero()
+  d$y <- rev(d$y)
+  expect_warning(cd_run(y ~ crf(x, model = "nec3param"), d, gaussian()),
+                 "only allows for response values to decline")
+})
+
+test_that("a hormesis model is exempt from the decline warning", {
+  d <- cd_data_zero()
+  d$y <- rev(d$y)
+  expect_no_warning(cd_run(y ~ crf(x, model = "nechorme"), d, gaussian(),
+                           model = "nechorme"))
+})
+
+test_that("an integer predictor is refused from the data check", {
+  d <- cd_data_zero()
+  d$x <- as.integer(d$x * 10)
+  expect_error(cd_run(y ~ crf(x, model = "nec3param"), d, gaussian()),
+               "does not currently support integer concentration")
+})
+
+
+# ---- two guards in check_data() that nothing can reach -----------------------
+#
+# Both branches below are written in check_data() and neither can fire, because
+# an earlier call raises first on the same input. They are pinned rather than
+# removed: a test that names the reachable error is what tells the next reader
+# that the branch underneath it is dead, and #265 is the precedent for a
+# condition that was written, never fired, and went unnoticed for five years.
+
+test_that("a character predictor errors from retrieve_var, not check_data", {
+  d <- cd_data_zero()
+  d$x <- as.character(d$x)
+  # check_data():112-118 composes "Your indicated predictor column ... requires
+  # the predictor column to be numeric". retrieve_var(error = TRUE) at :108
+  # raises first, so that message can never be produced.
+  msg <- tryCatch(cd_run(y ~ crf(x, model = "nec3param"), d, gaussian()),
+                  error = conditionMessage)
+  expect_match(msg, "is not numeric")
+  expect_false(grepl("indicated predictor column", msg))
+})
+
+test_that("a numeric group-level column errors from model.frame, not check_data", {
+  d <- cd_data_zero()
+  d$grp <- rep(1:2, 10)
+  # check_data():203-209 composes "Your group-level column(s) ... must be either
+  # a character or a factor". model.frame() refuses first, so that message can
+  # never be produced either.
+  msg <- tryCatch(cd_run(y ~ crf(x, model = "nec3param") + ogl(grp), d,
+                         gaussian()),
+                  error = conditionMessage)
+  expect_match(msg, "Group-level variables cannot be numeric")
+  expect_false(grepl("must be either a character or a factor", msg))
+})
+
+
+# ---- the response boundary corrections --------------------------------------
+#
+# The arithmetic and the messaging are asserted separately, because they do not
+# agree: one of the three corrections speaks and two are silent. That asymmetry
+# is what #93 was reopened on, so it is pinned here as a value rather than left
+# as a claim in an issue comment.
+
+test_that("a Gamma zero is shifted by one tenth of the smallest non-zero value", {
+  res <- suppressMessages(cd_run(y ~ crf(x, model = "nec3param"),
+                                 cd_data_zero(), Gamma(link = "identity")))
+  # min(y[y > 0]) is 3, so the zeros become 0.3 and nothing else changes.
+  expect_identical(sort(unique(res$mod_dat$y)), c(0.3, 3, 6, 8))
+})
+
+test_that("the Gamma zero shift is reported, and names the remedy", {
+  msg <- paste(cd_messages(y ~ crf(x, model = "nec3param"), cd_data_zero(),
+                           Gamma(link = "identity")), collapse = " ")
+  expect_match(msg, "shifted to 0\\.3")
+  expect_match(msg, "hurdle_gamma")
+})
+
+test_that("a beta zero is shifted by the same rule", {
+  res <- cd_run(y ~ crf(x, model = "nec3param"), cd_data_bounded(),
+                Beta(link = "identity"))
+  # min(y[y > 0]) is 0.3, so the zeros become 0.03.
+  expect_true(0.03 %in% round(res$mod_dat$y, 10))
+  expect_false(any(res$mod_dat$y == 0))
+})
+
+test_that("a beta one is reduced by exactly 0.001", {
+  res <- cd_run(y ~ crf(x, model = "nec3param"), cd_data_bounded(),
+                Beta(link = "identity"))
+  expect_true(0.999 %in% round(res$mod_dat$y, 10))
+  expect_false(any(res$mod_dat$y == 1))
+})
+
+test_that("both beta corrections are silent, unlike the Gamma one", {
+  # Pins the #93 measurement. If either correction is given a message, this
+  # assertion fails and #93 is the issue to read before changing it.
+  expect_length(cd_messages(y ~ crf(x, model = "nec3param"),
+                            cd_data_bounded(), Beta(link = "identity")), 0)
+})
+
+test_that("zero_inflated_beta keeps its zeros and loses its ones", {
+  res <- cd_run(y ~ crf(x, model = "nec3param"), cd_data_bounded(),
+                brms::zero_inflated_beta(link = "identity"))
+  # The zeros are the signal the zi block identifies itself from; the ones are
+  # still outside Beta's open support and must go.
+  expect_true(any(res$mod_dat$y == 0))
+  expect_false(any(res$mod_dat$y == 1))
+})
+
+test_that("a family with no excluded boundary leaves the response alone", {
+  d <- cd_data_zero()
+  res <- cd_run(y ~ crf(x, model = "nec3param"), d, gaussian())
+  expect_identical(res$mod_dat$y, d$y)
+  expect_length(cd_messages(y ~ crf(x, model = "nec3param"), d, gaussian()), 0)
+})
+
+test_that("the predictor reaches the fit exactly as recorded", {
+  # #269 removed all three predictor corrections. A zero control is an ordinary
+  # control: no family constrains the support of a predictor.
+  d <- cd_data_zero()
+  d$x <- rep(c(0, 1, 10, 100), each = 5)
+  res <- suppressMessages(cd_run(y ~ crf(x, model = "nec3param"), d,
+                                 Gamma(link = "identity")))
+  expect_identical(res$mod_dat$x, d$x)
+})
+
+test_that("a 0-1 bounded predictor keeps both of its bounds", {
+  # #265: check_data() tested x_type == "beta" while set_distribution() returns
+  # "Beta", so these two branches never fired in any release. #269 removed them
+  # rather than repairing them, and this pins that they stay removed.
+  d <- data.frame(x = rep(c(0, 0.25, 0.5, 1), each = 5),
+                  y = rep(c(8, 6, 3, 1), each = 5))
+  res <- cd_run(y ~ crf(x, model = "nec3param"), d, Gamma(link = "identity"))
+  expect_identical(range(res$mod_dat$x), c(0, 1))
+})
+
+
+# ---- the shape of what is returned ------------------------------------------
+
+test_that("check_data returns mod_dat and the family, and nothing else", {
+  res <- cd_run(y ~ crf(x, model = "nec3param"), cd_data_zero(), gaussian())
+  expect_named(res, c("mod_dat", "family"))
+  expect_named(res$mod_dat, c("x", "y", "trials"))
+  expect_s3_class(res$family, "family")
+})
+
+test_that("trials come from the trials variable for a binomial family", {
+  d <- data.frame(x = rep(c(0.1, 1, 10, 100), each = 5),
+                  suc = as.integer(rep(c(9, 7, 4, 1), each = 5)),
+                  tot = as.integer(rep(10, 20)))
+  res <- cd_run(suc | trials(tot) ~ crf(x, model = "nec3param"), d,
+                binomial(link = "identity"))
+  expect_identical(res$mod_dat$trials, d$tot)
+})
+
+test_that("a rate() term adds the denominator under its own name", {
+  d <- data.frame(x = rep(c(0.1, 1, 10, 100), each = 5),
+                  y = as.integer(rep(c(20, 15, 8, 2), each = 5)),
+                  n = rep(2, 20))
+  res <- cd_run(y | rate(n) ~ crf(x, model = "nec3param"), d,
+                poisson(link = "identity"))
+  # Named denom rather than rate: it is the denominator of the rate, not the
+  # rate. See R/check_data.R.
+  expect_true("denom" %in% names(res$mod_dat))
+  expect_identical(unique(res$mod_dat$denom), 2)
+})
+
+test_that("is_censored returns a scalar FALSE that recycles", {
+  # The contract the boundary corrections depend on: with no cens() term the
+  # result must recycle harmlessly against a response of any length.
+  expect_identical(is_censored(NULL), FALSE)
+  expect_length(is_censored(NULL) & rep(TRUE, 3), 3)
+  expect_identical(is_censored(c(0, -1, 1, NA)), c(FALSE, TRUE, TRUE, FALSE))
+})
+
+
+# ---- what each caller does with the result ----------------------------------
+#
+# check_data() has three call sites in R/ and they do not agree on what to do
+# with the corrected data frame it returns. #258 was one caller getting it
+# wrong; #274 is a second, found four days later. Enumerating them here is what
+# makes the next one visible without another user report.
+
+test_that("get_priors builds its priors from the corrected response", {
+  # R/get_priors.R:163. The Gamma zero shift must reach the prior, or top and
+  # bot are derived from a response the fit will never see.
+  d <- cd_data_zero()
+  pr <- suppressMessages(
+    get_priors(y ~ crf(x, model = "nec3param"), data = d,
+               family = Gamma(link = "identity"))
+  )
+  expect_s3_class(pr, "brmsprior")
+  expect_true(all(is.finite(as.numeric(
+    gsub(".*\\(|,.*|\\)", "", pr$prior[pr$nlpar == "bot"])
+  ))))
+})
+
+test_that("has_family_changed reports a correction it then discards", {
+  # PINS THE #274 DEFECT. update() with newdata runs check_data() through
+  # has_family_changed(), which keeps only the family and drops the corrected
+  # data frame, so the user is told their data was repaired and the fit then
+  # fails on the condition that was reported repaired -- the #258 symptom on a
+  # route #258 did not cover.
+  #
+  # INVERT THIS TEST WHEN #274 IS FIXED: the message should no longer be
+  # emitted from this route, or the correction should reach the caller.
+  skip_on_cran()
+  data(manec_example, package = "bayesnec")
+  f <- suppressMessages(pull_out(manec_example, model = "nec4param"))
+  d <- f$fit$data
+  d$y <- abs(d$y)
+  d$y[1:3] <- 0
+  msgs <- capture.output(
+    invisible(has_family_changed(list(f), d, Gamma(link = "identity"))),
+    type = "message"
+  )
+  expect_true(any(grepl("shifted", msgs)))
+  expect_identical(sum(d$y == 0), 3L)
+})

--- a/tests/testthat/test-check_data.R
+++ b/tests/testthat/test-check_data.R
@@ -128,7 +128,7 @@ test_that("a numeric group-level column errors from model.frame, not check_data"
 })
 
 
-test_that("check_custom_name is called and its result discarded", {
+test_that("the check_custom_name result is discarded", {
   # R/check_data.R:211 assigns custom_name <- check_custom_name(family) and
   # nothing reads it; custom_name occurs once in the file. check_custom_name()
   # is pure (R/helpers.R:18-24), so the call has no effect at all. The same

--- a/tests/testthat/test-check_data.R
+++ b/tests/testthat/test-check_data.R
@@ -131,7 +131,7 @@ test_that("a numeric group-level column errors from model.frame, not check_data"
 # ---- the response boundary corrections --------------------------------------
 #
 # The arithmetic and the messaging are asserted separately, because they do not
-# agree: one of the three corrections speaks and two are silent. That asymmetry
+# agree: one of the three corrections is announced and two are not. That asymmetry
 # is what #93 was reopened on, so it is pinned here as a value rather than left
 # as a claim in an issue comment.
 

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -15,7 +15,7 @@
 # on the PREDICTOR axis -- but the nec and ec10 annotations are transformed
 # unconditionally at R/plot.R:130-131, outside that guard. The two halves of
 # the figure are therefore drawn on different scales, and the abline() at
-# R/plot.R:179 lands off the end of the axis. Both halves are asserted below,
+# R/plot.R:180 lands off the end of the axis. Both halves are asserted below,
 # because a fix that corrects either one alone leaves the figure wrong.
 #
 # The issue records that this could only be read from source. It is reproduced
@@ -103,7 +103,7 @@ test_that("the nec annotation is drawn off the end of the axis", {
   # that added this file originally described as xform being "silently
   # skipped". It is not skipped. R/plot.R:130-131 apply it to nec and ec10
   # unconditionally, outside the guard, so with a transformed response the
-  # abline() at R/plot.R:179 is drawn at the transformed NEC on an axis left
+  # abline() at R/plot.R:180 is drawn at the transformed NEC on an axis left
   # untransformed, and the line is not on the figure at all.
   #
   # abline() is intercepted rather than the value recomputed here: what has to

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -15,7 +15,7 @@
 # on the PREDICTOR axis -- but the nec and ec10 annotations are transformed
 # unconditionally at R/plot.R:130-131, outside that guard. The two halves of
 # the figure are therefore drawn on different scales, and the abline() at
-# R/plot.R:180 lands off the end of the axis. Both halves are asserted below,
+# R/plot.R:180 is drawn beyond the axis limit. Both halves are asserted below,
 # because a fix that corrects either one alone leaves the figure wrong.
 #
 # The issue records that this could only be read from source. It is reproduced
@@ -66,7 +66,9 @@ test_that("all_models draws a panel per candidate, named", {
   )
   pl_x_max(manec_example, all_models = TRUE)
   expect_true(all(names(manec_example$mod_fits) %in% labels))
-  # And not otherwise: the model-average plot draws one panel and names none.
+  # And not otherwise. The model-average plot does call legend(), at
+  # R/plot.R:333, but with the estimate string rather than a model name, so no
+  # candidate name appears.
   labels <- character()
   pl_x_max(manec_example, all_models = FALSE)
   expect_false(any(names(manec_example$mod_fits) %in% labels))
@@ -74,18 +76,35 @@ test_that("all_models draws a panel per candidate, named", {
 
 test_that("add_nec and add_ec10 decide what is annotated", {
   # Same reasoning: silence is not evidence that either argument was read.
-  # The three branches at R/plot.R:179-192 are mutually exclusive, so counting
-  # the abline() calls says which one was taken.
+  # The three branches at R/plot.R:179-192 are mutually exclusive, so the
+  # abline() calls are counted AND their values identified. Counting alone does
+  # not discriminate: one call is drawn whether the branch taken is the nec or
+  # the ec10, so swapping R/plot.R:190 to draw ec10 in the nec branch would
+  # pass a count-only assertion.
   skip_on_cran()
   drawn <- list()
   local_mocked_bindings(
     abline = function(v = NULL, ...) drawn[[length(drawn) + 1L]] <<- v,
     .package = "bayesnec"
   )
+  # Neither annotation: no vertical line at all.
   pl_x_max(nec4param, add_nec = FALSE)
   expect_length(drawn, 0)
-  pl_x_max(nec4param, add_nec = TRUE, add_ec10 = TRUE)
+  # The nec alone, drawn at the NEC estimate and its two bounds.
+  pl_x_max(nec4param, add_nec = TRUE)
+  expect_length(drawn, 1)
+  expect_equal(unname(drawn[[1]]), unname(nec4param$ne), tolerance = 1e-8)
+  # The ec10 alone. manec_example is gaussian, so R/plot.R:114-115 takes the
+  # relative branch (R/plot.R:114-115); the value is not asserted here beyond
+  # its being a different one, because ecx() is under test in test-ecx.R.
+  pl_x_max(nec4param, add_nec = FALSE, add_ec10 = TRUE)
   expect_length(drawn, 2)
+  expect_false(isTRUE(all.equal(unname(drawn[[2]]), unname(nec4param$ne))))
+  # Both, in the documented order: the nec in red, then the ec10 in orange.
+  pl_x_max(nec4param, add_nec = TRUE, add_ec10 = TRUE)
+  expect_length(drawn, 4)
+  expect_equal(unname(drawn[[3]]), unname(nec4param$ne), tolerance = 1e-8)
+  expect_equal(unname(drawn[[4]]), unname(drawn[[2]]), tolerance = 1e-8)
 })
 
 

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -1,0 +1,120 @@
+# plot() for the bayesnec classes had no test file of its own in any release.
+# What coverage existed asserted that the call did not error; nothing asserted
+# what was drawn.
+#
+# The base-graphics paths cannot be inspected by reading a returned object, so
+# the assertions here read the device instead: plotting to a null pdf() device
+# and reading par("usr") gives the x-axis limits the call actually produced.
+# That is enough to assert the one thing about these paths that has been
+# reported wrong -- whether xform reached the predictor axis -- without
+# comparing images.
+#
+# #268 is the defect: the decision to apply xform is made with an
+# all-or-nothing guard on the formula as a whole (R/plot.R:119 and :259), so a
+# transformation on the RESPONSE suppresses xform on the PREDICTOR axis. The
+# issue records that it could only be read from source. It is reproduced here
+# with no fitting, by giving a stored fit a formula that transforms its
+# response.
+#
+# Nothing here fits a model. Every assertion runs off manec_example.
+
+pl_fit <- function() {
+  data(manec_example, package = "bayesnec")
+  suppressMessages(pull_out(manec_example, model = "nec4param"))
+}
+
+pl_manec <- function() {
+  data(manec_example, package = "bayesnec")
+  manec_example
+}
+
+# exp() rather than log(): manec_example's response reaches -6.9 and log() of
+# it is NaN. Only the presence of a transformation on the response matters.
+pl_transform_response <- function(fit) {
+  fit$bayesnecformula <- bayesnecformula(exp(y) ~ crf(x, model = "nec4param"))
+  fit
+}
+
+# The x-axis limits the call produced, read off the device rather than from a
+# returned object, because these are base-graphics methods that return nothing.
+pl_x_limits <- function(obj, ...) {
+  pdf(NULL)
+  on.exit(dev.off(), add = TRUE)
+  suppressMessages(plot(obj, ...))
+  par("usr")[1:2]
+}
+
+
+# ---- the call completes for each class and argument combination -------------
+
+test_that("plot draws a single fit and a model set", {
+  expect_silent(pl_x_limits(pl_fit()))
+  expect_silent(pl_x_limits(pl_manec()))
+})
+
+test_that("plot draws every candidate model when asked", {
+  expect_silent(pl_x_limits(pl_manec(), all_models = TRUE))
+})
+
+test_that("plot accepts the annotation arguments", {
+  expect_silent(pl_x_limits(pl_fit(), add_nec = FALSE))
+  expect_silent(pl_x_limits(pl_fit(), add_ec10 = TRUE))
+})
+
+
+# ---- xform on the predictor axis --------------------------------------------
+
+test_that("xform widens the predictor axis of a single fit", {
+  f <- pl_fit()
+  plain <- pl_x_limits(f)
+  scaled <- pl_x_limits(f, xform = function(x) x * 100)
+  expect_equal(scaled, plain * 100, tolerance = 1e-6)
+})
+
+test_that("xform widens the predictor axis of a model set", {
+  m <- pl_manec()
+  plain <- pl_x_limits(m)
+  scaled <- pl_x_limits(m, xform = function(x) x * 100)
+  expect_equal(scaled, plain * 100, tolerance = 1e-6)
+})
+
+test_that("a transformed response suppresses xform on the predictor axis", {
+  # PINS THE #268 DEFECT on the base-plot path for a bayesnecfit
+  # (R/plot.R:119). xform is accepted and silently ignored, so the axis is
+  # drawn on the fitted scale while the caller asked for the recorded one.
+  #
+  # INVERT THIS TEST WHEN #268 IS FIXED: the two should then differ by the
+  # factor xform applies, as in "xform widens the predictor axis of a single
+  # fit" above.
+  f <- pl_transform_response(pl_fit())
+  expect_equal(pl_x_limits(f, xform = function(x) x * 100), pl_x_limits(f),
+               tolerance = 1e-6)
+})
+
+test_that("a transformed response suppresses xform for a model set too", {
+  # PINS THE #268 DEFECT on the bayesmanecfit branch (R/plot.R:259). Same
+  # inversion applies.
+  m <- pl_manec()
+  # The model name is substituted into the formula text rather than
+  # referenced: crf() evaluates its model argument where the formula is used,
+  # not where it is written.
+  mod <- names(m$mod_fits)[1]
+  m$mod_fits[[1]]$bayesnecformula <- bayesnecformula(
+    stats::as.formula(paste0("exp(y) ~ crf(x, model = \"", mod, "\")"))
+  )
+  expect_equal(pl_x_limits(m, xform = function(x) x * 100), pl_x_limits(m),
+               tolerance = 1e-6)
+})
+
+test_that("plot and autoplot agree on the predictor axis", {
+  # The two paths make the xform decision independently, in four places
+  # altogether. They agree today; this is what would catch one being fixed for
+  # #268 without the other.
+  f <- pl_fit()
+  gg <- suppressMessages(ggbnec_data(f, xform = function(x) x * 100))
+  base_max <- pl_x_limits(f, xform = function(x) x * 100)[2]
+  # The device pads the axis beyond the data, so the fitted range must fall
+  # inside the drawn range rather than equal it.
+  expect_lt(max(gg$x_e, na.rm = TRUE), base_max)
+  expect_gt(max(gg$x_e, na.rm = TRUE), base_max * 0.9)
+})

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -9,112 +9,136 @@
 # reported wrong -- whether xform reached the predictor axis -- without
 # comparing images.
 #
-# #268 is the defect: the decision to apply xform is made with an
-# all-or-nothing guard on the formula as a whole (R/plot.R:119 and :259), so a
-# transformation on the RESPONSE suppresses xform on the PREDICTOR axis. The
-# issue records that it could only be read from source. It is reproduced here
-# with no fitting, by giving a stored fit a formula that transforms its
-# response.
+# #268 is the defect, and it is not that xform is ignored. The decision to
+# apply it is made with an all-or-nothing guard on the formula as a whole
+# (R/plot.R:125 and :279), so a transformation on the RESPONSE suppresses xform
+# on the PREDICTOR axis -- but the nec and ec10 annotations are transformed
+# unconditionally at R/plot.R:130-131, outside that guard. The two halves of
+# the figure are therefore drawn on different scales, and the abline() at
+# R/plot.R:179 lands off the end of the axis. Both halves are asserted below,
+# because a fix that corrects either one alone leaves the figure wrong.
 #
-# Nothing here fits a model. Every assertion runs off manec_example.
-
-pl_fit <- function() {
-  data(manec_example, package = "bayesnec")
-  suppressMessages(pull_out(manec_example, model = "nec4param"))
-}
-
-pl_manec <- function() {
-  data(manec_example, package = "bayesnec")
-  manec_example
-}
-
-# exp() rather than log(): manec_example's response reaches -6.9 and log() of
-# it is NaN. Only the presence of a transformation on the response matters.
-pl_transform_response <- function(fit) {
-  fit$bayesnecformula <- bayesnecformula(exp(y) ~ crf(x, model = "nec4param"))
-  fit
-}
+# The issue records that this could only be read from source. It is reproduced
+# here with no fitting, using transformed_response_fit() from setup.R.
+#
+# Nothing here fits a model. Every assertion runs off nec4param and
+# manec_example, both built in setup.R.
 
 # The x-axis limits the call produced, read off the device rather than from a
 # returned object, because these are base-graphics methods that return nothing.
-pl_x_limits <- function(obj, ...) {
+# No suppression: an assertion of silence made through a helper that suppresses
+# messages cannot fail, and these methods are silent today.
+pl_x_max <- function(obj, ...) {
   pdf(NULL)
   on.exit(dev.off(), add = TRUE)
-  suppressMessages(plot(obj, ...))
-  par("usr")[1:2]
+  plot(obj, ...)
+  par("usr")[2]
+}
+
+# The factor by which xform changed the axis. A ratio rather than a pair of
+# limits: it is scale-free, so it does not encode base graphics' 4% default
+# axis expansion the way a comparison against a fixed number would, and it is
+# directly comparable with the same ratio taken from the ggplot2 path.
+pl_x_ratio <- function(obj) {
+  pl_x_max(obj, xform = function(x) x * 100) / pl_x_max(obj)
 }
 
 
-# ---- the call completes for each class and argument combination -------------
-
-test_that("plot draws a single fit and a model set", {
-  expect_silent(pl_x_limits(pl_fit()))
-  expect_silent(pl_x_limits(pl_manec()))
-})
+# ---- the argument combinations nothing else covers --------------------------
+#
+# plot() on a plain bayesnecfit and bayesmanecfit is already asserted silent
+# and invisible in test-bayesnec_methods.R and test-bayesmanec_methods.R, so it
+# is not repeated. all_models, add_nec and add_ec10 are asserted nowhere else.
 
 test_that("plot draws every candidate model when asked", {
-  expect_silent(pl_x_limits(pl_manec(), all_models = TRUE))
+  skip_on_cran()
+  expect_silent(pl_x_max(manec_example, all_models = TRUE))
 })
 
 test_that("plot accepts the annotation arguments", {
-  expect_silent(pl_x_limits(pl_fit(), add_nec = FALSE))
-  expect_silent(pl_x_limits(pl_fit(), add_ec10 = TRUE))
+  skip_on_cran()
+  expect_silent(pl_x_max(nec4param, add_nec = FALSE))
+  expect_silent(pl_x_max(nec4param, add_ec10 = TRUE))
 })
 
 
 # ---- xform on the predictor axis --------------------------------------------
 
 test_that("xform widens the predictor axis of a single fit", {
-  f <- pl_fit()
-  plain <- pl_x_limits(f)
-  scaled <- pl_x_limits(f, xform = function(x) x * 100)
-  expect_equal(scaled, plain * 100, tolerance = 1e-6)
+  skip_on_cran()
+  expect_equal(pl_x_ratio(nec4param), 100, tolerance = 1e-6)
 })
 
 test_that("xform widens the predictor axis of a model set", {
-  m <- pl_manec()
-  plain <- pl_x_limits(m)
-  scaled <- pl_x_limits(m, xform = function(x) x * 100)
-  expect_equal(scaled, plain * 100, tolerance = 1e-6)
+  skip_on_cran()
+  expect_equal(pl_x_ratio(manec_example), 100, tolerance = 1e-6)
 })
+
+
+# ---- #268, pinned on both halves of the figure ------------------------------
 
 test_that("a transformed response suppresses xform on the predictor axis", {
   # PINS THE #268 DEFECT on the base-plot path for a bayesnecfit
-  # (R/plot.R:119). xform is accepted and silently ignored, so the axis is
-  # drawn on the fitted scale while the caller asked for the recorded one.
+  # (the guard at R/plot.R:125). xform is accepted and silently dropped from
+  # the axis, so the data is drawn on the fitted scale while the caller asked
+  # for the recorded one.
   #
-  # INVERT THIS TEST WHEN #268 IS FIXED: the two should then differ by the
-  # factor xform applies, as in "xform widens the predictor axis of a single
-  # fit" above.
-  f <- pl_transform_response(pl_fit())
-  expect_equal(pl_x_limits(f, xform = function(x) x * 100), pl_x_limits(f),
-               tolerance = 1e-6)
+  # INVERT THIS TEST WHEN #268 IS FIXED: the ratio should then be 100, as in
+  # "xform widens the predictor axis of a single fit" above.
+  skip_on_cran()
+  f <- transformed_response_fit(nec4param, "nec4param")
+  expect_equal(pl_x_ratio(f), 1, tolerance = 1e-6)
 })
 
 test_that("a transformed response suppresses xform for a model set too", {
-  # PINS THE #268 DEFECT on the bayesmanecfit branch (R/plot.R:259). Same
-  # inversion applies.
-  m <- pl_manec()
-  # The model name is substituted into the formula text rather than
-  # referenced: crf() evaluates its model argument where the formula is used,
-  # not where it is written.
-  mod <- names(m$mod_fits)[1]
-  m$mod_fits[[1]]$bayesnecformula <- bayesnecformula(
-    stats::as.formula(paste0("exp(y) ~ crf(x, model = \"", mod, "\")"))
-  )
-  expect_equal(pl_x_limits(m, xform = function(x) x * 100), pl_x_limits(m),
-               tolerance = 1e-6)
+  # PINS THE #268 DEFECT on the bayesmanecfit branch (the guard at
+  # R/plot.R:279). Same inversion applies.
+  skip_on_cran()
+  m <- transformed_response_manec(manec_example)
+  expect_equal(pl_x_ratio(m), 1, tolerance = 1e-6)
 })
 
-test_that("plot and autoplot agree on the predictor axis", {
-  # The two paths make the xform decision independently, in four places
-  # altogether. They agree today; this is what would catch one being fixed for
-  # #268 without the other.
-  f <- pl_fit()
-  gg <- suppressMessages(ggbnec_data(f, xform = function(x) x * 100))
-  base_max <- pl_x_limits(f, xform = function(x) x * 100)[2]
-  # The device pads the axis beyond the data, so the fitted range must fall
-  # inside the drawn range rather than equal it.
-  expect_lt(max(gg$x_e, na.rm = TRUE), base_max)
-  expect_gt(max(gg$x_e, na.rm = TRUE), base_max * 0.9)
+test_that("the nec annotation is drawn off the end of the axis", {
+  # PINS THE OTHER HALF OF #268, which the issue does not state and the PR
+  # that added this file originally described as xform being "silently
+  # skipped". It is not skipped. R/plot.R:130-131 apply it to nec and ec10
+  # unconditionally, outside the guard, so with a transformed response the
+  # abline() at R/plot.R:179 is drawn at the transformed NEC on an axis left
+  # untransformed, and the line is not on the figure at all.
+  #
+  # abline() is intercepted rather than the value recomputed here: what has to
+  # be asserted is the number the package passed to it, not a number this file
+  # worked out for itself, which would still pass if R/plot.R:130-131 changed.
+  # The suite already mocks this way in test-fit_bayesnec.R and
+  # test-inits_functions.R.
+  #
+  # INVERT THIS TEST WHEN #268 IS FIXED: the drawn NEC must then fall inside
+  # the axis, whichever scale the fix settles on. A fix that changes only the
+  # guard, or only R/plot.R:130-131, fails one of the two tests and leaves the
+  # other passing, which is the point of asserting both.
+  skip_on_cran()
+  f <- transformed_response_fit(nec4param, "nec4param")
+  drawn <- NULL
+  local_mocked_bindings(abline = function(v = NULL, ...) drawn <<- v,
+                        .package = "bayesnec")
+  axis_max <- pl_x_max(f, xform = function(x) x * 100)
+  # Measured on nec4param: the axis maximum is 3.35 and the NEC line, its lower
+  # and its upper bound are drawn at 146, 136 and 153.
+  expect_length(drawn, 3)
+  expect_gt(min(drawn), axis_max)
+})
+
+test_that("plot and autoplot make the xform decision the same way", {
+  # The two paths make that decision independently, in four places altogether.
+  # This is what catches one being fixed for #268 without the other, so it is
+  # asserted on the fixture where the guard actually fires: with an
+  # untransformed formula both paths apply xform whatever the guard says, and
+  # the comparison is vacuous.
+  #
+  # Ratios rather than limits, so the base path's axis expansion does not enter
+  # the comparison.
+  skip_on_cran()
+  f <- transformed_response_fit(nec4param, "nec4param")
+  gg_ratio <- gg_x_max(f, xform = function(x) x * 100) / gg_x_max(f)
+  expect_equal(pl_x_ratio(f), gg_ratio, tolerance = 1e-6)
 })

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -78,8 +78,8 @@ test_that("add_nec and add_ec10 decide what is annotated", {
   # Same reasoning: silence is not evidence that either argument was read.
   # The three branches at R/plot.R:179-192 are mutually exclusive, so the
   # abline() calls are counted AND their values identified. Counting alone does
-  # not discriminate: one call is drawn whether the branch taken is the nec or
-  # the ec10, so swapping R/plot.R:190 to draw ec10 in the nec branch would
+  # not discriminate: one call is drawn whether the branch taken is the nec at
+  # R/plot.R:180 or the ec10 at :185, so drawing ec10 from the nec branch would
   # pass a count-only assertion.
   skip_on_cran()
   drawn <- list()
@@ -94,13 +94,16 @@ test_that("add_nec and add_ec10 decide what is annotated", {
   pl_x_max(nec4param, add_nec = TRUE)
   expect_length(drawn, 1)
   expect_equal(unname(drawn[[1]]), unname(nec4param$ne), tolerance = 1e-8)
-  # The ec10 alone. manec_example is gaussian, so R/plot.R:114-115 takes the
-  # relative branch (R/plot.R:114-115); the value is not asserted here beyond
-  # its being a different one, because ecx() is under test in test-ecx.R.
+  # The ec10 alone. nec4param is gaussian, so R/plot.R:114-115 takes the
+  # relative branch. The value is not asserted here beyond its being a
+  # different one, because ecx() is under test in test-ecx.R.
   pl_x_max(nec4param, add_nec = FALSE, add_ec10 = TRUE)
   expect_length(drawn, 2)
   expect_false(isTRUE(all.equal(unname(drawn[[2]]), unname(nec4param$ne))))
-  # Both, in the documented order: the nec in red, then the ec10 in orange.
+  # Both, in the order R/plot.R:189-191 draws them: the nec in red, then the
+  # ec10 in orange. The second call must repeat the ec10 of the previous block;
+  # ecx() on a bayesnecfit reads stored draws with no resampling, so the value
+  # is deterministic across the two plot() calls.
   pl_x_max(nec4param, add_nec = TRUE, add_ec10 = TRUE)
   expect_length(drawn, 4)
   expect_equal(unname(drawn[[3]]), unname(nec4param$ne), tolerance = 1e-8)

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -213,6 +213,14 @@ test_that("position_legend refuses the numeric vector its documentation names", 
                   error = conditionMessage)
   expect_match(msg, "'arg' must be of length 1")
   expect_false(grepl("legend positions must be one of", msg))
+  # Both halves on both classes. Asserting the refusal on both and the
+  # inversion on one is how the earlier bayesmanecfit gaps in this file arose:
+  # repairing R/plot.R:232 alone left every assertion here passing.
+  msg_m <- tryCatch(pl_x_max(manec_example,
+                             position_legend = c("topright", "bogus")),
+                    error = conditionMessage)
+  expect_match(msg_m, "'arg' must be of length 1")
+  expect_false(grepl("Legend positions must be one of", msg_m))
 })
 
 

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -4,9 +4,9 @@
 #
 # The base-graphics paths cannot be inspected by reading a returned object, so
 # the assertions here read the device instead: plotting to a null pdf() device
-# and reading par("usr") gives the x-axis limits the call actually produced.
+# and reading par("usr") gives the x-axis limits the call produced.
 # That is enough to assert the one thing about these paths that has been
-# reported wrong -- whether xform reached the predictor axis -- without
+# reported wrong, whether xform reached the predictor axis, without
 # comparing images.
 #
 # #268 is the defect, and it is not that xform is ignored. The decision to
@@ -177,12 +177,35 @@ test_that("the nec annotation is drawn off the end of the axis", {
   expect_gt(min(drawn), axis_max)
 })
 
+test_that("the model set draws its nec annotation off the axis too", {
+  # The bayesmanecfit branch has the same split: R/plot.R:279 guards the axis
+  # and R/plot.R:283 transforms the weighted nec unconditionally. Asserted
+  # separately from the bayesnecfit case above because it is a separate pair of
+  # lines -- correcting one pair and not the other is exactly the half-fix this
+  # file exists to catch, and until this assertion was added the model-set
+  # annotation was the one site of the four that nothing observed.
+  #
+  # Measured on manec_example with xform = x * 100: the axis maximum is 3.35
+  # and the weighted NEC and its bounds are drawn at 145, 74.9 and 152.7.
+  #
+  # INVERT THIS TEST WHEN #268 IS FIXED, with the sibling above it.
+  skip_on_cran()
+  m <- transformed_response_manec(manec_example)
+  drawn <- NULL
+  local_mocked_bindings(abline = function(v = NULL, ...) drawn <<- v,
+                        .package = "bayesnec")
+  axis_max <- pl_x_max(m, xform = function(x) x * 100)
+  expect_length(drawn, 3)
+  expect_gt(min(drawn), axis_max)
+})
+
 test_that("plot and autoplot make the xform decision the same way", {
-  # The two paths make that decision independently, in four places altogether.
-  # This is what catches one being fixed for #268 without the other, so it is
-  # asserted on the fixture where the guard actually fires: with an
-  # untransformed formula both paths apply xform whatever the guard says, and
-  # the comparison is vacuous.
+  # The two paths make that decision independently. Today this assertion is
+  # implied by the two axis pins above -- both ratios are pinned to 1
+  # separately, so it cannot fail unless one of those fails first -- and it is
+  # kept for what happens after #268 is fixed. Those two pins are then inverted
+  # to 100 or deleted; this one is not, and it goes on requiring the two paths
+  # to agree whatever scale the fix settles on.
   #
   # Ratios rather than limits, so the base path's axis expansion does not enter
   # the comparison.

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -76,7 +76,7 @@ test_that("all_models draws a panel per candidate, named", {
 
 test_that("add_nec and add_ec10 decide what is annotated", {
   # Same reasoning: silence is not evidence that either argument was read.
-  # The three branches at R/plot.R:179-192 are mutually exclusive, so the
+  # The three branches at R/plot.R:179-195 are mutually exclusive, so the
   # abline() calls are counted AND their values identified. Counting alone does
   # not discriminate: one call is drawn whether the branch taken is the nec at
   # R/plot.R:180 or the ec10 at :185, so drawing ec10 from the nec branch would
@@ -116,17 +116,23 @@ test_that("add_nec and add_ec10 decide what is annotated", {
 # The same shape as the two dead branches this branch pins in check_data(): a
 # condition written, never fired. Neither has an issue yet.
 
-test_that("the lxform branch in plot() cannot be reached", {
+test_that("the lxform branch in plot() cannot be reached, on either class", {
   # R/plot.R:152-157 and :304-309 compose an axis call for the case where
-  # lxform is not a function. R/plot.R:80-82 has already stopped on that input,
-  # and lxform is not reassigned between them, so the condition at :152 is
-  # always FALSE and the else at :164 always runs. The consequence is that
-  # axis(side = 1) and axis(side = 1, at = signif(xticks, 2)) are dead, and
-  # xticks is therefore always applied through the else branch instead.
+  # lxform is not a function. Each is preceded by a guard that has already
+  # stopped on that input -- R/plot.R:80-82 for a bayesnecfit and :222-224 for
+  # a bayesmanecfit -- and lxform is not reassigned between them, so both
+  # conditions are always FALSE and the else at :164 and :316 always runs. The
+  # consequence is that axis(side = 1) and axis(side = 1, at = signif(xticks,
+  # 2)) are dead at both sites, and xticks is always applied through the else.
+  #
+  # Both classes are asserted. Pinning one and not the other is how the
+  # bayesmanecfit half of #268 escaped notice for six review rounds.
   #
   # Pinned as current behaviour, not asserted to be correct.
   skip_on_cran()
   expect_error(pl_x_max(nec4param, lxform = "not a function"),
+               "lxform must be a function")
+  expect_error(pl_x_max(manec_example, lxform = "not a function"),
                "lxform must be a function")
   calls <- list()
   local_mocked_bindings(
@@ -135,8 +141,15 @@ test_that("the lxform branch in plot() cannot be reached", {
   )
   pl_x_max(nec4param)
   pl_x_max(nec4param, xticks = c(0, 1, 2, 3))
+  pl_x_max(manec_example)
+  pl_x_max(manec_example, xticks = c(0, 1, 2, 3))
+  # The count first. all() of an empty list is TRUE, so without this the
+  # assertion below would also pass if axis() were never called at all -- which
+  # is a reachable state, since xaxt = "n" is set at R/plot.R:145 and the axis
+  # is drawn only by these calls.
+  expect_length(calls, 4)
   # Every call comes from the else branch, which always supplies at and labels.
-  # A reachable :153 or :155 would produce a call with neither.
+  # A reachable :153, :155, :306 or :308 would produce a call with neither.
   expect_true(all(vapply(calls, function(nm) all(c("at", "labels") %in% nm),
                          logical(1))))
 })
@@ -150,6 +163,11 @@ test_that("position_legend refuses the numeric vector its documentation names", 
   skip_on_cran()
   expect_error(pl_x_max(nec4param, position_legend = c(0.5, 0.5)),
                "legend positions must be one of")
+  # R/plot.R:232-235 is the same guard for a bayesmanecfit, with the same
+  # inversion and a differently worded message. Asserted so that the issue this
+  # becomes states both call sites.
+  expect_error(pl_x_max(manec_example, position_legend = c(0.5, 0.5)),
+               "Legend positions must be one of")
   # And the arguments to match() are the wrong way round -- the vector of valid
   # keywords is matched into the user's value rather than the reverse -- so a
   # value containing one valid keyword passes the guard however much else is in
@@ -269,6 +287,26 @@ test_that("the ec10 annotation is drawn off the axis as well", {
                         .package = "bayesnec")
   axis_max <- pl_x_max(f, add_nec = FALSE, add_ec10 = TRUE,
                        xform = function(x) x * 100)
+  expect_length(drawn, 3)
+  expect_gt(min(drawn), axis_max)
+})
+
+test_that("the model set draws its ec10 annotation off the axis too", {
+  # The fourth and last of the annotation sites: R/plot.R:284 transforms ec10
+  # on the bayesmanecfit branch, outside the guard at :279. Adding the
+  # single-fit ec10 pin alone left this one unobserved, which is the third time
+  # in this review that a bayesmanecfit site was missed after its bayesnecfit
+  # twin was covered.
+  #
+  # INVERT THIS TEST WHEN #268 IS FIXED, with its siblings above.
+  skip_on_cran()
+  m <- transformed_response_manec(manec_example)
+  drawn <- NULL
+  local_mocked_bindings(abline = function(v = NULL, ...) drawn <<- v,
+                        .package = "bayesnec")
+  axis_max <- suppressWarnings(
+    pl_x_max(m, add_nec = FALSE, add_ec10 = TRUE, xform = function(x) x * 100)
+  )
   expect_length(drawn, 3)
   expect_gt(min(drawn), axis_max)
 })

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -48,17 +48,44 @@ pl_x_ratio <- function(obj) {
 #
 # plot() on a plain bayesnecfit and bayesmanecfit is already asserted silent
 # and invisible in test-bayesnec_methods.R and test-bayesmanec_methods.R, so it
-# is not repeated. all_models, add_nec and add_ec10 are asserted nowhere else.
+# is not repeated. all_models, add_nec and add_ec10 are asserted nowhere else,
+# and each is asserted here on what it changes rather than on the call
+# completing, which any value of the argument would satisfy.
 
-test_that("plot draws every candidate model when asked", {
+test_that("all_models draws a panel per candidate, named", {
+  # Asserting only that the call is silent would pass just as well with
+  # all_models = FALSE, and so would not detect the argument being ignored.
+  # R/plot.R:253 labels each panel with the model name, and that legend() call
+  # is reached only from the all_models loop, so the names it is given are
+  # evidence of which candidates were drawn.
   skip_on_cran()
-  expect_silent(pl_x_max(manec_example, all_models = TRUE))
+  labels <- character()
+  local_mocked_bindings(
+    legend = function(..., legend = NULL) labels <<- c(labels, as.character(legend)),
+    .package = "bayesnec"
+  )
+  pl_x_max(manec_example, all_models = TRUE)
+  expect_true(all(names(manec_example$mod_fits) %in% labels))
+  # And not otherwise: the model-average plot draws one panel and names none.
+  labels <- character()
+  pl_x_max(manec_example, all_models = FALSE)
+  expect_false(any(names(manec_example$mod_fits) %in% labels))
 })
 
-test_that("plot accepts the annotation arguments", {
+test_that("add_nec and add_ec10 decide what is annotated", {
+  # Same reasoning: silence is not evidence that either argument was read.
+  # The three branches at R/plot.R:179-192 are mutually exclusive, so counting
+  # the abline() calls says which one was taken.
   skip_on_cran()
-  expect_silent(pl_x_max(nec4param, add_nec = FALSE))
-  expect_silent(pl_x_max(nec4param, add_ec10 = TRUE))
+  drawn <- list()
+  local_mocked_bindings(
+    abline = function(v = NULL, ...) drawn[[length(drawn) + 1L]] <<- v,
+    .package = "bayesnec"
+  )
+  pl_x_max(nec4param, add_nec = FALSE)
+  expect_length(drawn, 0)
+  pl_x_max(nec4param, add_nec = TRUE, add_ec10 = TRUE)
+  expect_length(drawn, 2)
 })
 
 

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -52,6 +52,37 @@ pl_x_ratio <- function(obj) {
 # and each is asserted here on what it changes rather than on the call
 # completing, which any value of the argument would satisfy.
 
+test_that("add_nec and add_ec10 decide what is annotated for a model set too", {
+  # R/plot.R:331-346 repeats the three-branch structure of :179-195 for a
+  # bayesmanecfit, and until this block was added nothing observed which
+  # annotation each branch drew: changing R/plot.R:337 to draw nec in the ec10
+  # branch -- the model-set analogue of the mutation the bayesnecfit block
+  # below names -- passed every assertion in this branch. The combined branch
+  # at :341-343 was executed by nothing.
+  #
+  # This was the fourth occasion in review on which a bayesmanecfit site was
+  # found uncovered after its bayesnecfit twin was covered.
+  skip_on_cran()
+  drawn <- list()
+  local_mocked_bindings(
+    abline = function(v = NULL, ...) drawn[[length(drawn) + 1L]] <<- v,
+    .package = "bayesnec"
+  )
+  suppressWarnings(pl_x_max(manec_example, add_nec = FALSE))
+  expect_length(drawn, 0)
+  suppressWarnings(pl_x_max(manec_example, add_nec = TRUE))
+  expect_length(drawn, 1)
+  expect_equal(unname(drawn[[1]]), unname(manec_example$w_ne), tolerance = 1e-8)
+  suppressWarnings(pl_x_max(manec_example, add_nec = FALSE, add_ec10 = TRUE))
+  expect_length(drawn, 2)
+  expect_false(isTRUE(all.equal(unname(drawn[[2]]),
+                                unname(manec_example$w_ne))))
+  suppressWarnings(pl_x_max(manec_example, add_nec = TRUE, add_ec10 = TRUE))
+  expect_length(drawn, 4)
+  expect_equal(unname(drawn[[3]]), unname(manec_example$w_ne), tolerance = 1e-8)
+  expect_equal(unname(drawn[[4]]), unname(drawn[[2]]), tolerance = 1e-8)
+})
+
 test_that("all_models draws a panel per candidate, named", {
   # Asserting only that the call is silent would pass just as well with
   # all_models = FALSE, and so would not detect the argument being ignored.
@@ -149,7 +180,10 @@ test_that("the lxform branch in plot() cannot be reached, on either class", {
   # is drawn only by these calls.
   expect_length(calls, 4)
   # Every call comes from the else branch, which always supplies at and labels.
-  # A reachable :153, :155, :306 or :308 would produce a call with neither.
+  # The dead calls are at R/plot.R:154 and :156 and R/plot.R:306 and :308. A
+  # reachable :154 or :306 would produce a call with neither name; a reachable
+  # :156 or :308 would produce one with at but no labels. Requiring both names
+  # excludes all four.
   expect_true(all(vapply(calls, function(nm) all(c("at", "labels") %in% nm),
                          logical(1))))
 })

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -111,6 +111,59 @@ test_that("add_nec and add_ec10 decide what is annotated", {
 })
 
 
+# ---- two guards in plot() that nothing can reach ----------------------------
+#
+# The same shape as the two dead branches this branch pins in check_data(): a
+# condition written, never fired. Neither has an issue yet.
+
+test_that("the lxform branch in plot() cannot be reached", {
+  # R/plot.R:152-157 and :304-309 compose an axis call for the case where
+  # lxform is not a function. R/plot.R:80-82 has already stopped on that input,
+  # and lxform is not reassigned between them, so the condition at :152 is
+  # always FALSE and the else at :164 always runs. The consequence is that
+  # axis(side = 1) and axis(side = 1, at = signif(xticks, 2)) are dead, and
+  # xticks is therefore always applied through the else branch instead.
+  #
+  # Pinned as current behaviour, not asserted to be correct.
+  skip_on_cran()
+  expect_error(pl_x_max(nec4param, lxform = "not a function"),
+               "lxform must be a function")
+  calls <- list()
+  local_mocked_bindings(
+    axis = function(...) calls[[length(calls) + 1L]] <<- names(list(...)),
+    .package = "bayesnec"
+  )
+  pl_x_max(nec4param)
+  pl_x_max(nec4param, xticks = c(0, 1, 2, 3))
+  # Every call comes from the else branch, which always supplies at and labels.
+  # A reachable :153 or :155 would produce a call with neither.
+  expect_true(all(vapply(calls, function(nm) all(c("at", "labels") %in% nm),
+                         logical(1))))
+})
+
+test_that("position_legend refuses the numeric vector its documentation names", {
+  # R/plot.R:42-43 documents position_legend as "a numeric vector indicating
+  # the location of the NEC or EC10 legend, as per a call to legend". The guard
+  # at :89-91 accepts only the eight keyword strings, so the documented form is
+  # refused. Pinned as current behaviour: the guard and the documentation
+  # disagree and neither is asserted anywhere else.
+  skip_on_cran()
+  expect_error(pl_x_max(nec4param, position_legend = c(0.5, 0.5)),
+               "legend positions must be one of")
+  # And the arguments to match() are the wrong way round -- the vector of valid
+  # keywords is matched into the user's value rather than the reverse -- so a
+  # value containing one valid keyword passes the guard however much else is in
+  # it, and fails later inside legend() with a message that names neither the
+  # argument nor the valid values. Same shape as #265: a condition that does not
+  # test what it reads as testing.
+  msg <- tryCatch(pl_x_max(nec4param,
+                           position_legend = c("topright", "bogus")),
+                  error = conditionMessage)
+  expect_match(msg, "'arg' must be of length 1")
+  expect_false(grepl("legend positions must be one of", msg))
+})
+
+
 # ---- xform on the predictor axis --------------------------------------------
 
 test_that("xform widens the predictor axis of a single fit", {
@@ -195,6 +248,27 @@ test_that("the model set draws its nec annotation off the axis too", {
   local_mocked_bindings(abline = function(v = NULL, ...) drawn <<- v,
                         .package = "bayesnec")
   axis_max <- pl_x_max(m, xform = function(x) x * 100)
+  expect_length(drawn, 3)
+  expect_gt(min(drawn), axis_max)
+})
+
+test_that("the ec10 annotation is drawn off the axis as well", {
+  # The other annotation. R/plot.R:130 transforms ec10 outside the guard,
+  # exactly as :131 does nec, and until this assertion was added the ec10 half
+  # of the claim made at the top of this file was not read: gating ec10 alone
+  # left every assertion in the branch passing.
+  #
+  # Measured on nec4param with xform = x * 100: the axis maximum is 3.35 and
+  # the EC10 is drawn beyond it.
+  #
+  # INVERT THIS TEST WHEN #268 IS FIXED, with its siblings above.
+  skip_on_cran()
+  f <- transformed_response_fit(nec4param, "nec4param")
+  drawn <- NULL
+  local_mocked_bindings(abline = function(v = NULL, ...) drawn <<- v,
+                        .package = "bayesnec")
+  axis_max <- pl_x_max(f, add_nec = FALSE, add_ec10 = TRUE,
+                       xform = function(x) x * 100)
   expect_length(drawn, 3)
   expect_gt(min(drawn), axis_max)
 })


### PR DESCRIPTION
Closes #277.

Adds the three test files that have never existed in any release:
`test-check_data.R`, `test-plot.R` and `test-autoplot.R`. No package code is
changed.

## What

66 assertions over three new files. Nothing fits a model — every assertion runs
off `manec_example` and hand-built model frames, so the suite cost is seconds.

## Why it matters

The code producing the current defects is the code with no test file. Measured
on 2026-09-03 against `origin/master` (2.1.3.1) and `dev`:

- `check_data.R` has no test file in either version. It is the origin of #258,
  #265, #269, #271 and #274 — five defects in two weeks.
- `plot.R` and `autoplot.R` have no test file. They are #268, #160 and #161.
- **`xform` has zero assertions anywhere on the plotting path.** It is asserted
  only on the estimators. #268 is exactly that gap.

Where a test file was written, the discovery stopped: `test-validate_family.R`
0 → 99 assertions, `test-inits_functions.R` 0 → 114, `test-fit_bayesnec.R`
0 → 34, `test-define_prior.R` 33 → 103.

## Evidence

Nine of nine recent defects are present in the CRAN release, checked line by
line rather than taken from the issue text: #256 (`validate_family.R:14-15`),
#258 (`fit_bayesnec.R:36`), #265 (`check_data.R:55`, `:63`), #266
(`inits_functions.R:101`), #267 (`bnecfit-methods.R:150`), #268 (two sites in
`plot.R`, two in `autoplot.R`), #269 (`check_data.R:48`, `:56`), #272
(`set_distribution.R:48`), #244 (absent from `inits_functions.R`).

**#268 is reproduced here without fitting anything**, which the issue records as
not having been possible: giving a stored fit a formula that transforms its
response makes `find_transformations()` report `"y"` while the predictor is
untransformed, and `xform` is then silently skipped at all four sites. The base
paths are read by plotting to a null `pdf()` device and reading `par("usr")`.

## Three findings with no issue yet

- **Two branches of `check_data()` cannot be reached.** The non-numeric
  predictor branch (`:112-118`) is preceded by `retrieve_var(error = TRUE)` at
  `:108`, which raises first with a different message; the numeric group-level
  branch (`:203-209`) is preceded by `model.frame()`. Both are the shape of
  #265 — a condition written, never fired, unnoticed for years.
- **`NA` and `NaN` are dropped rather than refused.** The finiteness guard sees
  only what `model.frame()` passes it. `Inf` reaches it and is refused; `NA` and
  `NaN` are removed silently and the fit proceeds on fewer rows than supplied.
- **`ggbnec_data(x, nec = FALSE)` does nothing.** The argument is `add_nec`.
  `autoplot()` takes `nec` and forwards it, so the obvious transfer of the
  argument name is absorbed by `...`.

All three are pinned as current behaviour, not asserted to be correct.

## Two tests pin a defect rather than correct behaviour

Each says so in a comment naming the issue and the assertion to invert:

- **#268** — a transformed response suppresses `xform` on the predictor axis.
  Pinned on all four sites: two in `test-plot.R`, two in `test-autoplot.R`.
- **#274** — `has_family_changed()` reports a boundary correction and discards
  it, so `update()` with `newdata` fails on the condition it reported repaired.

Each fix becomes a one-line inversion plus the code change, rather than a fresh
reproduction.

## What is deliberately not duplicated

| already covered | where |
|---|---|
| the `check_data()` write-back into `brm()`'s data | `test-fit_bayesnec.R` |
| the censoring exemptions | `test-cens.R` |
| zeros preserved for a hurdle family | `test-hurdle_family.R` |
| `check_normalisation()` | `test-check_normalisation.R` |

## Verification

`NOT_CRAN=true`, R 4.6.1, `dev` at 9b8a4067.

```
test-check_data.R   PASS 37   FAIL 0
test-autoplot.R     PASS 18   FAIL 0
test-plot.R         PASS 11   FAIL 0
```

Full suite, `test_dir()` with `NOT_CRAN=true`:

```
FAIL 0 | WARN 2 | SKIP 0 | PASS 2390
```

Both warnings are pre-existing and neither is in a file this branch touches:
`test-disp_model.R:412` (a `loo` `p_waic` warning) and `test-get_priors.R:239`.
The three new files report zero warnings between them.

`DESCRIPTION` is bumped 2.1.3.25 -> 2.1.3.26 to keep the dev counter monotonic.
**No `NEWS.md` entry**: nothing here changes what a user of the package sees,
and a bullet saying tests were added would be noise in a release note. Flagged
because `00_protocol.md` item 4 asks for one by default.

**The Windows job is expected to be red.** #275: `R-CMD-check` force-installs
`StanHeaders` over the version `rstan` was matched to, and the failure is
identical on `dev`. It is not caused by this branch.

## Left undone

The three findings above have no issue of their own yet; #277 records them, and
they should be raised as one issue once this merges. `01_work_queue.md` records
them so they are not lost.

Note that `Closes #277` will not fire on merge, because this pull request
targets `dev` rather than the default branch. Close it by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QN6wLkaDNhzpwVr3ffFAKQ
