### PR TITLE
Refuse missing values; accept both position_legend forms; drop four dead guards (#278)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -169,10 +169,11 @@
   between models matters, refit the whole set.
 
 - The response write-back now matches rows by name rather than assigning
-  wholesale, so a data frame carrying an `NA` in any population variable no
-  longer fails with "replacement has *n* rows, data has *m*". The model frame
-  drops incomplete cases, so it is shorter than the data frame `brm()` is given
-  wherever one is present.
+  wholesale, so it is correct for a data frame whose row names are not `1:n`
+  and cannot fail with "replacement has *n* rows, data has *m*". A missing
+  value in a population variable, which is the other way the model frame comes
+  back shorter than the data frame `brm()` is given, is refused outright as of
+  the entry below rather than accommodated by the write-back.
 
 - `trials()` carrying arithmetic — `y | trials(n * 2) ~ crf(x, ...)` — no longer
   fits every observation against the wrong number of trials. The trials column
@@ -181,6 +182,42 @@
   then evaluated `trials(n * 2)` against *that*: a recorded 10 became 40. The
   write-back is removed; `check_data()` never corrects the trials variable, so
   it had nothing to carry.
+
+- `check_data()` refuses a row with a missing value in a population variable
+  rather than letting `stats::model.frame()` remove it. The model frame drops
+  incomplete cases before the finiteness guard is reached, so `Inf` was refused
+  while `NA` and `NaN` were removed silently: twenty rows supplied, nineteen
+  fitted, nothing said. The error reports how many rows held a missing value
+  and which they were. Where those rows are genuinely to be discarded, apply
+  `na.omit()` to the data frame before calling `bnec()`, so that the sample the
+  estimates are derived from is the user's decision and is visible in the
+  script. The guard also reads `is.finite()` elementwise rather than on the
+  mean, so a missing value that reaches it through
+  `options(na.action = "na.pass")` is refused as well, naming the column
+  (#278).
+
+- `position_legend` in `plot()` accepts the numeric form its documentation has
+  always named. Either of the two forms `graphics::legend()` takes is now
+  valid: one of the eight position keywords, or a numeric vector of length two
+  giving the x and y coordinates. The guard it replaces also tested
+  `match(legend_positions, position_legend)`, matching the valid keywords into
+  the user's value rather than the reverse, so `c("topright", "bogus")` passed
+  it and failed inside `legend()` with `'arg' must be of length 1`, which names
+  neither the argument nor the valid values. Both `plot()` methods now use one
+  guard with one message (#278).
+
+- `ggbnec_data()` validates `xform` for a `bayesmanecfit` as it already did for
+  a `bayesnecfit`. `ggbnec_data(x, xform = "no")` failed with
+  `could not find function "xform"` for a model set where a single fit reported
+  `xform must be a function.` (#278).
+
+- Four unreachable guards removed, with no change in behaviour. The predictor
+  and group-level type checks in `check_data()` composed a longer message than
+  `retrieve_var()` and `stats::model.frame()`, which refuse the same input
+  first and say the same thing; the `lxform` branch in each `plot()` method is
+  preceded by a guard that has already stopped on that input. Four
+  `check_custom_name()` calls whose result nothing read are removed alongside
+  them (#278).
 
 # bayesnec 2.1.4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -171,9 +171,9 @@
 - The response write-back now matches rows by name rather than assigning
   wholesale, so it is correct for a data frame whose row names are not `1:n`
   and cannot fail with "replacement has *n* rows, data has *m*". A missing
-  value in a population variable, which is the other way the model frame comes
-  back shorter than the data frame `brm()` is given, is refused outright as of
-  the entry below rather than accommodated by the write-back.
+  value in any variable the formula names, which is the other way the model
+  frame comes back shorter than the data frame `brm()` is given, is refused
+  outright as of the entry below rather than accommodated by the write-back.
 
 - `trials()` carrying arithmetic — `y | trials(n * 2) ~ crf(x, ...)` — no longer
   fits every observation against the wrong number of trials. The trials column
@@ -183,23 +183,30 @@
   write-back is removed; `check_data()` never corrects the trials variable, so
   it had nothing to carry.
 
-- `check_data()` refuses a row with a missing value in a population variable
-  rather than letting `stats::model.frame()` remove it. The model frame drops
-  incomplete cases before the finiteness guard is reached, so `Inf` was refused
-  while `NA` and `NaN` were removed silently: twenty rows supplied, nineteen
-  fitted, nothing said. The error reports how many rows held a missing value
-  and which they were. Where those rows are genuinely to be discarded, apply
-  `na.omit()` to the data frame before calling `bnec()`, so that the sample the
-  estimates are derived from is the user's decision and is visible in the
-  script. The guard also reads `is.finite()` elementwise rather than on the
-  mean, so a missing value that reaches it through
-  `options(na.action = "na.pass")` is refused as well, naming the column
-  (#278).
+- A row with a missing value in any variable the formula names is refused
+  rather than left for `stats::model.frame()` to remove. The model frame drops
+  incomplete cases before the finiteness guard in `check_data()` is reached, so
+  `Inf` was refused while `NA` and `NaN` were removed silently: twenty rows
+  supplied, nineteen fitted, nothing said. The error reports how many rows held
+  a missing value and which they were, by row name. Where those rows are
+  genuinely to be discarded, apply `na.omit()` to the data frame before calling
+  `bnec()`, so that the sample the estimates are derived from is the user's
+  decision and is visible in the script.
+
+  The check runs in `bnec()` before any model is fitted, and in `bnec_group()`
+  before the first level is, so a model set states the refusal once and a
+  grouped fit states it before it samples anything. It is retained in
+  `check_data()` for the two routes that do not come through `bnec()`:
+  `get_priors()` and `amend()`. The finiteness guard also reads `is.finite()`
+  elementwise rather than on the mean, so a missing value that reaches it
+  through `options(na.action = "na.pass")` is refused as well, naming the
+  column (#278).
 
 - `position_legend` in `plot()` accepts the numeric form its documentation has
-  always named. Either of the two forms `graphics::legend()` takes is now
-  valid: one of the eight position keywords, or a numeric vector of length two
-  giving the x and y coordinates. The guard it replaces also tested
+  always named. Both the keyword form and the coordinate form
+  `graphics::legend()` takes are now valid: one of the eight position keywords
+  the previous guard listed, or a numeric vector of length two giving the x and
+  y coordinates. The guard it replaces also tested
   `match(legend_positions, position_legend)`, matching the valid keywords into
   the user's value rather than the reverse, so `c("topright", "bogus")` passed
   it and failed inside `legend()` with `'arg' must be of length 1`, which names
@@ -213,9 +220,9 @@
 
 - Four unreachable guards removed, with no change in behaviour. The predictor
   and group-level type checks in `check_data()` composed a longer message than
-  `retrieve_var()` and `stats::model.frame()`, which refuse the same input
-  first and say the same thing; the `lxform` branch in each `plot()` method is
-  preceded by a guard that has already stopped on that input. Four
+  `retrieve_var()` and `check_formula()`, which refuse the same input first and
+  say the same thing; the `lxform` branch in each `plot()` method is preceded
+  by a guard that has already stopped on that input. Four
   `check_custom_name()` calls whose result nothing read are removed alongside
   them (#278).
 

--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -175,7 +175,6 @@ prep_raw_data <- function(brms_fit, bayesnecformula) {
   y_var <- attr(mod_dat, "bnec_pop")[["y_var"]]
   x_var <- attr(mod_dat, "bnec_pop")[["x_var"]]
   family <- brms_fit$family
-  custom_name <- check_custom_name(family)
   rate_var <- unname(attr(mod_dat, "bnec_pop")["rate_var"])
   if (family$family == "binomial" | family$family == "beta_binomial") {
     trials_var <- attr(mod_dat, "bnec_pop")[["trials_var"]]
@@ -338,6 +337,12 @@ ggbnec_data.bayesmanecfit <- function(x, add_nec = TRUE, add_ecx = FALSE,
                                       xform = identity, ...) {
   chk_lgl(add_nec)
   chk_lgl(add_ecx)
+  # Matching the bayesnecfit method. Without it a non-function xform reached
+  # mutate() and failed with "could not find function \"xform\"", which names
+  # neither the argument nor what it should have been. See #278.
+  if (!inherits(xform, "function")) {
+    stop("xform must be a function.")
+  }
   e_df <- x$w_pred_vals$data
   e_df <- data.frame(x_e = c(e_df$x, rev(e_df$x)),
                      y_e = c(e_df$Estimate, rep(NA, nrow(e_df))),

--- a/R/bnec.R
+++ b/R/bnec.R
@@ -8,9 +8,10 @@
 #' \code{\link{bayesnecformula}} and \code{\link{check_formula}}.
 #' @param data A \code{\link[base]{data.frame}} containing the data to use with
 #' the \code{formula}. Every variable the \code{formula} names must be
-#' complete: a row with an \code{NA}, \code{NaN} or \code{Inf} in any of them
-#' is refused rather than removed, so that the fit is never run on a smaller
-#' sample than was supplied without the user having chosen that. Apply
+#' complete: a row with an \code{NA} or \code{NaN} in any of them is refused
+#' rather than removed, so that the fit is never run on a smaller sample than
+#' was supplied without the user having chosen that. An \code{Inf} in the
+#' predictor or the response is refused as well. Apply
 #' \code{\link[stats]{na.omit}} before calling \code{bnec} where those rows
 #' are to be discarded.
 #' @param x_range A range of predictor values over which to consider extracting
@@ -465,14 +466,26 @@
 #' the \code{-Inf} reaches Stan. Add the offset of your choice to the data and
 #' name that column in the formula.
 #'
-#' \bold{NAs are thrown away}
-#' 
-#' Stan's default behaviour is to fail when the input data contains NAs. For
-#' that reason \pkg{brms} excludes any NAs from input data prior to fitting,
-#' and does not allow them back in as is the case with e.g. \code{stats::lm} and
-#' \code{na.action = exclude}. So we advise that you exclude any NAs in your
-#' data prior to fitting because if you so wish that should facilitate merging
-#' predictions back onto your original dataset.
+#' \bold{Missing values}
+#'
+#' A row with an \code{NA} or \code{NaN} in any variable the \code{formula}
+#' names is refused rather than removed, and so is an \code{Inf} in the
+#' predictor or the response. The error for a missing value reports how many
+#' rows held one and which they were, by row name; the error for a non-finite
+#' value names the column.
+#'
+#' \code{\link[stats]{model.frame}} drops incomplete cases before
+#' \pkg{bayesnec} is given the data, so until version 2.2.0 an \code{NA} left
+#' the fit running on fewer rows than were supplied with nothing said, while an
+#' \code{Inf} was refused. Both are now refused, so that the sample the
+#' estimates are derived from is the user's decision and is visible in the
+#' script.
+#'
+#' Apply \code{\link[stats]{na.omit}} to the data frame before calling
+#' \code{bnec} where those rows are to be discarded. The frame that results is
+#' the one the fit is derived from, so predictions align with it row for row:
+#' \pkg{brms} excludes NAs prior to fitting and does not pad the predictions
+#' back out, as \code{stats::lm} does with \code{na.action = na.exclude}.
 #'
 #' @return If argument model is a single string, then an object of class
 #' \code{\link{bayesnecfit}}; if many strings or a set,
@@ -545,6 +558,17 @@ bnec <- function(formula, data, x_range = NA, resolution = 1000, sig_val = 0.01,
   }
   formula <- bayesnecformula(formula)
   bdat <- model.frame(formula, data = data, run_par_checks = TRUE)
+  # Raised here rather than left to check_data(), which runs once per model
+  # inside fit_bayesnec(). bnec() wraps that call in try() for a model set, so
+  # from there the refusal was printed once per model and the call then ended
+  # on the generic all-models-failed advice, which names neither the missing
+  # values nor the remedy. The same reasoning as check_normalisation() and
+  # check_inline_boundary() below, and it applies more strongly: the default
+  # model argument is a set. Placed immediately after the model frame is built
+  # so that nothing downstream, the family choice included, is decided from a
+  # smaller sample than was supplied. check_data() keeps the check for the
+  # routes that do not come through here. See #278.
+  check_complete_cases(bdat)
   model <- get_model_from_formula(formula)
   brm_args <- list(...)
   # `prior` is an explicit argument (rather than relying on `...`) so that a

--- a/R/bnec.R
+++ b/R/bnec.R
@@ -7,7 +7,12 @@
 #' R formula or an actual \code{\link[stats]{formula}} object. See
 #' \code{\link{bayesnecformula}} and \code{\link{check_formula}}.
 #' @param data A \code{\link[base]{data.frame}} containing the data to use with
-#' the \code{formula}.
+#' the \code{formula}. Every variable the \code{formula} names must be
+#' complete: a row with an \code{NA}, \code{NaN} or \code{Inf} in any of them
+#' is refused rather than removed, so that the fit is never run on a smaller
+#' sample than was supplied without the user having chosen that. Apply
+#' \code{\link[stats]{na.omit}} before calling \code{bnec} where those rows
+#' are to be discarded.
 #' @param x_range A range of predictor values over which to consider extracting
 #' ECx.
 #' @param resolution The length of the predictor vector used for posterior

--- a/R/bnec_group.R
+++ b/R/bnec_group.R
@@ -113,9 +113,17 @@ bnec_group <- function(formula, data, group_var, family = NULL, ...) {
          " concentration-response model in its own right, so it needs enough",
          " data to support one.", call. = FALSE)
   }
+  # Refused before the loop, not left to the bnec() call for the level that
+  # holds it. Each level is a complete fit, so a missing value in level k would
+  # otherwise be reached only after levels 1 to k-1 had sampled -- measured on
+  # two levels of twelve, level "a" compiled and sampled to completion before
+  # level "b" raised. The whole data frame is checked here, so the rows are
+  # named as the user recorded them rather than by their position within a
+  # subset. See #278.
+  mod_dat <- model.frame(formula, data = data)
+  check_complete_cases(mod_dat)
   # Chosen once, from the whole response, for the reason in Details.
   if (is.null(family)) {
-    mod_dat <- model.frame(formula, data = data)
     y <- retrieve_var(mod_dat, "y_var", error = TRUE)
     tr <- retrieve_var(mod_dat, "trials_var")
     family <- set_distribution(y, support_integer = TRUE, trials = tr)

--- a/R/check_data.R
+++ b/R/check_data.R
@@ -109,19 +109,27 @@ check_data <- function(data, family, model) {
   bnec_pop_vars <- attr(data, "bnec_pop")
   y_pos <- which(names(bnec_pop_vars) == "y_var")
   x_pos <- which(names(bnec_pop_vars) == "x_var")
-  if (!is.numeric(x)) {
-    x_flag <- names(data)[x_pos]
-    stop(paste0("Your indicated predictor column \"", x_flag,
-                "\" contains data that is class ", class(x),
-                ". The function bnec requires the predictor",
-                " column to be numeric."))
+  # model.frame() removes incomplete cases before check_data() is given the
+  # data, so an NA or NaN never reached the finiteness guard below and the fit
+  # ran on fewer rows than were supplied with nothing said. Refused rather than
+  # announced: Inf is refused here already, and the sample the estimates are
+  # derived from is not something the package should change silently. The rows
+  # removed are recorded on the model frame by na.omit(), which is the only
+  # remaining evidence that they existed. See #278.
+  dropped <- attr(data, "na.action")
+  if (!is.null(dropped)) {
+    stop("Your data contains ", length(dropped), " row(s) with missing values",
+         " (NA or NaN), at row(s) ", paste0(unname(dropped), collapse = ", "),
+         ". The function bnec requires complete cases; remove or impute those",
+         " rows before fitting.")
   }
-  test_x <- mean(x)
-  test_y <- mean(y)
-  if (!is.finite(test_x)) {
+  # is.finite() elementwise rather than on the mean, so that a column reaching
+  # this point with NA still present -- a user with options(na.action =
+  # "na.pass"), for which the guard above sees nothing -- is named as well.
+  if (!all(is.finite(x))) {
     stop("Your predictor column contains values that are not finite.")
   }
-  if (!is.finite(test_y)) {
+  if (!all(is.finite(y))) {
     stop("Your response column contains values that are not finite.")
   }
   resp_check <- mean(y[which(x < mean(x))]) <
@@ -199,16 +207,6 @@ check_data <- function(data, family, model) {
   }
   mod_dat <- data.frame(x = data[[x_pos]], y = data[[y_pos]],
                         trials = nrow(data))
-  bnec_group_vars <- attr(data, "bnec_group")
-  if (any(!is.na(bnec_group_vars))) {
-    are_numeric <- sapply(data[, bnec_group_vars, drop = FALSE], is.numeric)
-    if (any(are_numeric)) {
-      to_flag <- paste0(names(are_numeric)[are_numeric], collapse = "; ")
-      stop("Your group-level column(s): ", to_flag, "; must be either a",
-           " character or a factor.")
-    }
-  }
-  custom_name <- check_custom_name(family)
   if (fam_tag == "binomial" || fam_tag == "beta_binomial") {
     mod_dat$trials <- retrieve_var(data, "trials_var", error = TRUE)
   }

--- a/R/check_data.R
+++ b/R/check_data.R
@@ -88,6 +88,43 @@ check_normalisation <- function(data) {
   invisible(NULL)
 }
 
+#' Refuse a model frame from which incomplete cases were removed
+#'
+#' \code{stats::model.frame()} drops an incomplete case before \pkg{bayesnec}
+#' sees the data, so an \code{NA} or \code{NaN} never reached the finiteness
+#' guard in \code{\link{check_data}} and the fit ran on fewer rows than were
+#' supplied with nothing said. Refused rather than announced: \code{Inf} is
+#' refused already, and the sample the estimates are derived from is not
+#' something the package should change silently.
+#'
+#' The rows removed are recorded on the model frame by
+#' \code{\link[stats]{na.omit}}, which is the only remaining evidence that
+#' they existed. They are reported by row name rather than by position: a name
+#' is what the user sees in their own data frame, and where the model frame was
+#' built from a subset --- one level of a \code{\link{bnec_group}} call --- a
+#' position indexes the subset and names no row of the data that was supplied.
+#'
+#' @param data A model frame, as returned by the \code{\link{model.frame}}
+#' method for a \code{\link{bayesnecformula}}.
+#'
+#' @return \code{NULL}, invisibly. Called for its error.
+#'
+#' @noRd
+check_complete_cases <- function(data) {
+  dropped <- attr(data, "na.action")
+  if (is.null(dropped)) {
+    return(invisible(NULL))
+  }
+  rows <- names(dropped)
+  if (is.null(rows)) {
+    rows <- as.character(unname(dropped))
+  }
+  stop("Your data contains ", length(dropped), " row(s) with missing values",
+       " (NA or NaN), at row(s) ", paste0(rows, collapse = ", "),
+       ". Every variable the formula names must be complete; remove or impute",
+       " those rows before fitting.", call. = FALSE)
+}
+
 #' check_data
 #'
 #' Check data input for a Bayesian NEC model fit
@@ -109,23 +146,16 @@ check_data <- function(data, family, model) {
   bnec_pop_vars <- attr(data, "bnec_pop")
   y_pos <- which(names(bnec_pop_vars) == "y_var")
   x_pos <- which(names(bnec_pop_vars) == "x_var")
-  # model.frame() removes incomplete cases before check_data() is given the
-  # data, so an NA or NaN never reached the finiteness guard below and the fit
-  # ran on fewer rows than were supplied with nothing said. Refused rather than
-  # announced: Inf is refused here already, and the sample the estimates are
-  # derived from is not something the package should change silently. The rows
-  # removed are recorded on the model frame by na.omit(), which is the only
-  # remaining evidence that they existed. See #278.
-  dropped <- attr(data, "na.action")
-  if (!is.null(dropped)) {
-    stop("Your data contains ", length(dropped), " row(s) with missing values",
-         " (NA or NaN), at row(s) ", paste0(unname(dropped), collapse = ", "),
-         ". The function bnec requires complete cases; remove or impute those",
-         " rows before fitting.")
-  }
+  # Kept here for the routes that do not come through bnec(): get_priors(),
+  # which checks each model of the set in turn, and amend(), which refits from
+  # the data frame an existing fit stores. bnec() and bnec_group() run it
+  # before any model is fitted, for the reason given at those call sites.
+  # See #278.
+  check_complete_cases(data)
   # is.finite() elementwise rather than on the mean, so that a column reaching
   # this point with NA still present -- a user with options(na.action =
-  # "na.pass"), for which the guard above sees nothing -- is named as well.
+  # "na.pass"), for which check_complete_cases() sees nothing -- is named as
+  # well.
   if (!all(is.finite(x))) {
     stop("Your predictor column contains values that are not finite.")
   }

--- a/R/plot.R
+++ b/R/plot.R
@@ -39,8 +39,12 @@ NULL
 #' estimated NEC value and 95% credible intervals should be added to the plot.
 #' @param add_ec10 A \code{\link[base]{logical}} value indicating if an
 #' estimated EC10 value and 95% credible intervals should be added to the plot.
-#' @param position_legend A \code{\link[base]{numeric}} vector indicating the
-#' location of the NEC or EC10 legend, as per a call to legend.
+#' @param position_legend Where to draw the NEC or EC10 legend, in either of
+#' the two forms \code{\link[graphics]{legend}} accepts: a single keyword out
+#' of \code{"left"}, \code{"topleft"}, \code{"top"}, \code{"topright"},
+#' \code{"right"}, \code{"bottomright"}, \code{"bottom"} and
+#' \code{"bottomleft"}, or a \code{\link[base]{numeric}} vector of length two
+#' giving the x and y coordinates of the legend in user units.
 #' @param xform A function to be applied as a transformation of the x data.
 #' @param lxform A function to be applied as a transformation only to axis
 #' labels and the annotated NEC / EC10 values.
@@ -84,13 +88,8 @@ plot.bayesnecfit <- function(x, ..., CI = TRUE, add_nec = TRUE,
   chk_lgl(jitter_y)
   chk_character(ylab)
   chk_character(xlab)
-  legend_positions <- c("left", "topleft", "top", "topright", 
-                        "right", "bottomright", "bottom","bottomleft")
-  if (length(na.omit(match(legend_positions, position_legend)))==0) {
-    stop(paste("legend positions must be one of ", paste0(legend_positions, collapse = ", " )))
-  }
+  legend_pos <- check_position_legend(position_legend)
   family <- x$fit$family$family
-  custom_name <- check_custom_name(x$fit$family)
   mod_dat <- model.frame(x$bayesnecformula, data = x$fit$data)
   y_var <- attr(mod_dat, "bnec_pop")[["y_var"]]
   x_var <- attr(mod_dat, "bnec_pop")[["x_var"]]
@@ -149,28 +148,18 @@ plot.bayesnecfit <- function(x, ..., CI = TRUE, add_nec = TRUE,
     rownames() |>
     suppressWarnings() |>
     suppressMessages()
-  if (!inherits(lxform, "function")) {
-    if (length(xticks) == 1) {
-      axis(side = 1)
-    } else {
-      axis(side = 1, at = signif(xticks, 2))
-    }
-    legend_nec <- paste(nec_tag, ": ", signif(nec["Estimate"], 2),
-                        " (", signif(nec["Q2.5"], 2), "-",
-                        signif(nec["Q97.5"], 2), ")", sep = "")
-    legend_ec10 <- paste("EC10: ", signif(ec10[1], 2),
-                         " (", signif(ec10[2], 2), "-",
-                         signif(ec10[3], 2), ")", sep = "")
-  } else {
-    x_labs <- signif(lxform(x_ticks), 2)
-    axis(side = 1, at = x_ticks, labels = x_labs)
-    legend_nec <- paste(nec_tag, ": ", signif(lxform(nec["Estimate"]), 2),
-                        " (", signif(lxform(nec["Q2.5"]), 2), "-",
-                        signif(lxform(nec["Q97.5"]), 2), ")", sep = "")
-    legend_ec10 <- paste("EC10: ", signif(lxform(ec10[1]), 2),
-                         " (", signif(lxform(ec10[2]), 2), "-",
-                         signif(lxform(ec10[3]), 2), ")", sep = "")
-  }
+  # lxform is guaranteed to be a function here, refused at the head of the
+  # method if it is not, so there is no branch for the case where it is not. One
+  # stood here until #278 and could never run. With the default
+  # lxform = identity these are the recorded values.
+  x_labs <- signif(lxform(x_ticks), 2)
+  axis(side = 1, at = x_ticks, labels = x_labs)
+  legend_nec <- paste(nec_tag, ": ", signif(lxform(nec["Estimate"]), 2),
+                      " (", signif(lxform(nec["Q2.5"]), 2), "-",
+                      signif(lxform(nec["Q97.5"]), 2), ")", sep = "")
+  legend_ec10 <- paste("EC10: ", signif(lxform(ec10[1]), 2),
+                       " (", signif(lxform(ec10[2]), 2), "-",
+                       signif(lxform(ec10[3]), 2), ")", sep = "")
   if (CI) {
     lines(x_vec, x$pred_vals$data$Q97.5, lty = 2)
     lines(x_vec, x$pred_vals$data$Q2.5, lty = 2)
@@ -178,18 +167,18 @@ plot.bayesnecfit <- function(x, ..., CI = TRUE, add_nec = TRUE,
   lines(x_vec, x$pred_vals$data$Estimate)
   if (add_nec & !add_ec10) {
     abline(v = nec, col = "red", lty = c(1, 3, 3))
-    legend(position_legend, bty = "n",
+    legend(legend_pos$x, legend_pos$y, bty = "n",
            legend = legend_nec, lty = 1, col = "red")
   }
   if (add_ec10 & !add_nec) {
     abline(v = ec10, col = "red", lty = c(1, 3, 3))
-    legend(position_legend, bty = "n",
+    legend(legend_pos$x, legend_pos$y, bty = "n",
            legend = legend_ec10, lty = 1, col = "red")
   }
   if (add_ec10 & add_nec) {
     abline(v = nec, col = "red", lty = c(1, 3, 3))
     abline(v = ec10, col = "orange", lty = c(1, 3, 3))
-    legend(position_legend, bty = "n",
+    legend(legend_pos$x, legend_pos$y, bty = "n",
            legend = c(legend_nec, legend_ec10),
            lty = 1, col = c("red", "orange"))
   }
@@ -227,12 +216,7 @@ plot.bayesmanecfit <- function(x, ..., CI = TRUE, add_nec = TRUE,
   chk_character(ylab)
   chk_character(xlab)
   chk_lgl(all_models)
-  legend_positions <- c("left", "topleft", "top", "topright", 
-          "right", "bottomright", "bottom","bottomleft")
-  if (length(na.omit(match(legend_positions, position_legend))) == 0) {
-    stop("Legend positions must be one of ",
-         paste0(legend_positions, collapse = ", " ), ".")
-  }
+  legend_pos <- check_position_legend(position_legend)
   if (all_models) {
     oldpar <- par(no.readonly = TRUE)
     on.exit(par(oldpar))
@@ -260,7 +244,6 @@ plot.bayesmanecfit <- function(x, ..., CI = TRUE, add_nec = TRUE,
     y_var <- attr(bdat, "bnec_pop")[["y_var"]]
     x_var <- attr(bdat, "bnec_pop")[["x_var"]]
     family <- universal$fit$family$family
-    custom_name <- check_custom_name(universal$fit$family)
     if (family == "binomial" | family == "beta_binomial") {
       trials_var <- attr(bdat, "bnec_pop")[["trials_var"]]
       y_dat <- mod_dat[[y_var]] / mod_dat[[trials_var]]
@@ -301,28 +284,15 @@ plot.bayesmanecfit <- function(x, ..., CI = TRUE, add_nec = TRUE,
       rownames() |>
       suppressWarnings() |>
       suppressMessages()
-    if (!inherits(lxform, "function")) {
-      if (length(xticks) == 1) {
-        axis(side = 1)
-      } else {
-        axis(side = 1, at = signif(xticks, 2))
-      }
-      legend_nec <- paste(nec_tag, ": ", signif(nec["Estimate"], 2),
-                          " (", signif(nec["Q2.5"], 2), "-",
-                          signif(nec["Q97.5"], 2), ")", sep = "")
-      legend_ec10 <- paste("EC10: ", signif(ec10[1], 2),
-                           " (", signif(ec10[2], 2), "-",
-                           signif(ec10[3], 2), ")", sep = "")
-    } else {
-      x_labs <- signif(lxform(x_ticks), 2)
-      axis(side = 1, at = x_ticks, labels = x_labs)
-      legend_nec <- paste(nec_tag, ": ", signif(lxform(nec["Estimate"]), 2),
-                          " (", signif(lxform(nec["Q2.5"]), 2), "-",
-                          signif(lxform(nec["Q97.5"]), 2), ")", sep = "")
-      legend_ec10 <- paste("EC10: ", signif(lxform(ec10[1]), 2),
-                           " (", signif(lxform(ec10[2]), 2), "-",
-                           signif(lxform(ec10[3]), 2), ")", sep = "")
-    }
+    # No lxform branch, for the reason given at the bayesnecfit site above.
+    x_labs <- signif(lxform(x_ticks), 2)
+    axis(side = 1, at = x_ticks, labels = x_labs)
+    legend_nec <- paste(nec_tag, ": ", signif(lxform(nec["Estimate"]), 2),
+                        " (", signif(lxform(nec["Q2.5"]), 2), "-",
+                        signif(lxform(nec["Q97.5"]), 2), ")", sep = "")
+    legend_ec10 <- paste("EC10: ", signif(lxform(ec10[1]), 2),
+                         " (", signif(lxform(ec10[2]), 2), "-",
+                         signif(lxform(ec10[3]), 2), ")", sep = "")
     if (CI) {
       lines(x_vec, x$w_pred_vals$data$Q97.5, lty = 2)
       lines(x_vec, x$w_pred_vals$data$Q2.5, lty = 2)
@@ -330,20 +300,61 @@ plot.bayesmanecfit <- function(x, ..., CI = TRUE, add_nec = TRUE,
     lines(x_vec, x$w_pred_vals$data$Estimate)
     if (add_nec & !add_ec10) {
       abline(v = nec, col = "red", lty = c(1, 3, 3))
-      legend(position_legend, bty = "n",
+      legend(legend_pos$x, legend_pos$y, bty = "n",
              legend = legend_nec, lty = 1, col = "red")
     }
     if (add_ec10 & !add_nec) {
       abline(v = ec10, col = "red", lty = c(1, 3, 3))
-      legend(position_legend, bty = "n",
+      legend(legend_pos$x, legend_pos$y, bty = "n",
              legend = legend_ec10, lty = 1, col = "red")
     }
     if (add_ec10 & add_nec) {
       abline(v = nec, col = "red", lty = c(1, 3, 3))
       abline(v = ec10, col = "orange", lty = c(1, 3, 3))
-      legend(position_legend, bty = "n",
+      legend(legend_pos$x, legend_pos$y, bty = "n",
              legend = c(legend_nec, legend_ec10),
              lty = 1, col = c("red", "orange"))
     }
   }
+}
+
+#' Validate and normalise the position_legend argument of the plot methods
+#'
+#' @param position_legend Either a single keyword out of the eight
+#' \code{\link[graphics]{legend}} accepts, or a \code{\link[base]{numeric}}
+#' vector of length two giving the x and y coordinates of the legend.
+#'
+#' @details Both forms are accepted because \code{legend} accepts both, and the
+#' documentation of \code{position_legend} named the numeric one while the guard
+#' this replaces refused it. That guard read
+#' \code{match(legend_positions, position_legend)}, which matches the valid
+#' keywords into the user's value rather than the reverse, so any value holding
+#' one valid keyword passed however much else was in it and failed later inside
+#' \code{legend()} with a message naming neither the argument nor the valid
+#' values. See #278.
+#'
+#' Returned as a list rather than passed through unchanged because
+#' \code{legend()} reads a length-two numeric \code{x} with \code{y = NULL} as
+#' the two corners of a rectangle, not as a point, so the pair has to be split
+#' across \code{x} and \code{y} at the call site.
+#'
+#' @return A \code{\link[base]{list}} with elements \code{x} and \code{y},
+#' suitable as the first two arguments of \code{\link[graphics]{legend}}.
+#'
+#' @noRd
+check_position_legend <- function(position_legend) {
+  legend_positions <- c("left", "topleft", "top", "topright", "right",
+                        "bottomright", "bottom", "bottomleft")
+  if (is.numeric(position_legend) && length(position_legend) == 2 &&
+        all(is.finite(position_legend))) {
+    return(list(x = position_legend[1], y = position_legend[2]))
+  }
+  if (is.character(position_legend) && length(position_legend) == 1 &&
+        position_legend %in% legend_positions) {
+    return(list(x = position_legend, y = NULL))
+  }
+  stop("position_legend must be one of ",
+       paste0("\"", legend_positions, "\"", collapse = ", "),
+       ", or a numeric vector of length two giving the x and y coordinates of",
+       " the legend.", call. = FALSE)
 }

--- a/R/plot.R
+++ b/R/plot.R
@@ -39,12 +39,14 @@ NULL
 #' estimated NEC value and 95% credible intervals should be added to the plot.
 #' @param add_ec10 A \code{\link[base]{logical}} value indicating if an
 #' estimated EC10 value and 95% credible intervals should be added to the plot.
-#' @param position_legend Where to draw the NEC or EC10 legend, in either of
-#' the two forms \code{\link[graphics]{legend}} accepts: a single keyword out
-#' of \code{"left"}, \code{"topleft"}, \code{"top"}, \code{"topright"},
-#' \code{"right"}, \code{"bottomright"}, \code{"bottom"} and
-#' \code{"bottomleft"}, or a \code{\link[base]{numeric}} vector of length two
-#' giving the x and y coordinates of the legend in user units.
+#' @param position_legend Where to draw the NEC or EC10 legend, in either the
+#' keyword form or the coordinate form \code{\link[graphics]{legend}} accepts:
+#' a single keyword out of \code{"left"}, \code{"topleft"}, \code{"top"},
+#' \code{"topright"}, \code{"right"}, \code{"bottomright"},
+#' \code{"bottom"} and \code{"bottomleft"}, or a \code{\link[base]{numeric}}
+#' vector of length two giving the x and y coordinates of the legend in user
+#' units. \code{legend}'s ninth keyword, \code{"center"}, is not accepted;
+#' give the coordinates instead.
 #' @param xform A function to be applied as a transformation of the x data.
 #' @param lxform A function to be applied as a transformation only to axis
 #' labels and the annotated NEC / EC10 values.
@@ -320,13 +322,15 @@ plot.bayesmanecfit <- function(x, ..., CI = TRUE, add_nec = TRUE,
 
 #' Validate and normalise the position_legend argument of the plot methods
 #'
-#' @param position_legend Either a single keyword out of the eight
-#' \code{\link[graphics]{legend}} accepts, or a \code{\link[base]{numeric}}
-#' vector of length two giving the x and y coordinates of the legend.
+#' @param position_legend Either a single keyword out of the eight listed in
+#' \code{?plot}, or a \code{\link[base]{numeric}} vector of length two giving
+#' the x and y coordinates of the legend.
 #'
 #' @details Both forms are accepted because \code{legend} accepts both, and the
 #' documentation of \code{position_legend} named the numeric one while the guard
-#' this replaces refused it. That guard read
+#' this replaces refused it. The keyword set is the eight that guard listed,
+#' which is \code{legend}'s nine less \code{"center"}; widening it is a
+#' separate decision from resolving the conflict. That guard read
 #' \code{match(legend_positions, position_legend)}, which matches the valid
 #' keywords into the user's value rather than the reverse, so any value holding
 #' one valid keyword passed however much else was in it and failed later inside

--- a/man/bnec.Rd
+++ b/man/bnec.Rd
@@ -30,7 +30,12 @@ R formula or an actual \code{\link[stats]{formula}} object. See
 \code{\link{bayesnecformula}} and \code{\link{check_formula}}.}
 
 \item{data}{A \code{\link[base]{data.frame}} containing the data to use with
-the \code{formula}.}
+the \code{formula}. Every variable the \code{formula} names must be
+complete: a row with an \code{NA}, \code{NaN} or \code{Inf} in any of them
+is refused rather than removed, so that the fit is never run on a smaller
+sample than was supplied without the user having chosen that. Apply
+\code{\link[stats]{na.omit}} before calling \code{bnec} where those rows
+are to be discarded.}
 
 \item{x_range}{A range of predictor values over which to consider extracting
 ECx.}

--- a/man/bnec.Rd
+++ b/man/bnec.Rd
@@ -31,9 +31,10 @@ R formula or an actual \code{\link[stats]{formula}} object. See
 
 \item{data}{A \code{\link[base]{data.frame}} containing the data to use with
 the \code{formula}. Every variable the \code{formula} names must be
-complete: a row with an \code{NA}, \code{NaN} or \code{Inf} in any of them
-is refused rather than removed, so that the fit is never run on a smaller
-sample than was supplied without the user having chosen that. Apply
+complete: a row with an \code{NA} or \code{NaN} in any of them is refused
+rather than removed, so that the fit is never run on a smaller sample than
+was supplied without the user having chosen that. An \code{Inf} in the
+predictor or the response is refused as well. Apply
 \code{\link[stats]{na.omit}} before calling \code{bnec} where those rows
 are to be discarded.}
 
@@ -442,14 +443,26 @@ evaluated by \code{brm()} instead, which \pkg{bayesnec} does not check, so
 the \code{-Inf} reaches Stan. Add the offset of your choice to the data and
 name that column in the formula.
 
-\bold{NAs are thrown away}
+\bold{Missing values}
 
-Stan's default behaviour is to fail when the input data contains NAs. For
-that reason \pkg{brms} excludes any NAs from input data prior to fitting,
-and does not allow them back in as is the case with e.g. \code{stats::lm} and
-\code{na.action = exclude}. So we advise that you exclude any NAs in your
-data prior to fitting because if you so wish that should facilitate merging
-predictions back onto your original dataset.
+A row with an \code{NA} or \code{NaN} in any variable the \code{formula}
+names is refused rather than removed, and so is an \code{Inf} in the
+predictor or the response. The error for a missing value reports how many
+rows held one and which they were, by row name; the error for a non-finite
+value names the column.
+
+\code{\link[stats]{model.frame}} drops incomplete cases before
+\pkg{bayesnec} is given the data, so until version 2.2.0 an \code{NA} left
+the fit running on fewer rows than were supplied with nothing said, while an
+\code{Inf} was refused. Both are now refused, so that the sample the
+estimates are derived from is the user's decision and is visible in the
+script.
+
+Apply \code{\link[stats]{na.omit}} to the data frame before calling
+\code{bnec} where those rows are to be discarded. The frame that results is
+the one the fit is derived from, so predictions align with it row for row:
+\pkg{brms} excludes NAs prior to fitting and does not pad the predictions
+back out, as \code{stats::lm} does with \code{na.action = na.exclude}.
 }
 \section{The link}{
 

--- a/man/plot.Rd
+++ b/man/plot.Rd
@@ -52,12 +52,14 @@ lower bounds of the individual predicted values from all posterior samples.}
 \item{add_nec}{A \code{\link[base]{logical}} value indicating if the
 estimated NEC value and 95\% credible intervals should be added to the plot.}
 
-\item{position_legend}{Where to draw the NEC or EC10 legend, in either of
-the two forms \code{\link[graphics]{legend}} accepts: a single keyword out
-of \code{"left"}, \code{"topleft"}, \code{"top"}, \code{"topright"},
-\code{"right"}, \code{"bottomright"}, \code{"bottom"} and
-\code{"bottomleft"}, or a \code{\link[base]{numeric}} vector of length two
-giving the x and y coordinates of the legend in user units.}
+\item{position_legend}{Where to draw the NEC or EC10 legend, in either the
+keyword form or the coordinate form \code{\link[graphics]{legend}} accepts:
+a single keyword out of \code{"left"}, \code{"topleft"}, \code{"top"},
+\code{"topright"}, \code{"right"}, \code{"bottomright"},
+\code{"bottom"} and \code{"bottomleft"}, or a \code{\link[base]{numeric}}
+vector of length two giving the x and y coordinates of the legend in user
+units. \code{legend}'s ninth keyword, \code{"center"}, is not accepted;
+give the coordinates instead.}
 
 \item{add_ec10}{A \code{\link[base]{logical}} value indicating if an
 estimated EC10 value and 95\% credible intervals should be added to the plot.}

--- a/man/plot.Rd
+++ b/man/plot.Rd
@@ -52,8 +52,12 @@ lower bounds of the individual predicted values from all posterior samples.}
 \item{add_nec}{A \code{\link[base]{logical}} value indicating if the
 estimated NEC value and 95\% credible intervals should be added to the plot.}
 
-\item{position_legend}{A \code{\link[base]{numeric}} vector indicating the
-location of the NEC or EC10 legend, as per a call to legend.}
+\item{position_legend}{Where to draw the NEC or EC10 legend, in either of
+the two forms \code{\link[graphics]{legend}} accepts: a single keyword out
+of \code{"left"}, \code{"topleft"}, \code{"top"}, \code{"topright"},
+\code{"right"}, \code{"bottomright"}, \code{"bottom"} and
+\code{"bottomleft"}, or a \code{\link[base]{numeric}} vector of length two
+giving the x and y coordinates of the legend in user units.}
 
 \item{add_ec10}{A \code{\link[base]{logical}} value indicating if an
 estimated EC10 value and 95\% credible intervals should be added to the plot.}

--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -70,6 +70,20 @@ test_that("ggbnec_data takes add_nec, and absorbs nec = FALSE into dots", {
 })
 
 
+test_that("a non-function xform is refused the same way on both classes", {
+  # The bayesnecfit method guarded xform and the bayesmanecfit method did not,
+  # so the same user error gave "xform must be a function." for one class and
+  # "could not find function \"xform\"" -- raised from inside mutate(), naming
+  # neither the argument nor what it should have been -- for the other. The
+  # guard was added to the model-set method in #278.
+  skip_on_cran()
+  expect_error(ggbnec_data(nec4param, xform = "no"),
+               "xform must be a function")
+  expect_error(ggbnec_data(manec_example, xform = "no"),
+               "xform must be a function")
+})
+
+
 # ---- xform on the predictor axis --------------------------------------------
 
 test_that("xform is applied to the predictor axis of a single fit", {

--- a/tests/testthat/test-bnec.R
+++ b/tests/testthat/test-bnec.R
@@ -14,6 +14,40 @@ test_that("user-supplied `prior` is not captured by partial matching to `prior_t
                "argument \"data\" is missing")
 })
 
+test_that("a model set states the missing-value refusal once, from bnec()", {
+  # check_data() runs once per model inside fit_bayesnec(), and bnec() wraps
+  # that call in try() for a model set, so a refusal raised from there was
+  # printed once per model and the call then ended on the generic
+  # all-models-failed advice, which names neither the missing values nor the
+  # remedy. The default model argument is a set, so that is the common path.
+  # The check is raised in bnec() instead, immediately after the model frame is
+  # built. See #278.
+  d <- nec_data
+  d$y[3] <- NA
+  msg <- tryCatch(bnec(y ~ crf(x, model = c("nec3param", "nec4param")),
+                       data = d, family = Beta(link = "identity")),
+                  error = conditionMessage)
+  expect_match(msg, "1 row\\(s\\) with missing values")
+  expect_false(grepl("None of the models fit successfully", msg))
+})
+
+test_that("the refusal precedes the family choice, so nothing is read off a subset", {
+  # Placed immediately after the model frame is built rather than beside
+  # check_normalisation(), so that nothing downstream, retrieve_valid_family()
+  # included, is decided from a smaller sample than was supplied. Asserted by
+  # the absence of the family-selection message, which is the only observable
+  # thing that runs between the two positions on this input. See #278.
+  d <- nec_data
+  d$y[3] <- NA
+  msgs <- capture.output(
+    msg <- tryCatch(bnec(y ~ crf(x, model = "nec3param"), data = d),
+                    error = conditionMessage),
+    type = "message"
+  )
+  expect_match(msg, "1 row\\(s\\) with missing values")
+  expect_length(msgs, 0)
+})
+
 test_that("Check models inappropriate for negative x are dropped", {
   # The family is given explicitly because nec_data's response is 0-1 bounded,
   # for which nechorme4pwr is now excluded up front (#177) -- the negative-x

--- a/tests/testthat/test-bnec_group.R
+++ b/tests/testthat/test-bnec_group.R
@@ -37,6 +37,28 @@ test_that("a level too small to support a fit is refused", {
   )
 })
 
+test_that("a missing value is refused before the first level is fitted", {
+  # Each level is a complete fit, so without a check before the loop a missing
+  # value in level "b" would be reached only after level "a" had compiled and
+  # sampled. Measured on two levels of twelve: level "a" ran to completion
+  # before level "b" raised. The whole data frame is checked, so the row is
+  # named as the user recorded it rather than by its position within a subset.
+  # See #278.
+  d <- data.frame(x = rep(1:10, 2), y = rep(seq(0.9, 0.1, length = 10), 2),
+                  site = rep(c("a", "b"), each = 10))
+  d$y[14] <- NA
+  msgs <- capture.output(
+    msg <- tryCatch(bnec_group(y ~ crf(x, "nec3param"), d, group_var = "site"),
+                    error = conditionMessage),
+    type = "message"
+  )
+  expect_match(msg, "1 row\\(s\\) with missing values")
+  expect_match(msg, "at row\\(s\\) 14")
+  # Nothing was fitted: bnec_group() announces every level it starts, so the
+  # absence of that message is what says the loop was never entered.
+  expect_false(any(grepl("Fitting level", msgs)))
+})
+
 test_that("crossed_group_weights requires the right class", {
   expect_error(crossed_group_weights(manec_example), "bayesnecgroupfit")
 })

--- a/tests/testthat/test-check_data.R
+++ b/tests/testthat/test-check_data.R
@@ -29,6 +29,10 @@ cd_run <- function(formula, data, family, model = "nec3param") {
   check_data(cd_bdat(formula, data), family, model)
 }
 
+# The missing-value refusal, as a regex, so the count and the rows can be
+# asserted around it without repeating the fixed part.
+cd_missing_msg <- "row\\(s\\) with missing values \\(NA or NaN\\), at row\\(s\\)"
+
 # The messages check_data() emits, as a character vector. Several corrections
 # are silent, and asserting the absence of a message is half of what this file
 # is for, so the helper returns them rather than swallowing them.
@@ -75,20 +79,34 @@ test_that("an NA or NaN row is refused, and the row is named", {
   # message can name them.
   d <- cd_data_zero()
   d$y[1] <- NaN
-  missing_msg <- "row\\(s\\) with missing values \\(NA or NaN\\), at row\\(s\\)"
   expect_error(cd_run(y ~ crf(x, model = "nec3param"), d, gaussian()),
-               paste("1", missing_msg, "1"))
+               paste("1", cd_missing_msg, "1"))
   # NA in the predictor is refused on the same route, and more than one row is
   # counted and named rather than only the first.
   d2 <- cd_data_zero()
   d2$x[c(2, 7)] <- NA
   expect_error(cd_run(y ~ crf(x, model = "nec3param"), d2, gaussian()),
-               paste("2", missing_msg, "2, 7"))
+               paste("2", cd_missing_msg, "2, 7"))
   # The remedy is named, since the user has to act on it: dropping the rows is
   # no longer done for them.
   msg <- tryCatch(cd_run(y ~ crf(x, model = "nec3param"), d, gaussian()),
                   error = conditionMessage)
   expect_match(msg, "remove or impute those rows")
+  # And no function is named, because three of them reach this check: bnec()
+  # and bnec_group() before they fit anything, and get_priors() per model.
+  expect_false(grepl("The function bnec", msg))
+})
+
+test_that("the rows are reported by name, not by position", {
+  # names(attr(data, "na.action")) holds the row names and its values hold the
+  # positions. The name is what the user sees in their own data frame, and
+  # where bnec() has been handed a subset -- one level of a bnec_group() call
+  # -- a position indexes the subset and names no row of the data supplied.
+  d <- cd_data_zero()
+  rownames(d) <- paste0("s", seq_len(nrow(d)) + 100L)
+  d$y[3] <- NA
+  expect_error(cd_run(y ~ crf(x, model = "nec3param"), d, gaussian()),
+               paste("1", cd_missing_msg, "s103"))
 })
 
 test_that("an NA reaching the guard directly is named by column", {

--- a/tests/testthat/test-check_data.R
+++ b/tests/testthat/test-check_data.R
@@ -66,17 +66,47 @@ test_that("a non-finite response is refused, naming the response", {
                "response column contains values that are not finite")
 })
 
-test_that("an NA or NaN row is dropped by model.frame, not caught by the check", {
-  # The finiteness guard sees only what model.frame() passes it, and
-  # model.frame() drops incomplete cases first. So Inf reaches the guard and is
-  # refused, while NA and NaN are removed silently and the fit proceeds on
-  # fewer rows than the user supplied. Pinned because the two behave
-  # differently and neither is announced; it is the same class of gap as #271,
-  # where a disp() sub-model is not checked for finiteness at all.
+test_that("an NA or NaN row is refused, and the row is named", {
+  # model.frame() removes incomplete cases before check_data() is given the
+  # data, so until #278 an NA or NaN left the fit running on fewer rows than
+  # were supplied with nothing said, while Inf was refused. Both are now
+  # refused. The rows model.frame() removed are read off the na.action
+  # attribute, which is the only remaining evidence that they existed, so the
+  # message can name them.
   d <- cd_data_zero()
   d$y[1] <- NaN
-  res <- cd_run(y ~ crf(x, model = "nec3param"), d, gaussian())
-  expect_identical(nrow(res$mod_dat), nrow(d) - 1L)
+  missing_msg <- "row\\(s\\) with missing values \\(NA or NaN\\), at row\\(s\\)"
+  expect_error(cd_run(y ~ crf(x, model = "nec3param"), d, gaussian()),
+               paste("1", missing_msg, "1"))
+  # NA in the predictor is refused on the same route, and more than one row is
+  # counted and named rather than only the first.
+  d2 <- cd_data_zero()
+  d2$x[c(2, 7)] <- NA
+  expect_error(cd_run(y ~ crf(x, model = "nec3param"), d2, gaussian()),
+               paste("2", missing_msg, "2, 7"))
+  # The remedy is named, since the user has to act on it: dropping the rows is
+  # no longer done for them.
+  msg <- tryCatch(cd_run(y ~ crf(x, model = "nec3param"), d, gaussian()),
+                  error = conditionMessage)
+  expect_match(msg, "remove or impute those rows")
+})
+
+test_that("an NA reaching the guard directly is named by column", {
+  # The na.action attribute is absent when the user has set
+  # options(na.action = "na.pass"), so the finiteness guard is the only thing
+  # that sees the missing value. It reads is.finite() elementwise rather than
+  # is.finite(mean(x)) so that this case is refused too, naming which of the
+  # two columns holds it.
+  old <- options(na.action = "na.pass")
+  on.exit(options(old), add = TRUE)
+  d <- cd_data_zero()
+  d$x[1] <- NA
+  expect_error(cd_run(y ~ crf(x, model = "nec3param"), d, gaussian()),
+               "predictor column contains values that are not finite")
+  d2 <- cd_data_zero()
+  d2$y[1] <- NaN
+  expect_error(cd_run(y ~ crf(x, model = "nec3param"), d2, gaussian()),
+               "response column contains values that are not finite")
 })
 
 test_that("a response that increases with the predictor warns", {
@@ -94,58 +124,48 @@ test_that("a hormesis model is exempt from the decline warning", {
 })
 
 
-# ---- two guards in check_data() that nothing can reach -----------------------
+# ---- the two guards check_data() no longer duplicates -----------------------
 #
-# Both branches below are written in check_data() and neither can fire, because
-# an earlier call raises first on the same input. They are pinned rather than
-# removed: a test that names the reachable error is what tells the next reader
-# that the branch underneath it is dead, and #265 is the precedent for a
-# condition that was written, never fired, and went unnoticed for five years.
+# check_data() used to compose its own message for each of the two inputs
+# below, and neither branch could fire: an earlier call raised first on the same
+# input. Both were removed in #278. The tests remain, asserting the error that
+# does fire, so that a reader who reinstates either branch is told what already
+# refuses the input.
 
-test_that("a character predictor errors from retrieve_var, not check_data", {
+test_that("a character predictor errors from retrieve_var", {
   d <- cd_data_zero()
   d$x <- as.character(d$x)
-  # check_data():112-118 composes "Your indicated predictor column ... requires
-  # the predictor column to be numeric". retrieve_var(error = TRUE) at :108
-  # raises first, so that message can never be produced.
   msg <- tryCatch(cd_run(y ~ crf(x, model = "nec3param"), d, gaussian()),
                   error = conditionMessage)
   expect_match(msg, "is not numeric")
-  expect_false(grepl("indicated predictor column", msg))
 })
 
-test_that("a numeric group-level column errors from model.frame, not check_data", {
+test_that("a numeric group-level column errors from model.frame", {
   d <- cd_data_zero()
   d$grp <- rep(1:2, 10)
-  # check_data():203-209 composes "Your group-level column(s) ... must be either
-  # a character or a factor". model.frame() refuses first, so that message can
-  # never be produced either.
   msg <- tryCatch(cd_run(y ~ crf(x, model = "nec3param") + ogl(grp), d,
                          gaussian()),
                   error = conditionMessage)
   expect_match(msg, "Group-level variables cannot be numeric")
-  expect_false(grepl("must be either a character or a factor", msg))
 })
 
 
-test_that("the check_custom_name result is discarded", {
-  # R/check_data.R:211 assigns custom_name <- check_custom_name(family) and
-  # nothing reads it; custom_name occurs once in the file. check_custom_name()
-  # is pure (R/helpers.R:18-24), so the call has no effect at all. The same
-  # dead assignment is at R/plot.R:93, R/plot.R:263 and R/autoplot.R:178.
+test_that("check_data does not call check_custom_name", {
+  # check_data() used to assign custom_name <- check_custom_name(family) and
+  # read it nowhere. check_custom_name() is pure, so the call had no effect and
+  # was removed in #278, along with the same dead assignment at three further
+  # sites in plot() and prep_raw_data().
   #
-  # Asserted by making the call return a value nothing could sensibly use and
-  # showing the result is unchanged, which pins the discard rather than the
-  # call. This is the third site of its kind in check_data(), after the two
-  # unreachable branches above, and it has no issue either.
+  # Asserted by making the call raise. A discarded result cannot be observed
+  # from the return value -- which is why the assignment survived -- so the
+  # absence of the call is what is asserted instead.
   d <- cd_data_zero()
-  plain <- cd_run(y ~ crf(x, model = "nec3param"), d, gaussian())
   local_mocked_bindings(
-    check_custom_name = function(...) "a value no caller reads",
+    check_custom_name = function(...) stop("check_custom_name was called"),
     .package = "bayesnec"
   )
-  expect_identical(cd_run(y ~ crf(x, model = "nec3param"), d, gaussian()),
-                   plain)
+  expect_error(cd_run(y ~ crf(x, model = "nec3param"), d, gaussian()),
+               NA)
 })
 
 

--- a/tests/testthat/test-fit_bayesnec.R
+++ b/tests/testthat/test-fit_bayesnec.R
@@ -111,13 +111,20 @@ test_that("the write-back still reaches brm() with no transformation at all", {
   # check_data() and fit_bayesnec() directly.
 })
 
-test_that("the write-back aligns rows when incomplete cases were dropped", {
+test_that("an incomplete case is refused before the write-back", {
+  # This case used to reach the write-back: model.frame() dropped the row, the
+  # write-back matched the remainder by name, and the fit proceeded on one row
+  # fewer than was supplied without saying so. check_data() refuses it as of
+  # #278, so the write-back is never asked to align around a missing row.
+  #
+  # The row-name matching the write-back does is still asserted, by the case
+  # below that gives the data frame names other than 1:n. It is what makes the
+  # write-back correct rather than what makes it survive a dropped row.
   d <- gamma_boundary_data()
   d$y[2] <- NA
-  out <- brm_data(y ~ crf(x, model = "nec3param"), d, Gamma(link = "identity"))
-  expect_equal(nrow(out), nrow(d))
-  expect_true(is.na(out$y[2]))
-  expect_equal(min(out$y, na.rm = TRUE), 0.3)
+  expect_error(brm_data(y ~ crf(x, model = "nec3param"), d,
+                        Gamma(link = "identity")),
+               "1 row\\(s\\) with missing values")
 })
 
 test_that("the write-back finds the right rows when row names are not 1:n", {
@@ -234,18 +241,33 @@ test_that("a disp() sub-model is built from the predictor as recorded", {
 
 test_that("a binomial fit reaches brm() with its trials column untouched", {
   # There is no trials write-back, because check_data() never corrects trials.
-  # The assertion is that the column arrives as recorded even where the model
-  # frame has dropped an incomplete case, which is where the write-back this
-  # replaced would have failed outright.
+  # The assertion is that the column arrives exactly as recorded, which is what
+  # the all-variable write-back this replaced did not do: it mapped the aterm
+  # back to the bare column name and overwrote it.
   d <- data.frame(x = rep(c(1, 10, 100), each = 4),
                   y = as.integer(rep(c(9, 5, 1), each = 4)),
                   n = as.integer(rep(10, 12)))
-  d$y[2] <- NA
   seen <- fit_data(y | trials(n) ~ crf(log(x), model = "nec3param"), d,
                    binomial(link = "identity"))
   expect_identical(seen$n, d$n)
   expect_equal(nrow(seen), nrow(d))
-  expect_true(is.na(seen$y[2]))
+  expect_identical(seen$y, d$y)
+})
+
+test_that("an incomplete case is refused for a binomial fit too", {
+  # The trials aterm and the response are both population variables, so an NA
+  # in either is dropped by model.frame() and refused by check_data(). Asserted
+  # on the trials column, which the response case above does not cover. See
+  # #278.
+  d <- data.frame(x = rep(c(1, 10, 100), each = 4),
+                  y = as.integer(rep(c(9, 5, 1), each = 4)),
+                  n = as.integer(rep(10, 12)))
+  d$n[3] <- NA
+  expect_error(
+    fit_data(y | trials(n) ~ crf(log(x), model = "nec3param"), d,
+             binomial(link = "identity")),
+    "1 row\\(s\\) with missing values"
+  )
 })
 
 test_that("a model set stops once on the conflict, not once per model", {

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -231,6 +231,11 @@ test_that("position_legend refuses what legend() cannot use, either class", {
                  "position_legend must be one of")
     expect_error(pl_x_max(obj, position_legend = c(0.5, 0.5, 0.5)),
                  "position_legend must be one of")
+    # "center" is legend()'s ninth keyword and was not among the eight the
+    # guard this replaces listed. Pinned because ?plot now names the exclusion,
+    # so widening the set later is a decision rather than an oversight.
+    expect_error(pl_x_max(obj, position_legend = "center"),
+                 "position_legend must be one of")
   }
 })
 

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -142,24 +142,16 @@ test_that("add_nec and add_ec10 decide what is annotated", {
 })
 
 
-# ---- two guards in plot() that nothing can reach ----------------------------
-#
-# The same shape as the two dead branches this branch pins in check_data(): a
-# condition written, never fired. Neither has an issue yet.
+# ---- the axis and the argument guards ---------------------------------------
 
-test_that("the lxform branch in plot() cannot be reached, on either class", {
-  # R/plot.R:152-157 and :304-309 compose an axis call for the case where
-  # lxform is not a function. Each is preceded by a guard that has already
-  # stopped on that input -- R/plot.R:80-82 for a bayesnecfit and :222-224 for
-  # a bayesmanecfit -- and lxform is not reassigned between them, so both
-  # conditions are always FALSE and the else at :164 and :316 always runs. The
-  # consequence is that axis(side = 1) and axis(side = 1, at = signif(xticks,
-  # 2)) are dead at both sites, and xticks is always applied through the else.
+test_that("the axis is always drawn with at and labels, on either class", {
+  # plot() used to branch on lxform not being a function, and neither branch
+  # could run: the guard at the head of each method has already stopped on that
+  # input and lxform is not reassigned between them. Both branches were removed
+  # in #278, leaving one axis call per method.
   #
   # Both classes are asserted. Pinning one and not the other is how the
   # bayesmanecfit half of #268 escaped notice for six review rounds.
-  #
-  # Pinned as current behaviour, not asserted to be correct.
   skip_on_cran()
   expect_error(pl_x_max(nec4param, lxform = "not a function"),
                "lxform must be a function")
@@ -176,51 +168,70 @@ test_that("the lxform branch in plot() cannot be reached, on either class", {
   pl_x_max(manec_example, xticks = c(0, 1, 2, 3))
   # The count first. all() of an empty list is TRUE, so without this the
   # assertion below would also pass if axis() were never called at all -- which
-  # is a reachable state, since xaxt = "n" is set at R/plot.R:145 and the axis
-  # is drawn only by these calls.
+  # is a reachable state, since xaxt = "n" is set before the axis is drawn and
+  # these calls are the only thing that draws it.
   expect_length(calls, 4)
-  # Every call comes from the else branch, which always supplies at and labels.
-  # The dead calls are at R/plot.R:154 and :156 and R/plot.R:306 and :308. A
-  # reachable :154 or :306 would produce a call with neither name; a reachable
-  # :156 or :308 would produce one with at but no labels. Requiring both names
-  # excludes all four.
+  # The surviving call always supplies at and labels. A reinstated
+  # axis(side = 1) would produce a call with neither name; a reinstated
+  # axis(side = 1, at = signif(xticks, 2)) would produce one with at but no
+  # labels. Requiring both names excludes both.
   expect_true(all(vapply(calls, function(nm) all(c("at", "labels") %in% nm),
                          logical(1))))
 })
 
-test_that("position_legend refuses the numeric vector its documentation names", {
-  # R/plot.R:42-43 documents position_legend as "a numeric vector indicating
-  # the location of the NEC or EC10 legend, as per a call to legend". The guard
-  # at :89-91 accepts only the eight keyword strings, so the documented form is
-  # refused. Pinned as current behaviour: the guard and the documentation
-  # disagree and neither is asserted anywhere else.
+test_that("position_legend accepts both forms legend() accepts", {
+  # position_legend was documented as "a numeric vector indicating the location
+  # of the NEC or EC10 legend, as per a call to legend" and its guard accepted
+  # only the eight keyword strings, so the documented form was refused. #278
+  # resolved the conflict in favour of the documentation: both forms are
+  # accepted, as legend() accepts both.
+  #
+  # A length-2 numeric cannot be passed to legend() as its x alone -- with
+  # y = NULL it reads as the two corners of a rectangle -- so the pair is split
+  # across x and y. Asserted on what legend() was given rather than on the
+  # device, since the legend position does not change par("usr").
   skip_on_cran()
-  expect_error(pl_x_max(nec4param, position_legend = c(0.5, 0.5)),
-               "legend positions must be one of")
-  # R/plot.R:232-235 is the same guard for a bayesmanecfit, with the same
-  # inversion and a differently worded message. Asserted so that the issue this
-  # becomes states both call sites.
-  expect_error(pl_x_max(manec_example, position_legend = c(0.5, 0.5)),
-               "Legend positions must be one of")
-  # And the arguments to match() are the wrong way round -- the vector of valid
-  # keywords is matched into the user's value rather than the reverse -- so a
-  # value containing one valid keyword passes the guard however much else is in
-  # it, and fails later inside legend() with a message that names neither the
-  # argument nor the valid values. Same shape as #265: a condition that does not
-  # test what it reads as testing.
-  msg <- tryCatch(pl_x_max(nec4param,
-                           position_legend = c("topright", "bogus")),
-                  error = conditionMessage)
-  expect_match(msg, "'arg' must be of length 1")
-  expect_false(grepl("legend positions must be one of", msg))
+  seen <- list()
+  local_mocked_bindings(
+    legend = function(x, y = NULL, ...) {
+      seen[[length(seen) + 1L]] <<- list(x = x, y = y)
+      invisible(NULL)
+    },
+    .package = "bayesnec"
+  )
+  pl_x_max(nec4param, position_legend = c(0.5, 0.25))
+  pl_x_max(manec_example, position_legend = c(0.5, 0.25))
+  pl_x_max(nec4param, position_legend = "bottomleft")
+  expect_length(seen, 3)
+  expect_identical(seen[[1]], list(x = 0.5, y = 0.25))
+  expect_identical(seen[[2]], list(x = 0.5, y = 0.25))
+  expect_identical(seen[[3]], list(x = "bottomleft", y = NULL))
+})
+
+test_that("position_legend refuses what legend() cannot use, either class", {
+  # The arguments to match() used to be the wrong way round -- the vector of
+  # valid keywords was matched into the user's value rather than the reverse --
+  # so a value holding one valid keyword passed however much else was in it,
+  # and failed later inside legend() with "'arg' must be of length 1", naming
+  # neither the argument nor the valid values. Same shape as #265: a condition
+  # that does not test what it reads as testing.
+  #
   # Both halves on both classes. Asserting the refusal on both and the
   # inversion on one is how the earlier bayesmanecfit gaps in this file arose:
-  # repairing R/plot.R:232 alone left every assertion here passing.
-  msg_m <- tryCatch(pl_x_max(manec_example,
-                             position_legend = c("topright", "bogus")),
+  # repairing one call site alone left every assertion here passing.
+  skip_on_cran()
+  for (obj in list(nec4param, manec_example)) {
+    msg <- tryCatch(pl_x_max(obj, position_legend = c("topright", "bogus")),
                     error = conditionMessage)
-  expect_match(msg_m, "'arg' must be of length 1")
-  expect_false(grepl("Legend positions must be one of", msg_m))
+    expect_match(msg, "position_legend must be one of")
+    expect_false(grepl("'arg' must be of length 1", msg))
+    # An unknown keyword on its own, and a numeric of the wrong length: the two
+    # forms are each refused by the message that names both.
+    expect_error(pl_x_max(obj, position_legend = "bogus"),
+                 "position_legend must be one of")
+    expect_error(pl_x_max(obj, position_legend = c(0.5, 0.5, 0.5)),
+                 "position_legend must be one of")
+  }
 })
 
 


### PR DESCRIPTION
Closes #278.

## What

Three arguments in `check_data()`, `plot()` and `ggbnec_data()` behaved in a way
the documentation did not describe, and four guards were unreachable. All seven
items are addressed, following the two decisions RF made on the choices #278
flagged.

## Why it matters

`bnec()` no longer fits on fewer rows than were supplied. `stats::model.frame()`
removes incomplete cases before `check_data()` is given the model frame, so `Inf`
was refused while `NA` and `NaN` were removed silently — twenty rows supplied,
nineteen fitted, nothing said. That is now an error naming the count and the rows.

`position_legend` accepts the numeric form its own documentation has always named,
and refuses a value `legend()` cannot use with a message that names the argument.
`ggbnec_data()` reports the same `xform` error for both fit classes.

**This narrows a behaviour introduced earlier in 2.2.0.** The response write-back
was changed to match rows by name so that a data frame with an `NA` in a population
variable no longer failed with "replacement has *n* rows, data has *m*". That input
is now refused before the write-back is reached. The row matching is still required
and still asserted, by the case that gives the data frame row names other than
`1:n`. The NEWS entry was rewritten to say so.

## Evidence

Item 1 is the only one with a scientific consequence, and #278 records the
measurement: twenty rows supplied, nineteen fitted, no message. Items 2, 3, 6 and 7
were measured by calling each function directly at `27d504de`; items 4 and 5 by
observing which error fires. All but item 3 were pinned by #276, and every pinning
assertion is inverted in this branch, so each test now states the new behaviour.

The full `testthat` suite was run on R 4.6.1 with `NOT_CRAN=true`, so nothing
was skipped: 57 files, no failures and no errors. The two warnings reported are
both present on `dev`. The eight files most exposed to the change —
`test-check_data.R`, `test-plot.R`, `test-autoplot.R`, `test-fit_bayesnec.R`,
`test-cens.R`, `test-get_priors.R`, `test-hurdle_family.R` and
`test-check_normalisation.R` — account for 144 of those tests.

<details>
<summary>Implementation detail</summary>

### Item 1 — the finiteness guard and missing values

Decided in the request: the guard refuses `NA` and `NaN` as it refuses `Inf`.

Three implementations were considered.

1. `na.action = na.pass` in `model.frame.bayesnecformula()`, so the rows survive
   and the existing guard names the column. **Rejected.** `check_data()` is not the
   first thing to see `bdat` in `bnec()` — `retrieve_valid_family()` calls
   `set_distribution()` on the response, and `check_normalisation()` and
   `check_inline_boundary()` both run first — so the error would come from one of
   those, about the wrong thing. It would also change what the other eight callers
   of the exported `model.frame` method receive.
2. Refuse inside `model.frame.bayesnecformula()`. **Rejected** for the same reason —
   eight callers, most of them on data a fit has already validated — and because
   the check belongs in the documented data check.
3. Refuse in `check_data()`, reading the rows off the `na.action` attribute
   `na.omit()` leaves on the model frame. **Adopted.** Unchanged for every other
   caller, and it covers all three routes into `check_data()` — `bnec()`,
   `fit_bayesnec()` and `get_priors()`.

The message reports the count and the row numbers. The column cannot be named from
the attribute once the rows are gone, so it is not.

The guard itself changed from `!is.finite(mean(x))` to `!all(is.finite(x))`. The
two agree on every input the first can see; the elementwise form also refuses a
missing value arriving through `options(na.action = "na.pass")`, where the attribute
is absent, and names which column holds it.

### Item 2 — `position_legend`

Two defects in one guard, at two call sites with two different messages. The
`match()` arguments were reversed, so `c("topright", "bogus")` passed and failed
inside `legend()` with `'arg' must be of length 1`. And the numeric form the
documentation named was refused.

Replaced with one `check_position_legend()`, accepting either a single keyword or a
length-two numeric and returning `list(x =, y =)`. The list is necessary: `legend()`
reads a length-two numeric `x` with `y = NULL` as the two corners of a rectangle,
not as a point, so passing the pair through as `x` would have placed the legend
somewhere the user did not ask for while appearing to work. The pair is split across
`x` and `y` at all six call sites.

Partial keyword matching was never available — the old guard required an exact
match before `legend()` saw the value — so `%in%` removes nothing that was available.

### Item 3 — `xform` for a model set

One guard added to `ggbnec_data.bayesmanecfit()`, matching
`ggbnec_data.bayesnecfit()`.

### Items 4 to 7 — deletions

Removed: the predictor and group-level type checks in `check_data()`, which
`retrieve_var()` and `stats::model.frame()` refuse first with the same substance;
the `lxform` branch in each `plot()` method; and the four discarded
`check_custom_name()` assignments #278 names.

The `check_custom_name` test now mocks the function to raise, which is the only way
the absence of a discarded call can be observed — asserting on the return value
cannot distinguish a pure call from no call, which is why the assignment survived.

### Found but not changed

Four further discarded `check_custom_name()` assignments exist outside the four
#278 names: `R/fit_bayesnec.R:38` (overwritten at `:57`), `R/amend.R:251`,
`R/define_prior.R:128` and `R/helpers.R:442`. Same defect, no behavioural
consequence, and outside what was agreed for this branch. A follow-up issue is
warranted if that group is considered worth changing.

### Files

| file | change |
|---|---|
| `R/check_data.R` | missing-value guard; elementwise finiteness; two dead branches and one discarded call removed |
| `R/plot.R` | `check_position_legend()`; both guards replaced; both `lxform` branches and both discarded calls removed; `position_legend` documentation |
| `R/autoplot.R` | `xform` guard on the model-set method; one discarded call removed |
| `R/bnec.R` | `@param data` states the complete-case requirement |
| `NEWS.md` | four entries; the write-back entry rewritten |
| `tests/testthat/` | every #276 pin inverted; three new cases |

</details>


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqT4YPVMUGKu3m5QQZFXfs
