### PR TITLE
Pin StanHeaders to 2.32.x on Windows so rstan can compile a model

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -46,16 +46,46 @@ jobs:
             stan-dev/cmdstanr
             RcppEigen
 
-      # Configures the Rtools toolchain on Windows. It does NOT install
-      # StanHeaders or rstan: `setup-r-dependencies` has already installed a
-      # matched pair through pak, and reinstalling either one over that pair is
-      # what caused #275. The two `install.packages()` calls removed here passed
-      # `repos = c("https://mc-stan.org/r-packages/", getOption("repos"))`, which
-      # is a fallback list rather than a preference, so an unreachable mc-stan
-      # index silently installed CRAN StanHeaders 2.39.1 over the 2.32.10 that
-      # matches rstan 2.32.7 and every brm() call then failed to compile. They
-      # were added in 7c52e186 (2022-11-01) to obtain a preview rstan for R 4.2;
-      # CRAN rstan supports current R, so the preview build is no longer needed.
+      # Pins StanHeaders on Windows. CRAN rstan 2.32.7 declares
+      # `StanHeaders (>= 2.32.0)` with no upper bound, so pak correctly resolves
+      # to StanHeaders 2.39.1 (published 2026-09-02); rstan 2.32.7 then cannot
+      # compile a model on Windows, and every brm() call fails with
+      # "invalid connection". See #275. macOS and Ubuntu pass with that same
+      # pair, so the pin is applied only where the failure occurs and the other
+      # three jobs keep checking against current CRAN.
+      #
+      # The dated snapshot serves StanHeaders 2.32.10 -- the last 2.32 release,
+      # and the version installed by the most recent green Windows run
+      # (dev bc5f7d00, 2026-09-02 04:55 UTC, before 2.39.1 was published at
+      # 12:10 UTC that day). Remove this step once CRAN rstan is released
+      # against StanHeaders 2.39 or later.
+      #
+      # The version is asserted rather than assumed: install.packages() only
+      # warns when a repository is unreachable, so without the check an
+      # unreachable snapshot would leave 2.39.1 in place and reproduce #275
+      # after a 30-minute test run instead of failing here with a named cause.
+      - name: Pin StanHeaders to a version rstan can compile against
+        if: runner.os == 'Windows'
+        run: |
+          install.packages("StanHeaders", repos = "https://packagemanager.posit.co/cran/2026-09-02")
+          sh <- packageVersion("StanHeaders")
+          rs <- packageVersion("rstan")
+          if (!grepl("^2[.]32[.]", sh)) {
+            stop("StanHeaders ", sh, " is installed but 2.32.x is required to ",
+                 "match rstan ", rs, "; see #275")
+          }
+          cat("StanHeaders", format(sh), "with rstan", format(rs), "\n")
+        shell: Rscript {0}
+
+      # Configures the Rtools toolchain on Windows. It no longer installs
+      # StanHeaders or rstan from https://mc-stan.org/r-packages/. Those two
+      # `install.packages()` calls were added in 7c52e186 (2022-11-01) to obtain
+      # a preview rstan for R 4.2; CRAN rstan supports current R, and neither
+      # `rstantools` nor `cmdstanr` is a dependency of this package, so the
+      # preview build is no longer needed. They also passed the mc-stan index
+      # and `getOption("repos")` together, which is a fallback list rather than
+      # a preference, so an unreachable index installed from CRAN without
+      # erroring -- a second, intermittent source of the same version skew.
       - name: Use Cmdstan to Fix
         run: |
           cmdstanr::check_cmdstan_toolchain(fix = TRUE)

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         config:
           - {os: macOS-latest,   r: 'release'}
-          - {os: windows-latest, r: 'release', rtools-version: '42'}
+          - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           # - {os: ubuntu-latest,   r: 'oldrel-1'}
@@ -46,10 +46,18 @@ jobs:
             stan-dev/cmdstanr
             RcppEigen
 
+      # Configures the Rtools toolchain on Windows. It does NOT install
+      # StanHeaders or rstan: `setup-r-dependencies` has already installed a
+      # matched pair through pak, and reinstalling either one over that pair is
+      # what caused #275. The two `install.packages()` calls removed here passed
+      # `repos = c("https://mc-stan.org/r-packages/", getOption("repos"))`, which
+      # is a fallback list rather than a preference, so an unreachable mc-stan
+      # index silently installed CRAN StanHeaders 2.39.1 over the 2.32.10 that
+      # matches rstan 2.32.7 and every brm() call then failed to compile. They
+      # were added in 7c52e186 (2022-11-01) to obtain a preview rstan for R 4.2;
+      # CRAN rstan supports current R, so the preview build is no longer needed.
       - name: Use Cmdstan to Fix
         run: |
-          install.packages("StanHeaders", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
-          install.packages("rstan", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
           cmdstanr::check_cmdstan_toolchain(fix = TRUE)
         shell: Rscript {0}
 


### PR DESCRIPTION
## What

Pins `StanHeaders` to 2.32.10 on the `windows-latest` job, from a dated Posit
Package Manager snapshot, and asserts the installed version so a bad pin fails
the job immediately.

Two secondary changes in the same file:

- The **Use Cmdstan to Fix** step no longer installs `StanHeaders` and `rstan`
  from `https://mc-stan.org/r-packages/`. It keeps
  `cmdstanr::check_cmdstan_toolchain(fix = TRUE)`, which configures Rtools.
- `rtools-version: '42'` is removed from the `windows-latest` matrix entry. The
  pin is inert — the job log reports `rtools45` — so this changes nothing in the
  job but stops the file declaring a version it does not get.

## Why it matters

The `windows-latest` job fails with 17 test errors, all `invalid connection`
from `brm()`. The check matrix is red on `dev`, so no pull request can show a
clean matrix and the Windows job cannot distinguish a real regression from this
one.

## Evidence

**The mechanism in #275 is not what is happening.** That issue attributes the
failure to the **Use Cmdstan to Fix** step force-installing `StanHeaders` over
the version `pak` had matched to `rstan`, and states that "`rstan`'s own version
constraint is bypassed because the install is unconditional". Three measurements
from this branch contradict that:

1. **`rstan` declares no upper bound.** CRAN `rstan` 2.32.7 has
   `Depends: StanHeaders (>= 2.32.0)` and `LinkingTo: StanHeaders (>= 2.32.0)`.
   StanHeaders 2.39.1 satisfies both, so `pak` resolving to it is correct and
   there is no constraint to bypass.
2. **`pak` installs 2.39.1 directly.** With both `install.packages()` calls
   removed, the first commit on this branch still failed identically —
   `[ FAIL 17 | WARN 1 | SKIP 4 ]`, the same 17 tests. The job log shows `pak`
   fetching
   `packagemanager.posit.co/cran/latest/bin/windows/contrib/4.6/StanHeaders_2.39.1.zip`
   with no reinstallation afterwards. Removing the force-install is therefore
   necessary tidying but not the fix.
3. **The same pair passes on macOS.** Both jobs report `rstan 2.32.7` and
   `StanHeaders 2.39.1`; `macOS-latest` passed in 30m42s. The incompatibility is
   specific to Windows, not to the version pair as such.

**What did change.** CRAN StanHeaders 2.39.1 was published 2026-09-02 12:10 UTC.
That falls between the two runs #275 identifies: `dev` at `bc5f7d00`, 04:55 UTC,
`[ FAIL 0 ]` with StanHeaders 2.32.10, and `dev` at `130aede3`, 23:52 UTC, the
failure. No package change is involved, which is consistent with #275's finding
that `dev` and PR #270 fail identically.

<details>
<summary>Implementation detail</summary>

This is the third of the three candidate fixes listed in #275 — "pin both" —
narrowed to `StanHeaders` alone, because `rstan` is not the package that moved.

`https://packagemanager.posit.co/cran/2026-09-02` serves StanHeaders 2.32.10 as
a Windows binary for R 4.6; snapshots are taken before 2.39.1 was published that
day. A binary avoids a source build of StanHeaders in every Windows run. This
restores exactly the pair the last green Windows run used.

The pin is applied under `if: runner.os == 'Windows'` so `macOS-latest` and both
Ubuntu jobs continue to check against current CRAN, which is what a CRAN
submission would face.

The step asserts the resulting version rather than assuming it.
`install.packages()` only warns when a repository is unreachable, so without the
assertion an unreachable snapshot would silently leave 2.39.1 in place and
reproduce this failure after a 30-minute test run. That is the same defect as
the fallback-list behaviour being removed, so it is guarded against rather than
reintroduced. The assertion was exercised locally: `2.39.1` fails the pattern,
`2.32.10` passes, and the message reads
`StanHeaders 2.39.1 is installed but 2.32.x is required to match rstan 2.32.7; see #275`.

A comment above the step records when it should be removed: once CRAN `rstan` is
released against StanHeaders 2.39 or later.

**Not established.** The reason StanHeaders 2.39.1 breaks model compilation on
Windows but not macOS is not diagnosed here. `invalid connection` is raised by
`rstan` after the compile, and the log records no linker message. The pin does
not depend on that mechanism, but it also does not explain it, so this is a
workaround with a removal condition rather than a repair.

**Definition of done.** The `windows-latest` job passes with no test error and
its log reports StanHeaders 2.32.10 with rstan 2.32.7. Not yet met at the time
of writing — the run for the pin is in progress.

</details>

Closes #275.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RL8GMc5SBLP7RnTCad23f6
