### PR TITLE
Halve the R-CMD-check volume, and supersede superseded runs

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,6 +1,26 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/master/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
-on: [push, pull_request]
+# A push to a branch that has an open pull request fires both `push` and
+# `pull_request`, so an unfiltered trigger ran the four-job matrix twice for
+# every push. With a stacked set of pull requests that is eight runs for one
+# propagated fix, on a repository that runs one job at a time, and the queue
+# never drained. Every other workflow here already filters; this one did not.
+#
+# `push` is now limited to the integration branches, and a branch with a pull
+# request is still checked through `pull_request`. Nothing loses coverage: a
+# stacked branch is checked on its own pull request, and again once GitHub
+# retargets that pull request to `dev` as the one below it merges.
+on:
+  push:
+    branches: [master, dev]
+  pull_request:
+  workflow_dispatch:
+
+# Supersede rather than queue. Pushing a correction to a branch whose check is
+# still running made both run to completion, and only the second was ever read.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 name: R-CMD-check
 


### PR DESCRIPTION
## What

`R-CMD-check` runs on push to the integration branches only, rather than to
every branch, and a new push to a ref cancels a check still running on it.

## Why it matters

`on: [push, pull_request]` with no branch filter means a push to a branch that
has an open pull request fires **both** events, so the four-job matrix runs
twice for every push. With a stacked set of pull requests that is **eight runs
for one propagated fix**, on a repository that runs one job at a time. The queue
stopped draining today and no branch reported for over an hour.

`R-CMD-check.yaml` was the only workflow here without a branch filter. `pkgdown`
already restricts to `master, dev`; `test-coverage` and `readme-renderer` to
`main, master`.

## Evidence

Eight runs queued simultaneously from one propagation across four stacked
branches, 2026-09-06:

```
dev                          pkgdown:      queued
dev                          R-CMD-check:  queued
batch-3-nec-prior            R-CMD-check:  queued
batch-4-group-scale          R-CMD-check:  queued
batch-4-group-scale          R-CMD-check:  queued   <- same commit, both events
batch-2-checks-and-reporting R-CMD-check:  queued
batch-2-checks-and-reporting R-CMD-check:  queued   <- same commit, both events
batch-1-ecx-definition       pkgdown:      queued
```

**Nothing loses coverage.** A branch with a pull request is still checked
through `pull_request`, and again once GitHub retargets that pull request to
`dev` as the one below it merges. What stops is the duplicate run of the same
commit and the runs on branches nobody has opened a pull request for.

<details>
<summary>Implementation detail</summary>

```yaml
on:
  push:
    branches: [master, dev]
  pull_request:
  workflow_dispatch:

concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

`pull_request` is left unfiltered on purpose, so a stacked pull request is
checked against its own base rather than only once it reaches `dev`. Filtering
it to `[master, dev]` as well would cut the volume further and is a one-line
change, at the cost of a stacked branch getting no signal until the one below it
merges.

`workflow_dispatch` is added so a branch that now falls outside the push filter
can still be checked on demand without opening a pull request.

`cancel-in-progress` supersedes rather than queues. Pushing a correction to a
branch whose check was still running previously ran both to completion and only
the second was ever read. On `dev` and `master` the same applies: the later
commit contains the earlier one.

**`.github/` scope.** This repository keeps `.github/` closed except by narrow
exemption --- #215, #230 and #275 each had one. This is the same kind of change
as #275: the workflow rather than the package, fixing a condition that prevents
the matrix from reporting at all.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVqihYoQkGUsZBhfcZcgju