### PR TITLE
Run the test suite in parallel (21 min against 55)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,4 +34,5 @@ URL: https://open-aims.github.io/bayesnec/
 BugReports: https://github.com/open-aims/bayesnec/issues
 Roxygen: list(markdown = TRUE)
 Config/testthat/edition: 3
+Config/testthat/parallel: true
 Config/roxygen2/version: 8.0.0

--- a/notes/running_the_test_suite.md
+++ b/notes/running_the_test_suite.md
@@ -1,0 +1,66 @@
+# Running the test suite
+
+The suite fits models: 53 `bnec()` calls across 25 of the 57 test files, each
+compiling and sampling a Stan program. That is what makes it slow, and it is the
+only thing that does.
+
+## In parallel, which is the default
+
+`Config/testthat/parallel: true` in `DESCRIPTION` makes `testthat` run each test
+**file** in its own subprocess. `devtools::test()` and `R CMD check` pick that up
+with no further setup.
+
+Measured on 2026-09-07, 22 cores, 8 workers: **21 minutes against 55 serial**, on
+645 tests. The speed-up is 2.6x rather than the 8x the worker count suggests,
+because parallelism is by file and the wall clock floors at the slowest single
+file. Further gains would come from splitting the heaviest fitting files, not
+from raising the worker count.
+
+## Running it by hand, and the four traps
+
+A parallel worker is a **fresh R process**. It does not inherit the parent's
+loaded package, its library paths, or its attached namespaces. Each of the
+following fails in a way that does not name the cause:
+
+1. **`devtools::load_all()` is invisible to workers.** They start clean and call
+   `library(<pkg>)`, so the package must be *installed*. The failure is
+   `testthat subprocess failed to start ... attempt to use zero-length variable
+   name`.
+
+2. **`R_LIBS_USER` replaces the library path, it does not add to it.** Setting it
+   to a scratch directory hides every other installed package; here that surfaces
+   as `package 'brms' 2.22.0 was found, but >= 2.23.0 is required`. Prepend to
+   `.libPaths()` inside the script instead.
+
+3. **`test_dir()` does not infer the package name** when loading an installed
+   build. Without `package =`, the workers call `library("")` and stop with
+   `invalid package name`.
+
+4. **`setup.R` runs in every worker**, where `utils` and `stats` are not
+   attached. `data()` and `runif()` are not visible and the setup fails before
+   any test runs. Everything in `setup.R` outside base is namespaced for this
+   reason; keep it that way.
+
+The incantation that works:
+
+```bash
+R CMD INSTALL --no-docs --library=/tmp/lib .
+
+NOT_CRAN=true TESTTHAT_PARALLEL=TRUE TESTTHAT_CPUS=8 Rscript -e '
+  .libPaths(c("/tmp/lib", .libPaths()))
+  library(testthat); library(bayesnec)
+  test_dir("tests/testthat", package = "bayesnec", load_package = "installed")'
+```
+
+## Choosing the worker count
+
+**Memory-bound, not core-bound.** A worker with `brms` loaded holds about 1.4 GB,
+so 8 workers is roughly 11 GB. `TESTTHAT_CPUS` sets it; `getOption("Ncpus")`
+takes precedence if set. On a machine shared with a running analysis, pick a
+number that leaves it room --- the suite is not the only thing that matters.
+
+## `NOT_CRAN`
+
+**Without `NOT_CRAN=true` the suite reports zero failures while skipping nearly
+every assertion**, because most files open with `skip_on_cran()`. A clean run
+that finishes suspiciously quickly is that, not success.

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,10 +1,16 @@
 library(bayesnec)
 library(brms)
 library(testthat)
+
+# stats:: and utils:: are namespaced explicitly because this file also runs in
+# each of testthat's parallel worker subprocesses, which attach far less than an
+# interactive session: data() and runif() are not visible there, and the setup
+# fails before a single test runs. Nothing else in this file reaches outside
+# base.
 options(mc.cores = 1)
 
 random_filename <- function(nchar) {
-  paste0(c(round(runif(nchar) * 15), sample(letters, nchar),
+  paste0(c(round(stats::runif(nchar) * 15), sample(letters, nchar),
          sample(LETTERS, nchar))[sample(1:nchar * 3, nchar)], collapse = "")
 }
 
@@ -14,14 +20,14 @@ add_na <- function(x, n = 3) {
   x_b
 }
 
-data(nec_data)
+utils::data(nec_data)
 other_data <- nec_data
 colnames(other_data) <- c("a", "b")
 nec_data$count <- as.integer(round(nec_data$y * 20))
 nec_data$trials <- as.integer(20)
 nec_data$log_x <- log(nec_data$x)
 
-data(manec_example)
+utils::data(manec_example)
 nec4param <- pull_out(manec_example, model = "nec4param") |>
   suppressMessages() |>
   suppressWarnings()


### PR DESCRIPTION
## What

`Config/testthat/parallel: true`, plus the two changes to `tests/testthat/setup.R`
that parallel execution requires, and a note recording how to run the suite by
hand.

## Why it matters

The suite fits models --- 53 `bnec()` calls across 25 of the 57 test files, each
compiling and sampling a Stan program --- and ran them one after another. On a
22-core machine that meant a **55-minute** wall clock at a load average of about
2, with twenty cores idle. A gate that long is a gate people skip, and skipping
it is how the last round of failures reached CI.

## Evidence

Measured 2026-09-07, same branch, same 645 tests, 8 workers:

| | wall clock | load |
|---|---|---|
| serial | ~55 min | ~2 |
| parallel, 8 workers | **21.1 min** | ~13 |

**2.6x, not 8x.** `testthat` parallelises by *file*, so the wall clock floors at
the slowest single file; load fell from 13 to 3 well before the run ended. The
remaining gain is in splitting the heaviest fitting files, not in raising the
worker count, and that is not attempted here.

## What `setup.R` needed, and why

A worker is a fresh R process with far less attached than an interactive session.
`setup.R` runs in every one of them, and its `data()` and `runif()` calls are not
visible there, so **the setup failed before a single test ran**. Both are now
namespaced, which is what this repository's style calls for in test code anyway.

<details>
<summary>Implementation detail</summary>

### The four traps, all recorded in `notes/running_the_test_suite.md`

Each fails in a way that does not name its cause, and between them they cost four
attempts:

1. `devtools::load_all()` is invisible to workers --- they call `library(<pkg>)`,
   so the package must be installed. Presents as *"testthat subprocess failed to
   start ... attempt to use zero-length variable name"*.
2. `R_LIBS_USER` **replaces** the library path rather than adding to it, hiding
   every other package; here, *"package 'brms' 2.22.0 was found, but >= 2.23.0 is
   required"*. Prepend to `.libPaths()` instead.
3. `test_dir()` does not infer the package name with `load_package = "installed"`;
   without `package =` the workers call `library("")`.
4. `setup.R`'s unqualified `data()` and `runif()`, above.

### Worker count is memory-bound

A worker with `brms` loaded holds about 1.4 GB, so 8 workers is roughly 11 GB.
`TESTTHAT_CPUS` sets it. The note says to leave room for anything else running on
the machine rather than taking every core.

### One thing this surfaced that is not a test problem

Running 18 processes on 22 cores creates contention, and under it
`test-nechormepwr-bounded.R` failed where it passes serially. That is not
flakiness: it is the wall-clock bound added to `make_good_inits()` in #266
turning initial values --- and therefore fits --- into a function of machine
load. Raised separately; it is a defect in that change, not in this one, and this
change is what made it visible.

### CI

`R CMD check` picks up `Config/testthat/parallel` with no workflow change. The
runners are smaller than this machine, so the gain there will be smaller.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVqihYoQkGUsZBhfcZcgju