### PR TITLE
Reduce the default estimation resolution to 200

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bayesnec
 Title: A Bayesian No-Effect- Concentration (NEC) Algorithm
-Version: 2.1.3.32
+Version: 2.1.3.33
 Authors@R: c(person("Rebecca", "Fisher", email = "r.fisher@aims.gov.au", role = c("aut", "cre"),comment = c(ORCID = "0000-0001-5148-6731")), person("Diego R.","Barneche",role="aut",comment = c(ORCID = "0000-0002-4568-2362")), person("Gerard F.","Ricardo",role="aut",comment = c(ORCID = "0000-0002-2220-3971")), person("David R.","Fox",role="aut",comment = c(ORCID = "0000-0002-3178-7243")))
 Description: Implementation of No-Effect-Concentration estimation that uses 'brms' (see Burkner (2017)<doi:10.18637/jss.v080.i01>; Burkner (2018)<doi:10.32614/RJ-2018-017>; Carpenter 'et al.' (2017)<doi:10.18637/jss.v076.i01> to fit concentration(dose)-response data using Bayesian methods for the purpose of estimating 'ECx' values, but more particularly 'NEC' (see Fox (2010)<doi:10.1016/j.ecoenv.2009.09.012>), 'NSEC' (see Fisher and Fox (2023)<doi:10.1002/etc.5610>), and 'N(S)EC (see Fisher et al. 2023<doi:10.1002/ieam.4809>). A full description of this package can be found in Fisher 'et al.' (2024)<doi:10.18637/jss.v110.i05>. This package expands and supersedes an original version implemented in 'R2jags' (see Su and Yajima (2020)<https://CRAN.R-project.org/package=R2jags>; Fisher et al. (2020)<doi:10.5281/ZENODO.3966864>).
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -134,6 +134,26 @@
   `bayesnechurdlefit` methods included; they previously stopped with "missing
   values and NaN's not allowed" on a posterior the package had itself written.
 
+- **The default `resolution` is reduced from 1000 to 200** in `ecx()`,
+  `nsec()`, `ecnsec()` and `average_estimates()`. The value of 1000 was
+  calibrated for the nearest-grid-point search that interpolation replaces,
+  where the grid spacing set the precision directly. With interpolation the
+  precision saturates: measured on the equations of `manec_example` at 100
+  draws and on a `nec4param` fit of `nec_data` at 4000 draws, the largest
+  change in any reported ECx or NSEC between a resolution of 200 and one of
+  2000 was 0.006 per cent, and the binding case was `nsec()` on `nec4param`.
+  The reduction lowers the run time of a 4000 draw `nsec()` call by about 10
+  per cent, and the saving grows with the number of draws. The measurement does
+  not cover `bnec_hurdle()` fits or a predictor carrying an inline
+  transformation. Prediction and plotting grids are unaffected: `bnec()`,
+  `bnec_newdata()`, `autoplot()` and the `fitted()`, `predict()` and
+  `posterior_epred()` methods keep a default of 1000 (#39).
+
+- **`ecnsec()` predicts over 200 grid points rather than 10.** Both its
+  methods took 10, disagreeing with the 1000 the `\usage` section stated. The
+  value sets the denominator under `type = "range"`, which was therefore read
+  off a ten-point curve.
+
 - **`ecx_val` is no longer capped at 99.** Any value above 0 is accepted. Under
   `"absolute"` the reference is 0, so a value above 100 names a target below
   zero, which is a real measurement on a response that can go negative and is

--- a/R/average_estimates.R
+++ b/R/average_estimates.R
@@ -62,7 +62,7 @@
 average_estimates <- function(x, estimate = "nec", ecx_val = 10,
                               posterior = FALSE, type = "absolute",
                               sig_val = 0.01,
-                              resolution = 1000, x_range = NA, xform = identity,
+                              resolution = 200, x_range = NA, xform = identity,
                               prob_vals = c(0.5, 0.025, 0.975)) {
   if (!is.list(x) | is.null(names(x))) {
     stop("Argument x must be a named list")

--- a/R/bayesnechurdlefit-class.R
+++ b/R/bayesnechurdlefit-class.R
@@ -219,7 +219,7 @@ nec.bayesnechurdlefit <- function(object, posterior = FALSE, xform = identity,
 #' @method ecx bayesnechurdlefit
 #'
 #' @export
-ecx.bayesnechurdlefit <- function(object, ecx_val = 10, resolution = 1000,
+ecx.bayesnechurdlefit <- function(object, ecx_val = 10, resolution = 200,
                                   posterior = FALSE, type = "absolute",
                                   x_range = NA, xform = identity,
                                   prob_vals = c(0.5, 0.025, 0.975),

--- a/R/bayesnechurdlefit-methods.R
+++ b/R/bayesnechurdlefit-methods.R
@@ -241,7 +241,7 @@ bnec_newdata.bayesnechurdlefit <- function(x, resolution = 100,
 #' @method nsec bayesnechurdlefit
 #'
 #' @export
-nsec.bayesnechurdlefit <- function(object, sig_val = 0.01, resolution = 1000,
+nsec.bayesnechurdlefit <- function(object, sig_val = 0.01, resolution = 200,
                                    x_range = NA,
                                    xform = identity,
                                    prob_vals = c(0.5, 0.025, 0.975), ...,
@@ -923,7 +923,7 @@ autoplot.bayesnechurdlefit <- function(object, ..., which = "combined",
 #' @method ecnsec bayesnechurdlefit
 #'
 #' @export
-ecnsec.bayesnechurdlefit <- function(object, nsec, resolution = 10,
+ecnsec.bayesnechurdlefit <- function(object, nsec, resolution = 200,
                                      x_range = NA,
                                      type = "absolute", xform = identity,
                                      prob_vals = c(0.5, 0.025, 0.975), ...,

--- a/R/ecnsec.R
+++ b/R/ecnsec.R
@@ -5,8 +5,10 @@
 #' \code{\link{bayesmanecfit}} returned by \code{\link{bnec}}.
 #' @param nsec A numeric value indicating the NSEC value for which to extract 
 #' the percentage effect.
-#' @param resolution The number of unique x values over which to find NSEC -
-#' large values will make the NSEC estimate more precise.
+#' @param resolution The number of unique x values over which the curve is
+#' predicted. It affects only \code{type = "range"}, where the denominator is
+#' the lowest response the curve predicts over the grid. The default of 200
+#' matches \code{\link{ecx}} and \code{\link{nsec}}.
 #' @param type A \code{\link[base]{character}} vector, taking values of
 #' "absolute" (the default), "relative" or "range". See Details.
 #' @param xform A function to apply to the returned estimated NSEC concentration
@@ -50,7 +52,7 @@
 #' }
 #'
 #' @export
-ecnsec <- function(object, nsec, resolution = 1000, x_range = NA, 
+ecnsec <- function(object, nsec, resolution = 200, x_range = NA, 
                    type = "absolute",
                  xform = identity, prob_vals = c(0.5, 0.025, 0.975), ...) {
   UseMethod("ecnsec")
@@ -73,7 +75,7 @@ ecnsec <- function(object, nsec, resolution = 1000, x_range = NA,
 #' @noRd
 #'
 #' @export
-ecnsec.bnecfit <- function(object, nsec, resolution = 10, x_range = NA, 
+ecnsec.bnecfit <- function(object, nsec, resolution = 200, x_range = NA, 
                                type = "absolute",
                              xform = identity, prob_vals = c(0.5, 0.025, 0.975), ..., 
                              posterior = FALSE) {

--- a/R/ecx.R
+++ b/R/ecx.R
@@ -12,8 +12,12 @@
 #' Details.
 #' @param type A \code{\link[base]{character}} vector, taking values of
 #' "absolute" (the default), "relative", "range" or "direct". See Details.
-#' @param resolution The number of unique x values over which to find ECx --
-#' large values will make the ECx estimate more precise.
+#' @param resolution The number of unique x values over which to find ECx.
+#' The crossing is located by linear interpolation between the two grid values
+#' that bracket it, so precision saturates well below the grid spacing.
+#' Increasing the resolution beyond the default of 200 changed the estimate by
+#' less than 0.01 percent on the fits tested, and increases the run time
+#' roughly in proportion.
 #' @param posterior A \code{\link[base]{logical}} value indicating if the full
 #' posterior sample of calculated ECx values should be returned instead of
 #' just the median and 95 credible intervals.
@@ -115,7 +119,7 @@
 # class-specific arguments there. Naming it on the generic is what puts it in
 # the \usage section; documented-but-absent arguments are an R CMD check
 # WARNING, and methods are @noRd so the generic is the only place it can appear.
-ecx <- function(object, ecx_val = 10, resolution = 1000,
+ecx <- function(object, ecx_val = 10, resolution = 200,
                 posterior = FALSE, type = "absolute", x_range = NA,
                 xform = identity, prob_vals = c(0.5, 0.025, 0.975), ...,
                 dpar = NULL) {
@@ -136,7 +140,7 @@ ecx <- function(object, ecx_val = 10, resolution = 1000,
 #' @noRd
 #'
 #' @export
-ecx.bayesnecfit <- function(object, ecx_val = 10, resolution = 1000,
+ecx.bayesnecfit <- function(object, ecx_val = 10, resolution = 200,
                             posterior = FALSE, type = "absolute",
                             x_range = NA, xform = identity,
                             prob_vals = c(0.5, 0.025, 0.975), ...,
@@ -278,7 +282,7 @@ ecx.bayesnecfit <- function(object, ecx_val = 10, resolution = 1000,
 #' @noRd
 #'
 #' @export
-ecx.bayesmanecfit <- function(object, ecx_val = 10, resolution = 1000,
+ecx.bayesmanecfit <- function(object, ecx_val = 10, resolution = 200,
                               posterior = FALSE, type = "absolute",
                               x_range = NA, xform = identity,
                               prob_vals = c(0.5, 0.025, 0.975), ...,

--- a/R/nsec.R
+++ b/R/nsec.R
@@ -5,8 +5,12 @@
 #' \code{\link{bayesmanecfit}} returned by \code{\link{bnec}}.
 #' @param sig_val Probability value to use as the lower quantile to test
 #' significance of the predicted posterior values.
-#' @param resolution The number of unique x values over which to find NSEC -
-#' large values will make the NSEC estimate more precise.
+#' @param resolution The number of unique x values over which to find NSEC.
+#' The crossing is located by linear interpolation between the two grid values
+#' that bracket it, so precision saturates well below the grid spacing.
+#' Increasing the resolution beyond the default of 200 changed the estimate by
+#' less than 0.01 percent on the fits tested, and increases the run time
+#' roughly in proportion.
 #' @param xform A function to apply to the returned estimated concentration
 #' values.
 #' @param x_range A range of x values over which to consider extracting NSEC.
@@ -91,7 +95,7 @@
 # dpar sits after `...` for the same reason as in ecx(): it matches the methods,
 # and naming it here is what puts it in \usage. Methods that have no use for it
 # (nsec.drc, nsec.brmsfit) absorb it through their own `...`.
-nsec <- function(object, sig_val = 0.01, resolution = 1000,
+nsec <- function(object, sig_val = 0.01, resolution = 200,
                  x_range = NA,
                  xform = identity, prob_vals = c(0.5, 0.025, 0.975), ...,
                  dpar = NULL) {
@@ -115,7 +119,7 @@ nsec <- function(object, sig_val = 0.01, resolution = 1000,
 #' @noRd
 #'
 #' @export
-nsec.bayesnecfit <- function(object, sig_val = 0.01, resolution = 1000,
+nsec.bayesnecfit <- function(object, sig_val = 0.01, resolution = 200,
                              x_range = NA,
                              xform = identity, prob_vals = c(0.5, 0.025, 0.975), ...,
                              posterior = FALSE, dpar = NULL) {
@@ -228,7 +232,7 @@ nsec.bayesnecfit <- function(object, sig_val = 0.01, resolution = 1000,
 #' @noRd
 #'
 #' @export
-nsec.bayesmanecfit <- function(object, sig_val = 0.01, resolution = 1000,
+nsec.bayesmanecfit <- function(object, sig_val = 0.01, resolution = 200,
                                x_range = NA,
                                xform = identity, prob_vals = c(0.5, 0.025, 0.975), ...,
                                posterior = FALSE, dpar = NULL) {
@@ -307,7 +311,7 @@ nsec.bayesmanecfit <- function(object, sig_val = 0.01, resolution = 1000,
 #' @noRd
 #'
 #' @export
-nsec.brmsfit <- function(object, sig_val = 0.01, resolution = 1000,    
+nsec.brmsfit <- function(object, sig_val = 0.01, resolution = 200,    
                          x_range = NA,
                          xform = identity, prob_vals = c(0.5, 0.025, 0.975), ..., 
                          posterior = FALSE,
@@ -450,7 +454,7 @@ nsec.brmsfit <- function(object, sig_val = 0.01, resolution = 1000,
 #' @noRd
 #'
 #' @export
-nsec.drc <- function(object, sig_val = 0.01, resolution = 1000,
+nsec.drc <- function(object, sig_val = 0.01, resolution = 200,
                      x_range = NA,
                      xform = identity, prob_vals = c(0.5, 0.025, 0.975), ...,
                      x_var,

--- a/man/average_estimates.Rd
+++ b/man/average_estimates.Rd
@@ -11,7 +11,7 @@ average_estimates(
   posterior = FALSE,
   type = "absolute",
   sig_val = 0.01,
-  resolution = 1000,
+  resolution = 200,
   x_range = NA,
   xform = identity,
   prob_vals = c(0.5, 0.025, 0.975)
@@ -41,8 +41,12 @@ just the median and 95 credible intervals.}
 \item{sig_val}{Probability value to use as the lower quantile to test
 significance of the predicted posterior values.}
 
-\item{resolution}{The number of unique x values over which to find ECx --
-large values will make the ECx estimate more precise.}
+\item{resolution}{The number of unique x values over which to find ECx.
+The crossing is located by linear interpolation between the two grid values
+that bracket it, so precision saturates well below the grid spacing.
+Increasing the resolution beyond the default of 200 changed the estimate by
+less than 0.01 percent on the fits tested, and increases the run time
+roughly in proportion.}
 
 \item{x_range}{A range of x values over which to consider extracting ECx.}
 

--- a/man/compare_estimates.Rd
+++ b/man/compare_estimates.Rd
@@ -34,8 +34,12 @@ Details.}
 \item{sig_val}{Probability value to use as the lower quantile to test
 significance of the predicted posterior values.}
 
-\item{resolution}{The number of unique x values over which to find ECx --
-large values will make the ECx estimate more precise.}
+\item{resolution}{The number of unique x values over which to find ECx.
+The crossing is located by linear interpolation between the two grid values
+that bracket it, so precision saturates well below the grid spacing.
+Increasing the resolution beyond the default of 200 changed the estimate by
+less than 0.01 percent on the fits tested, and increases the run time
+roughly in proportion.}
 
 \item{x_range}{A range of x values over which to consider extracting ECx.}
 }

--- a/man/compare_fitted.Rd
+++ b/man/compare_fitted.Rd
@@ -11,8 +11,12 @@ compare_fitted(x, resolution = 50, x_range = NA, make_newdata = TRUE, ...)
 \code{\link{bayesnecfit}} or \code{\link{bayesmanecfit}} returned by
 \code{\link{bnec}}.}
 
-\item{resolution}{The number of unique x values over which to find ECx --
-large values will make the ECx estimate more precise.}
+\item{resolution}{The number of unique x values over which to find ECx.
+The crossing is located by linear interpolation between the two grid values
+that bracket it, so precision saturates well below the grid spacing.
+Increasing the resolution beyond the default of 200 changed the estimate by
+less than 0.01 percent on the fits tested, and increases the run time
+roughly in proportion.}
 
 \item{x_range}{A range of x values over which to consider extracting ECx.}
 

--- a/man/compare_posterior.Rd
+++ b/man/compare_posterior.Rd
@@ -42,8 +42,12 @@ Details.}
 \item{sig_val}{Probability value to use as the lower quantile to test
 significance of the predicted posterior values.}
 
-\item{resolution}{The number of unique x values over which to find ECx --
-large values will make the ECx estimate more precise.}
+\item{resolution}{The number of unique x values over which to find ECx.
+The crossing is located by linear interpolation between the two grid values
+that bracket it, so precision saturates well below the grid spacing.
+Increasing the resolution beyond the default of 200 changed the estimate by
+less than 0.01 percent on the fits tested, and increases the run time
+roughly in proportion.}
 
 \item{x_range}{A range of x values over which to consider extracting ECx.}
 

--- a/man/ecnsec.Rd
+++ b/man/ecnsec.Rd
@@ -8,7 +8,7 @@ object of class \code{\link{bayesnecfit}} or \code{\link{bayesmanecfit}}.}
 ecnsec(
   object,
   nsec,
-  resolution = 1000,
+  resolution = 200,
   x_range = NA,
   type = "absolute",
   xform = identity,
@@ -23,8 +23,10 @@ ecnsec(
 \item{nsec}{A numeric value indicating the NSEC value for which to extract
 the percentage effect.}
 
-\item{resolution}{The number of unique x values over which to find NSEC -
-large values will make the NSEC estimate more precise.}
+\item{resolution}{The number of unique x values over which the curve is
+predicted. It affects only \code{type = "range"}, where the denominator is
+the lowest response the curve predicts over the grid. The default of 200
+matches \code{\link{ecx}} and \code{\link{nsec}}.}
 
 \item{x_range}{A range of x values over which to consider extracting NSEC.}
 

--- a/man/ecnsec.bayesnechurdlefit.Rd
+++ b/man/ecnsec.bayesnechurdlefit.Rd
@@ -8,7 +8,7 @@
 \method{ecnsec}{bayesnechurdlefit}(
   object,
   nsec,
-  resolution = 10,
+  resolution = 200,
   x_range = NA,
   type = "absolute",
   xform = identity,
@@ -24,8 +24,10 @@
 \item{nsec}{A numeric value indicating the NSEC value for which to extract
 the percentage effect.}
 
-\item{resolution}{The number of unique x values over which to find NSEC -
-large values will make the NSEC estimate more precise.}
+\item{resolution}{The number of unique x values over which the curve is
+predicted. It affects only \code{type = "range"}, where the denominator is
+the lowest response the curve predicts over the grid. The default of 200
+matches \code{\link{ecx}} and \code{\link{nsec}}.}
 
 \item{x_range}{A range of x values over which to consider extracting NSEC.}
 

--- a/man/ecx.Rd
+++ b/man/ecx.Rd
@@ -7,7 +7,7 @@
 ecx(
   object,
   ecx_val = 10,
-  resolution = 1000,
+  resolution = 200,
   posterior = FALSE,
   type = "absolute",
   x_range = NA,
@@ -27,8 +27,12 @@ is a response value rather than a percentage. Values above 100 are
 meaningful under "absolute" for a response that can go negative --- see
 Details.}
 
-\item{resolution}{The number of unique x values over which to find ECx --
-large values will make the ECx estimate more precise.}
+\item{resolution}{The number of unique x values over which to find ECx.
+The crossing is located by linear interpolation between the two grid values
+that bracket it, so precision saturates well below the grid spacing.
+Increasing the resolution beyond the default of 200 changed the estimate by
+less than 0.01 percent on the fits tested, and increases the run time
+roughly in proportion.}
 
 \item{posterior}{A \code{\link[base]{logical}} value indicating if the full
 posterior sample of calculated ECx values should be returned instead of

--- a/man/ecx.bayesnechurdlefit.Rd
+++ b/man/ecx.bayesnechurdlefit.Rd
@@ -7,7 +7,7 @@
 \method{ecx}{bayesnechurdlefit}(
   object,
   ecx_val = 10,
-  resolution = 1000,
+  resolution = 200,
   posterior = FALSE,
   type = "absolute",
   x_range = NA,
@@ -26,8 +26,12 @@ is a response value rather than a percentage. Values above 100 are
 meaningful under "absolute" for a response that can go negative --- see
 Details.}
 
-\item{resolution}{The number of unique x values over which to find ECx --
-large values will make the ECx estimate more precise.}
+\item{resolution}{The number of unique x values over which to find ECx.
+The crossing is located by linear interpolation between the two grid values
+that bracket it, so precision saturates well below the grid spacing.
+Increasing the resolution beyond the default of 200 changed the estimate by
+less than 0.01 percent on the fits tested, and increases the run time
+roughly in proportion.}
 
 \item{posterior}{A \code{\link[base]{logical}} value indicating if the full
 posterior sample of calculated ECx values should be returned instead of

--- a/man/nsec.Rd
+++ b/man/nsec.Rd
@@ -8,7 +8,7 @@ object of class \code{\link{bayesnecfit}} or \code{\link{bayesmanecfit}}.}
 nsec(
   object,
   sig_val = 0.01,
-  resolution = 1000,
+  resolution = 200,
   x_range = NA,
   xform = identity,
   prob_vals = c(0.5, 0.025, 0.975),
@@ -23,8 +23,12 @@ nsec(
 \item{sig_val}{Probability value to use as the lower quantile to test
 significance of the predicted posterior values.}
 
-\item{resolution}{The number of unique x values over which to find NSEC -
-large values will make the NSEC estimate more precise.}
+\item{resolution}{The number of unique x values over which to find NSEC.
+The crossing is located by linear interpolation between the two grid values
+that bracket it, so precision saturates well below the grid spacing.
+Increasing the resolution beyond the default of 200 changed the estimate by
+less than 0.01 percent on the fits tested, and increases the run time
+roughly in proportion.}
 
 \item{x_range}{A range of x values over which to consider extracting NSEC.}
 

--- a/man/nsec.bayesnechurdlefit.Rd
+++ b/man/nsec.bayesnechurdlefit.Rd
@@ -7,7 +7,7 @@
 \method{nsec}{bayesnechurdlefit}(
   object,
   sig_val = 0.01,
-  resolution = 1000,
+  resolution = 200,
   x_range = NA,
   xform = identity,
   prob_vals = c(0.5, 0.025, 0.975),
@@ -22,8 +22,12 @@
 \item{sig_val}{Probability value to use as the lower quantile to test
 significance of the predicted posterior values.}
 
-\item{resolution}{The number of unique x values over which to find NSEC -
-large values will make the NSEC estimate more precise.}
+\item{resolution}{The number of unique x values over which to find NSEC.
+The crossing is located by linear interpolation between the two grid values
+that bracket it, so precision saturates well below the grid spacing.
+Increasing the resolution beyond the default of 200 changed the estimate by
+less than 0.01 percent on the fits tested, and increases the run time
+roughly in proportion.}
 
 \item{x_range}{A range of x values over which to consider extracting NSEC.}
 

--- a/tests/testthat/test-ecx.R
+++ b/tests/testthat/test-ecx.R
@@ -262,3 +262,22 @@ test_that("the relative rename warns once for a set, not once per equation", {
   # The option is restored, so a later call in the same session still warns.
   expect_null(getOption("bayesnec.relative_warned"))
 })
+
+test_that("the estimate is insensitive to resolution above the default", {
+  skip_on_cran()
+  # This pins the basis for the default of 200. The crossing is interpolated
+  # between the two bracketing grid points rather than snapped to the nearer of
+  # them, so precision saturates well below the grid spacing and the default no
+  # longer needs to be large. A five-fold increase must not change either
+  # estimator materially. See #39.
+  # as.numeric() rather than unname(): the estimate has a "resolution"
+  # attribute recording what it was computed at, which differs by construction.
+  expect_equal(as.numeric(ecx(nec4param, resolution = 200)),
+               as.numeric(ecx(nec4param, resolution = 1000)),
+               tolerance = 1e-3)
+  suppressWarnings({
+    n200 <- as.numeric(nsec(nec4param, resolution = 200))
+    n1000 <- as.numeric(nsec(nec4param, resolution = 1000))
+  })
+  expect_equal(n200, n1000, tolerance = 1e-3)
+})


### PR DESCRIPTION
## What

The default `resolution` is reduced from 1000 to 200 in `ecx()`, `nsec()`,
`ecnsec()` and `average_estimates()`.

## Why it matters

The crossing is located by linear interpolation between the two grid values that
bracket it (`crossing_x()`, added in #281), not by taking the nearest grid point.
The grid therefore no longer sets the precision. A default should sit where the
accuracy curve flattens, and 1000 was calibrated for the search that
interpolation replaced, so it is vestigial. Reducing it lowers the run time of a
4000 draw call by about 10 per cent, and the saving grows with the number of
draws.

A second defect is corrected in the same change: both `ecnsec()` methods took
`resolution = 10` while the generic, and therefore the `\usage` section of
`?ecnsec`, stated 1000. The value sets the denominator under `type = "range"`,
which was consequently read off a ten-point curve.

## Evidence

Each resolution compared against a reference of 2000.

Package example fits, 100 draws (`manec_example`, `nec4param` and `ecx4param`
pulled out), largest relative error in the reported median across the four
fit/endpoint combinations:

| resolution | worst relative error |
|---:|---:|
| 25 | 1.59% |
| 50 | 0.305% |
| 100 | 0.069% |
| 200 | 0.0056% |
| 500 | 0.0012% |
| 1000 | 0.00025% |

`nec4param` fitted to `nec_data` (2 chains, `iter` 4000, `warmup` 2000, seed 7,
giving 4000 draws), `ecx()` median and the median of five timings:

| resolution | estimate | relative error | median seconds |
|---:|---:|---:|---:|
| 25 | 1.939907 | 0.182% | 0.90 |
| 50 | 1.937134 | 0.039% | 0.92 |
| 100 | 1.936487 | 0.0052% | 0.95 |
| 200 | 1.936415 | 0.0015% | 1.29 |
| 500 | 1.936386 | 0.0000% | 1.34 |
| 1000 | 1.936388 | 0.0001% | 1.43 |
| 2000 | 1.936386 | 0.0000% | 1.98 |

The worst error at 200 across both runs is 0.006 per cent. The binding case is
`nsec()` on `nec4param`: a threshold equation puts a corner in the curve, so its
crossing is the one least well approximated by a straight line between grid
points. The measurement does not cover `bnec_hurdle()` fits or a predictor with
an inline transformation.

Closes #39.

<details>
<summary>Implementation detail</summary>

**Changed.** The `resolution` default in the `ecx`, `nsec` and `ecnsec` generics
and in every method of each --- `.bayesnecfit`, `.bayesmanecfit`, `.brmsfit`,
`.drc`, `.bnecfit` and `.bayesnechurdlefit` --- and in `average_estimates()`,
which passes the argument straight through to `ecx()` or `nsec()`.

**Not changed.** Prediction and plotting grids keep a default of 1000, since
they are drawn rather than searched and 200 points would be visible in a figure:
`bnec()`, `bnec_newdata()`, `expand_nec()`, `expand_manec()`, `amend()`,
`update.bnecfit()`, `autoplot()`, `plot()`, `ggbnec_data()`, and the `fitted()`,
`predict()` and `posterior_epred()` methods. `compare_estimates()` (100),
`compare_posterior()` (500 / 50) and `compare_fitted()` (50) already defaulted
below 200 and are left alone.

**Documentation.** The `@param resolution` text for `ecx()` and `nsec()` said
"large values will make the ECx estimate more precise", which has not been true
since interpolation replaced the nearest-grid-point search. It now states that
precision saturates and what the measurement showed. `ecnsec()` gets its own
wording, since `resolution` there affects only `type = "range"`.

**Test.** `tests/testthat/test-ecx.R` pins the basis for the default: `ecx()`
and `nsec()` on `nec4param` at resolutions of 200 and 1000 must agree to within
0.1 per cent. The comparison is on `as.numeric()` rather than `unname()`,
because the estimate has a `resolution` attribute that differs by construction.

**Not done here.** The rendered `example1` and `example2` vignettes still print
`attr(,"resolution") [1] 1000`. They are generated from `.Rmd.orig` by
`vignettes/precompile.R`, so the full precompile queued as #190 and #248
regenerates them. The values were not hand-edited, because the estimates in
those blocks would also change in their last displayed digit.

**Why not `uniroot.all`,** as #39 originally proposed. The implementation
evaluates the whole grid in a single `posterior_epred()` call and then searches
each draw's row. A root finder needs the mean function at arbitrary *x* per
draw, which within this implementation means either repeated `posterior_epred()`
calls or re-deriving all 23 equations outside `brms` --- the latter duplicating
definitions `brms` already holds, and neither reaching the `dpar` and hurdle
paths for free. The precision it would recover is below 0.01 per cent at the new
default. The speed argument in the original issue was against the old
nearest-grid-point search, which needed a large grid to be accurate at all.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVqihYoQkGUsZBhfcZcgju
