### PR TITLE
Guard update() on the surviving set, and honour a supplied init (#288, #290, #285)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -164,6 +164,29 @@
 
 ## Bug fixes
 
+- `update()` on a `bayesmanecfit` returned an object classed `bayesmanecfit`
+  with none of that class's structure whenever all but one model failed to
+  refit. The guard tested the length of the candidate set going in rather than
+  the number of survivors coming out, so `expand_manec()`'s single-survivor
+  branch --- which returns a bare one-element list of `prebayesnecfit` --- was
+  classed as a model average. The result had no `mod_fits`, `mod_stats` or
+  `w_pred_vals`, and every `bayesmanecfit` method then failed naming a missing
+  component rather than the update. `update()` now routes a single survivor
+  through `expand_nec()` and returns a `bayesnecfit`, which is what `bnec()` and
+  `amend()` already returned for the same surviving set (#288).
+
+- A supplied `init` no longer triggers the initial-value search. The search ran
+  when `init` was absent **or** when `skip_check` was `TRUE`, so a caller who
+  supplied initial values under `skip_check = TRUE` waited for a search and then
+  had what they supplied overwritten by its result. Measured on a 32-row,
+  four-dose `Beta` fixture with `nec3param`, 2026-09-07, R 4.6.1: 597.6 s with
+  `init` supplied against 577.2 s without, identical within noise. The one
+  caller that depended on the search running regardless was `amend()`, which
+  passed the stanfit initial values of a model already in the set to a model
+  being added to it; those values name another equation's parameters and were
+  discarded by the search in every case, so `amend()` no longer passes them and
+  its behaviour is unchanged (#290).
+
 - `ecx()` and `nsec()` discarded any arithmetic inside an inline `crf()`
   transformation when putting the estimate back on the fitted scale. The
   substitution replaced the parsed call's first argument slot, so
@@ -534,6 +557,19 @@
   assumes the posteriors come from separate fits --- two levels of one fit share
   draws, and permuting them widens the difference posterior and pulls
   `prob_diff` toward 0.5, which under-detects a real difference (#218).
+
+## Documentation
+
+- `?bnec` and `?models` now state that a model group names the shape of the
+  response and not the set of equations admissible for it. `mod_groups$decline`
+  includes `neclin` and `ecxlin`, whose mean decays by subtraction and is
+  unbounded below, so neither is admissible for a response bounded at zero. A
+  `bnec()` call is unaffected --- `check_models()` drops them where the family
+  requires it, and a group string is filtered by the same check that
+  `model = "all"` is --- but nothing said so, and code reading the group
+  directly as a statement of admissibility got two equations that are not.
+  `models()` given a numeric range returns the admissible set and is the route
+  to use where that is what is wanted (#285).
 
 # bayesnec 2.1.4
 

--- a/R/amend.R
+++ b/R/amend.R
@@ -243,9 +243,16 @@ amend_model_set <- function(object, mod_fits, old_method, drop = NULL,
     model <- model_set[m]
     mod_m <- try(old_fits[[model]], silent = TRUE)
     if (!inherits(mod_m, "prebayesnecfit")) {
+      # No `init`. This branch is reached only for a model that is not already
+      # in the set, and simdat$init holds the stanfit initial values of a model
+      # that is -- values named for another equation's parameters, which are
+      # meaningless here. add_brm_defaults() overwrote them with its own search
+      # in every case, so omitting them changes nothing that happened; what it
+      # changes is that the search is now requested by the absence of `init`
+      # rather than compelled by skip_check. See #290.
       brm_args <- list(
         family = family, iter = simdat$iter, thin = simdat$thin,
-        warmup = simdat$warmup, init = simdat$init, chains = simdat$chains,
+        warmup = simdat$warmup, chains = simdat$chains,
         sample_prior = simdat$sample_prior
       )
       brm_args$prior <- priors

--- a/R/bnec.R
+++ b/R/bnec.R
@@ -130,6 +130,11 @@
 #' parameter (without a bottom plateau) will be fit; "zero_bounded" are models
 #' that are bounded to be zero; or "decline" excludes all hormesis models, i.e.,
 #' only allows a strict decline in response across the whole predictor range.
+#' Each group names a shape rather than a set of equations admissible for a
+#' given response --- "decline" includes the linear-decay models, which are
+#' dropped for a zero-bounded or 0, 1 bounded response --- so a group string is
+#' filtered by the same family check that \code{model = "all"} is. See
+#' \code{\link{models}}.
 #' Notice that if one of these group strings is provided together with a
 #' user-specified named list for the \code{\link[brms]{brm}}'s argument
 #' \code{prior}, the list names need to contain

--- a/R/bnecfit-methods.R
+++ b/R/bnecfit-methods.R
@@ -249,10 +249,26 @@ update.bnecfit <- function(object, newdata = NULL, recompile = NULL,
   }
   formulas <- lapply(object, extract_formula)
   if (length(object) > 1) {
-    object <- expand_manec(object, formula = formulas, x_range = x_range,
-                           resolution = resolution, sig_val = sig_val,
-                           loo_controls = loo_controls)
-    out <- allot_class(object, c("bayesmanecfit", "bnecfit"))
+    mod_fits <- expand_manec(object, formula = formulas, x_range = x_range,
+                             resolution = resolution, sig_val = sig_val,
+                             loo_controls = loo_controls)
+    # Guard on the length of the result, not on the length of the set that went
+    # in. Where all but one model fails to refit, expand_manec() returns a bare
+    # one-element list of prebayesnecfit, which has none of a bayesmanecfit's
+    # structure; classing that as one gave an object whose every method failed
+    # on a missing `mod_fits`. bnec() and amend() already guard this way and
+    # route the single survivor through expand_nec(); the three entry points
+    # now agree, which is what stopped this being noticed. See #288.
+    if (length(mod_fits) > 1) {
+      out <- allot_class(mod_fits, c("bayesmanecfit", "bnecfit"))
+    } else {
+      surviving <- names(mod_fits)
+      mod_fits <- expand_nec(mod_fits[[1]], formula = formulas[[surviving]],
+                             x_range = x_range, resolution = resolution,
+                             sig_val = sig_val, loo_controls = loo_controls,
+                             model = surviving)
+      out <- allot_class(mod_fits, c("bayesnecfit", "bnecfit"))
+    }
   } else if (length(object) == 1) {
     if (inherits(object[[1]], "somethingwentwrong")) {
       stop("Your attempt to update the original model(s) failed. Perhaps you",

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -828,7 +828,17 @@ add_brm_defaults <- function(
       fill_missing_priors(priors, default_priors, model)
     }
   }
-  if (!("init" %in% names(brm_args)) || skip_check) {
+  # Whether anyone needs initial values, and nothing else. This used to read
+  # `|| skip_check`, which made a caller who supplied `init` pay for the search
+  # anyway whenever the data check was skipped -- and then discarded what they
+  # supplied, because the search result is assigned over it below. Measured on a
+  # 32-row four-dose Beta fixture with nec3param, 2026-09-07, R 4.6.1: 597.6 s
+  # with `init` supplied against 577.2 s without, identical within noise. The
+  # clause was load-bearing for one caller only, and that is fixed at its
+  # source: amend() passed `init = simdat$init`, the stanfit inits of a model
+  # already in the set, to a model being added to it, so the search had to run
+  # to overwrite them. amend() no longer passes them. See #290.
+  if (!("init" %in% names(brm_args))) {
     msg_tag <- family$family
     model_tag <- if (is.null(model_survival) || identical(model_survival,
                                                           model)) {

--- a/R/models.R
+++ b/R/models.R
@@ -63,6 +63,16 @@
 #' not need to be controlled by the user and a call to \code{\link{bnec}} with
 #' \code{models = "all"} will simply exclude inappropriate models.
 #'
+#' A model group names a shape, not a set of equations admissible for a given
+#' response. "decline" is the set that excludes the hormesis models, and it
+#' therefore includes "neclin" and "ecxlin", whose mean decays by subtraction
+#' and is unbounded below. Neither is admissible for a response bounded at
+#' zero. A \code{\link{bnec}} call is unaffected, because the same internal
+#' check described above drops them where the family requires it; what the
+#' group name does not do is state which equations that check will keep. Code
+#' that needs the admissible set should ask for it directly, by passing the
+#' numeric range --- \code{models(c(0, 1))} --- rather than reading a group.
+#'
 #' \bold{Coming from the \code{drc} package}
 #'
 #' \code{drc}'s \code{NEC.2()}, \code{NEC.3()} and \code{NEC.4()} are

--- a/man/bnec.Rd
+++ b/man/bnec.Rd
@@ -176,6 +176,11 @@ parameter will be fit; "bot_free" meaning only models without a "bot"
 parameter (without a bottom plateau) will be fit; "zero_bounded" are models
 that are bounded to be zero; or "decline" excludes all hormesis models, i.e.,
 only allows a strict decline in response across the whole predictor range.
+Each group names a shape rather than a set of equations admissible for a
+given response --- "decline" includes the linear-decay models, which are
+dropped for a zero-bounded or 0, 1 bounded response --- so a group string is
+filtered by the same family check that \code{model = "all"} is. See
+\code{\link{models}}.
 Notice that if one of these group strings is provided together with a
 user-specified named list for the \code{\link[brms]{brm}}'s argument
 \code{prior}, the list names need to contain

--- a/man/models.Rd
+++ b/man/models.Rd
@@ -75,6 +75,16 @@ predictor contains negative values. These restrictions do
 not need to be controlled by the user and a call to \code{\link{bnec}} with
 \code{models = "all"} will simply exclude inappropriate models.
 
+A model group names a shape, not a set of equations admissible for a given
+response. "decline" is the set that excludes the hormesis models, and it
+therefore includes "neclin" and "ecxlin", whose mean decays by subtraction
+and is unbounded below. Neither is admissible for a response bounded at
+zero. A \code{\link{bnec}} call is unaffected, because the same internal
+check described above drops them where the family requires it; what the
+group name does not do is state which equations that check will keep. Code
+that needs the admissible set should ask for it directly, by passing the
+numeric range --- \code{models(c(0, 1))} --- rather than reading a group.
+
 \bold{Coming from the \code{drc} package}
 
 \code{drc}'s \code{NEC.2()}, \code{NEC.3()} and \code{NEC.4()} are

--- a/tests/testthat/test-bnecfit-methods.R
+++ b/tests/testthat/test-bnecfit-methods.R
@@ -157,3 +157,39 @@ test_that("a link the caller writes is honoured on update", {
   )
   expect_equal(got$family$link, "logit")
 })
+
+test_that("update returns a bayesnecfit when only one model survives", {
+  skip_on_cran()
+  # A refit that fails for one model of a set is the ordinary case
+  # expand_manec()'s single-survivor branch exists to handle, so update() must
+  # return what bnec() and amend() return for the same surviving set. It
+  # classed the bare one-element list as a bayesmanecfit, and every method on
+  # the result then failed on a missing `mod_fits`. See #288.
+  #
+  # The stub returns the stored fit unchanged for the first model and fails for
+  # the second, which reaches the branch without sampling.
+  tbl <- get(".__S3MethodsTable__.", envir = asNamespace("stats"))
+  orig_method <- get("update.brmsfit", envir = tbl)
+  on.exit(assign("update.brmsfit", orig_method, envir = tbl), add = TRUE)
+  n_called <- 0
+  stub <- function(object, formula. = NULL, newdata = NULL, recompile = NULL,
+                   ...) {
+    n_called <<- n_called + 1
+    if (n_called == 1) {
+      object
+    } else {
+      stop("halted by test")
+    }
+  }
+  assign("update.brmsfit", stub, envir = tbl)
+  # try(silent = FALSE) in the refit loop prints the stub's stop to stderr.
+  invisible(capture.output(
+    upd <- suppressMessages(update(manec_example)),
+    type = "message"
+  ))
+  expect_s3_class(upd, "bayesnecfit")
+  expect_false(inherits(upd, "bayesmanecfit"))
+  expect_true(is_bayesnecfit(upd))
+  expect_equal(upd$model, names(manec_example$mod_fits)[1])
+  expect_error(suppressWarnings(summary(upd)), NA)
+})

--- a/tests/testthat/test-check_priors.R
+++ b/tests/testthat/test-check_priors.R
@@ -37,11 +37,10 @@ test_that("adapt_delta is not raised for a transformed ogl term", {
   gs <- parse_group_terms(f, "nec3param")
   # The initial-value search is mocked away. This fixture cannot be initialised
   # at all, so the search runs to the 1e4 cap -- 577 seconds measured -- and
-  # these assertions are about adapt_delta, not about inits. Supplying
-  # init = "random" does not avoid it here: add_brm_defaults() runs the search
-  # when init is absent OR when skip_check is TRUE (R/helpers.R:831), and these
-  # calls pass skip_check = TRUE. test-define_prior.R suppresses it with `init`
-  # instead, which works there because that call passes skip_check = FALSE.
+  # these assertions are about adapt_delta, not about inits. Since #290 an
+  # init = "random" in the argument list would suppress the search here too;
+  # the mock is kept because it states what these calls need directly, rather
+  # than through a second argument whose effect on the search is incidental.
   local_mocked_bindings(
     make_good_inits = function(...) list(random = "random"),
     .package = "bayesnec"

--- a/tests/testthat/test-inits_functions.R
+++ b/tests/testthat/test-inits_functions.R
@@ -421,6 +421,46 @@ test_that("the fixed parameter is dropped before the inits reach brm", {
   # the prior itself must still reach brm(); only the init is dropped
   expect_true("constant(0)" %in% out$prior$prior)
 })
+
+test_that("a supplied init is honoured whether or not the data check is run", {
+  # add_brm_defaults() used to run the search when `init` was absent OR when
+  # skip_check was TRUE, so a caller who supplied initial values under
+  # skip_check = TRUE paid for a search -- measured at 577 s on a fixture that
+  # cannot be initialised -- and then had what they supplied overwritten by its
+  # result. The two conditions answer different questions: whether anyone needs
+  # initial values, and whether the data has been checked. See #290.
+  x <- as.numeric(rep(1:10, each = 5))
+  set.seed(42)
+  y <- 3 * exp(-exp(-0.5) * pmax(x - 4, 0)) + rnorm(length(x), 0, 0.1)
+  searched <- FALSE
+  local_mocked_bindings(
+    make_good_inits = function(...) {
+      searched <<- TRUE
+      list(random = "random")
+    },
+    .package = "bayesnec"
+  )
+  for (sc in c(TRUE, FALSE)) {
+    searched <- FALSE
+    out <- suppressMessages(
+      bayesnec:::add_brm_defaults(list(init = "random"), "nec4param",
+                                 validate_family("gaussian"), x, y,
+                                 skip_check = sc, custom_name = NULL)
+    )
+    expect_false(searched)
+    expect_identical(out$init, "random")
+  }
+  # Absent, the search still runs on both routes.
+  for (sc in c(TRUE, FALSE)) {
+    searched <- FALSE
+    suppressMessages(
+      bayesnec:::add_brm_defaults(list(), "nec4param",
+                                 validate_family("gaussian"), x, y,
+                                 skip_check = sc, custom_name = NULL)
+    )
+    expect_true(searched)
+  }
+})
 # --- #244 x #148: the two halves of the constant-prior NA ---------------------
 # brms carries a parameter fixed by constant() into the draws as a zero-variance
 # column, and posterior returns NA for it. Before #148 Part D that NA reached


### PR DESCRIPTION
## What

Resolves the three issues opened while reviewing the batch merged into `dev`
last week: #288, #290 and #285. Two are code fixes with tests; the third is
documentation only.

## Why it matters

**#288 — `update()` returns an unusable object.** On a `bayesmanecfit` where all
but one model fails to refit, `update()` returned something classed
`bayesmanecfit` with none of that class's structure. Every method on the result
then failed naming a missing component rather than the update. A refit failing
for one model of a set is the ordinary case that code path exists to handle.
`bnec()` and `amend()` already returned a `bayesnecfit` for the same surviving
set, so the three entry points disagreed; they now agree.

**#290 — a supplied `init` was paid for and then discarded.** The initial-value
search ran when `init` was absent **or** when `skip_check` was `TRUE`. A caller
who supplied initial values under `skip_check = TRUE` therefore waited for the
search — 577 s measured on a fixture that cannot be initialised — and then had
what they supplied overwritten by its result. `amend()` reaches this path, so
adding a model to an existing set with `init` supplied paid it too.

**#285 — `mod_groups$decline` is not a statement of admissibility.** The group
includes `neclin` and `ecxlin`, whose mean decays by subtraction and is
unbounded below, so neither is admissible for a response bounded at zero. A
`bnec()` call is unaffected, because `check_models()` drops them where the
family requires it. Nothing said so, and code reading the group directly as a
statement of admissibility got two equations that are not.

## Evidence

**#288.** `R/bnecfit-methods.R:251` branched on `length(object) > 1`, the length
of the list *before* the refits, then classed whatever `expand_manec()` returned
as `c("bayesmanecfit", "bnecfit")` unconditionally. With one survivor
`expand_manec()` returns `object[success_models]`
(`R/expand_classes.R:275-282`), a bare one-element list of `prebayesnecfit`.
The new test in `test-bnecfit-methods.R` fails on the unfixed code with five
failures and passes on the fixed code.

**#290.** Measured on a 32-row, four-dose `Beta` fixture with `nec3param`,
2026-09-07, R 4.6.1: 597.6 s with `init` supplied against 577.2 s without —
identical within noise, so the supplied value changed nothing.

The issue's proposed one-line deletion of `|| skip_check` is **not** safe on its
own, and this is the substantive finding. `amend()` built `brm_args` with
`init = simdat$init`, which is `modfit$fit$fit@inits` — the stanfit initial
values of a model *already in the set*. That branch (`R/amend.R:243`) is reached
only for a model that is **not** in the set, so those values always name another
equation's parameters. The `|| skip_check` clause was what forced the search to
run and overwrite them; deleting it alone would have passed one equation's inits
to a different equation. It is fixed at the source instead: `amend()` no longer
passes `init`, so the search is requested by the absence of `init` rather than
compelled by `skip_check`, and `amend()`'s behaviour is unchanged.

One correction to #290's text: it records that the search result is overridden
by the supplied values. It is the other way round — `brm_args$init <- inits`
(`R/helpers.R:936`) is the last statement of the block, so the caller's `init`
was silently discarded. The fix corrects that as well as the runtime.

**#285.** Resolved by the issue's first option, documenting the group rather
than changing it. Non-breaking, and `?bnec` already read this way ("only allows
a strict decline in response across the whole predictor range").

<details>
<summary>Implementation detail</summary>

### #288 — `R/bnecfit-methods.R`

Assign the result of `expand_manec()`, test *its* length, and route a single
survivor through `expand_nec()`, which is the shape `R/bnec.R:667-676` and
`R/amend.R:298-303` already use.

`formulas[[surviving]]` rather than `formulas[[1]]`: `formulas` is built from
the pre-refit list, so the surviving model is not necessarily its first element.
`expand_manec()` returns a subset of the list it was given, so the names align.

The `length(object) == 1` branch is untouched, so its `somethingwentwrong` error
is still reachable, and the "all models fail" path still stops inside
`expand_manec()`. `bnec_record` is attached after the branch and does not depend
on which one ran.

### #290 — `R/helpers.R`, `R/amend.R`

`R/helpers.R:831` becomes `if (!("init" %in% names(brm_args)))`. `R/amend.R:246`
drops `init = simdat$init` from the argument list. Both sites carry a comment
recording the measurement and the reason, since the clause had none and the next
reader will ask the same question the issue did.

`skip_check` is not otherwise consulted for initial values. It is a
`fit_bayesnec()` argument defaulting to `FALSE`, and `amend()` is its only
`TRUE` caller; `fit_bayesnec()` is not exported.

### Tests

- `test-bnecfit-methods.R`: a stub written into the stats S3 methods table
  returns the stored fit for the first model and fails for the second, so the
  single-survivor branch is reached without sampling. Asserts the result is a
  `bayesnecfit` and not a `bayesmanecfit`, that `is_bayesnecfit()` holds, that
  `$model` names the survivor, and that `summary()` does not error.
- `test-inits_functions.R`: `make_good_inits()` is mocked with a flag. With
  `init` supplied the search must not run and `out$init` must be returned
  unchanged, for `skip_check` both `TRUE` and `FALSE`; with `init` absent it
  must still run on both routes.
- `test-check_priors.R:41-44` carried a comment stating the old
  "init absent OR skip_check" rule as the reason for its mock. The comment is
  corrected; the mock is kept, because it states what those calls need directly.

### Test runs

`NOT_CRAN=true`, R 4.5.2 (WSL), 2026-09-08:

- `test-bnecfit-methods.R` — 0 failures, 31 pass (5 failures without the #288 fix)
- `test-amend.R` — 0 failures, 21 pass
- `test-check_priors.R` — 0 failures, 15 pass
- `test-inits_functions.R` — 0 failures, 370 pass

### Not done here

`failed_models()` is still not attached by `update()`, which #288 records as a
separate question. `mod_groups$decline` is unchanged, per the resolution chosen
for #285.

</details>

Closes #285
Closes #288
Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176pqhDhAhhHf1E5CdaSyE9
