### PR TITLE
Keep dispersion() where an observation is reproduced exactly (#298)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -263,24 +263,38 @@
   (1 - mu) n` for a binomial and `mu` for a Poisson --- and the response at such
   an observation is the fitted value, so its residual is `0/0`. One of them made
   every draw `NaN`, and the whole vector was returned empty with a message
-  attributing it to a bad model fit. Such observations are now excluded from
-  both the observed and the simulated sum, every draw is retained, and a message
-  names them. Where instead the response differs from a fitted value of zero
-  variance, the observed Pearson residual is infinite; that is a property of the
-  fit rather than a numerical limit, so the statistic is reported as `Inf` and a
-  warning names the observations rather than the case being swallowed by the
-  same branch. It is a warning rather than an error because `dispersion()` is
-  called once per equation from `expand_nec()`, where stopping would abandon
-  construction of the whole `bayesmanecfit`. Measured on the `nassarius`
-  contaminant A survival set of `vignette("example9")` (binomial, `decline`,
-  nine equations, 2026-09-08, R 4.6.1): three equations returned `NA`, among
-  them `ecxsigm` at 0.767 of the model weight with a Bayesian R-squared of 0.91,
-  while `ecxexp` at 0.002 of the weight reported a value. The statistic was
-  therefore least available for the equations describing the data best, since
-  underflow requires a fast decay. `expand_nec()` writes the four `dispersion_*`
-  columns of the weights table from this vector, so those columns now populate
-  for such a fit. An empty vector is returned only where every observation is
-  degenerate, with a message that says so (#298).
+  attributing it to a bad model fit.
+
+  Such a term is now excluded from both the observed and the simulated sum and
+  every draw is retained. The exclusion is the limit rather than an
+  approximation to it: as the fitted mean tends to zero with a response of zero
+  both terms tend to zero, so excluding them is arithmetically identical to
+  contributing zero to each sum, and the ratio is self-normalising, so its null
+  value of 1 holds whatever the size of the retained set. It is made draw by
+  draw, since an observation whose fitted mean underflows in one draw gives an
+  ordinary residual in another, and a message reports the observations and the
+  draws affected. Measured on the fixture added with this change, 400 post
+  warm-up draws: 229 draws exclude nothing, 60 exclude three observations and
+  111 exclude six, and no observation is excluded in every draw.
+
+  Where instead the response differs from a fitted value of zero variance, the
+  statistic is reported as `Inf` and a warning names the observations, rather
+  than the case being swallowed by the same branch. The infinity is produced by
+  the underflow, since in exact arithmetic the residual there is large and
+  finite, but the misfit it reports is real. It is a warning rather than an
+  error because `dispersion()` is called once per equation from `expand_nec()`,
+  where stopping would abandon construction of the whole `bayesmanecfit`.
+
+  Measured on the `nassarius` contaminant A survival set of
+  `vignette("example9")` (binomial, `decline`, nine equations, 2026-09-08, R
+  4.6.1): three equations returned `NA`, among them `ecxsigm` at 0.767 of the
+  model weight with a Bayesian R-squared of 0.91, while `ecxexp` at 0.002 of the
+  weight reported a value. The statistic was therefore least available for the
+  equations describing the data best, since underflow requires a fast decay.
+  `expand_nec()` writes the four `dispersion_*` columns of the weights table
+  from this vector, so those columns now populate for such a fit. An empty
+  vector is returned only where no observation contributes a residual in any
+  draw, with a message that says so (#298).
 
 - `update()` on a `bayesmanecfit` returned an object classed `bayesmanecfit`
   with none of that class's structure whenever all but one model failed to

--- a/NEWS.md
+++ b/NEWS.md
@@ -257,6 +257,31 @@
 
 ## Bug fixes
 
+- `dispersion()` no longer discards the statistic where a single observation is
+  reproduced exactly. The Pearson denominator is the fitted standard deviation,
+  which underflows to exactly zero for a curve that decays fast enough --- `mu
+  (1 - mu) n` for a binomial and `mu` for a Poisson --- and the response at such
+  an observation is the fitted value, so its residual is `0/0`. One of them made
+  every draw `NaN`, and the whole vector was returned empty with a message
+  attributing it to a bad model fit. Such observations are now excluded from
+  both the observed and the simulated sum, every draw is retained, and a message
+  names them. Where instead the response differs from a fitted value of zero
+  variance, the observed Pearson residual is infinite; that is a property of the
+  fit rather than a numerical limit, so the statistic is reported as `Inf` and a
+  warning names the observations rather than the case being swallowed by the
+  same branch. It is a warning rather than an error because `dispersion()` is
+  called once per equation from `expand_nec()`, where stopping would abandon
+  construction of the whole `bayesmanecfit`. Measured on the `nassarius`
+  contaminant A survival set of `vignette("example9")` (binomial, `decline`,
+  nine equations, 2026-09-08, R 4.6.1): three equations returned `NA`, among
+  them `ecxsigm` at 0.767 of the model weight with a Bayesian R-squared of 0.91,
+  while `ecxexp` at 0.002 of the weight reported a value. The statistic was
+  therefore least available for the equations describing the data best, since
+  underflow requires a fast decay. `expand_nec()` writes the four `dispersion_*`
+  columns of the weights table from this vector, so those columns now populate
+  for such a fit. An empty vector is returned only where every observation is
+  degenerate, with a message that says so (#298).
+
 - `update()` on a `bayesmanecfit` returned an object classed `bayesmanecfit`
   with none of that class's structure whenever all but one model failed to
   refit. The guard tested the length of the candidate set going in rather than

--- a/R/dispersion.R
+++ b/R/dispersion.R
@@ -28,6 +28,20 @@
 #' posterior probability of under-dispersion, which no other summary here
 #' addresses.
 #'
+#' \bold{An observation the model reproduces exactly is excluded.} The Pearson
+#' denominator is the fitted standard deviation, which is exactly zero wherever
+#' the fitted mean underflows --- \code{mu (1 - mu) n} for a binomial and
+#' \code{mu} for a Poisson both do so for a curve that decays fast enough. An
+#' observation whose response equals that fitted value contributes \code{0/0}
+#' to both sums and says nothing about dispersion in either direction, so it is
+#' excluded from both and every draw is retained. The number of observations
+#' excluded is reported. Where instead the response differs from a fitted value
+#' of zero variance, the model has assigned zero variance to a value it did not
+#' predict; the Pearson residual is infinite, the statistic is reported as
+#' \code{Inf}, and a warning names the observations. An empty vector is
+#' returned only where every observation has zero variance and is reproduced
+#' exactly, in which case there are no residuals to compare.
+#'
 #' \bold{A beta-binomial fit does not address under-dispersion.}
 #' \code{beta_binomial} adds a variance component to the binomial, so it can
 #' represent a variance above the binomial's and not one below it. Where
@@ -69,6 +83,13 @@ dispersion <- function(model, summary = FALSE, seed = 10) {
   }
   chk_lgl(summary)
   chk_number(seed)
+  # Captured before `model` is replaced by the brmsfit. expand_nec() calls this
+  # once per equation, so an unnamed message on a model set says only that
+  # something somewhere was excluded, which is not enough to act on.
+  mod_name <- model$model
+  if (is.null(mod_name)) {
+    mod_name <- "fitted"
+  }
   formula <- model$bayesnecformula
   model <- model$fit
   mod_dat <- model.frame(formula, data = model$data)
@@ -92,10 +113,12 @@ dispersion <- function(model, summary = FALSE, seed = 10) {
     prd_out <- posterior_epred(model)
     set.seed(seed)
     ppd_out <- posterior_predict(model)
-    prd_sr <- matrix(0, nrow(prd_out), ncol(prd_out))
-    sim_sr <- matrix(0, nrow(prd_out), ncol(prd_out))
+    # The per-observation fitted variance is collected first and the residual
+    # arithmetic done in one place, because an observation with zero variance
+    # has to be handled differently depending on whether the response agrees
+    # with the fitted value. See pearson_dispersion() and #298.
+    var_out <- matrix(0, nrow(prd_out), ncol(prd_out))
     for (i in seq_len(nrow(prd_out))) {
-      prd_y <- prd_out[i, ]
       prd_mu <- fam_fcts$linkinv(lpd_out[i, ])
       prd_var_y <- fam_fcts$variance(prd_mu)
       if (fam == "binomial") {
@@ -115,17 +138,16 @@ dispersion <- function(model, summary = FALSE, seed = 10) {
         # rather than copying this line. See #136.
         prd_var_y <- prd_var_y * model$data[[rate_var]]
       }
-      prd_res <- (obs_y - prd_y) / sqrt(prd_var_y)
-      sim_y <- ppd_out[i, ]
-      sim_res <- (sim_y - prd_y) / sqrt(prd_var_y)
-      prd_sr[i, ] <- prd_res^2
-      sim_sr[i, ] <- sim_res^2
+      var_out[i, ] <- prd_var_y
     }
-    disp <- rowSums(prd_sr) / rowSums(sim_sr)
-    if (any(is.na(disp))) {
-      message("Your model predictions have generated no residuals; this is",
-              " most likely cause by a bad model fit. Ignoring dispersion",
-              " calculation.")
+    disp <- pearson_dispersion(obs_y, prd_out, ppd_out, var_out,
+                               labels = rownames(model$data),
+                               model_name = mod_name)
+    if (all(is.na(disp))) {
+      message("Every observation has a fitted variance of zero and is",
+              " reproduced exactly by the ", mod_name, " model, so there are",
+              " no residuals to compare. The dispersion statistic is not",
+              " defined for this fit.")
       numeric()
     } else {
       if (summary) {
@@ -147,4 +169,115 @@ dispersion <- function(model, summary = FALSE, seed = 10) {
   } else {
     numeric()
   }
+}
+
+#' Pearson residual dispersion ratio, with degenerate observations handled
+#'
+#' Computes, for each posterior draw, the ratio of the observed to the
+#' simulated Pearson residual sum of squares.
+#'
+#' @param obs_y A \code{\link[base]{numeric}} vector of observed responses.
+#' @param prd_out A draws-by-observations \code{\link[base]{matrix}} of fitted
+#' means, from \code{\link[brms]{posterior_epred}}.
+#' @param ppd_out A draws-by-observations \code{\link[base]{matrix}} of
+#' simulated responses, from \code{\link[brms]{posterior_predict}}.
+#' @param var_out A draws-by-observations \code{\link[base]{matrix}} of fitted
+#' variances on the scale of \code{obs_y}.
+#' @param labels A \code{\link[base]{character}} vector naming the
+#' observations, used in the message and the warning. Defaults to the column
+#' positions.
+#' @param model_name A \code{\link[base]{character}} naming the equation, used
+#' in the message and the warning.
+#'
+#' @details The Pearson denominator is \code{sqrt(var_out)}, which is exactly
+#' zero wherever the fitted mean underflows --- \code{mu (1 - mu) n} for a
+#' binomial and \code{mu} for a Poisson both do so for a curve that decays fast
+#' enough. Two cases reach that zero and they need opposite treatment.
+#'
+#' Where the response equals the fitted value, the model is degenerate at that
+#' observation and the data agree with it exactly. Both the observed and the
+#' simulated term are \code{0/0}: the observation says nothing about dispersion
+#' in either direction, so it is excluded from both sums and every draw is
+#' retained. Discarding the whole statistic instead, as this function did
+#' before #298, lost it precisely for the equations describing the data best,
+#' since underflow requires a fast decay.
+#'
+#' Where the response differs from the fitted value, the model has assigned zero
+#' variance to a value it did not predict. That is a severe misfit rather than a
+#' numerical artefact, so its infinite observed term is kept and the statistic
+#' is reported as \code{Inf}. Only the simulated term is excluded, because a
+#' degenerate predictive distribution cannot deviate from its mean and is
+#' \code{0/0} whichever case holds. A warning names the observations. It is a
+#' warning rather than an error because \code{dispersion()} is called once per
+#' equation from \code{expand_nec()}, so stopping would abandon construction of
+#' a whole \code{\link{bayesmanecfit}} for one candidate whose shape is wrong.
+#'
+#' @return A \code{\link[base]{numeric}} vector with one element per draw.
+#' \code{NA} for a draw in which every observation is degenerate and agreeing.
+#'
+#' @noRd
+pearson_dispersion <- function(obs_y, prd_out, ppd_out, var_out,
+                               labels = NULL, model_name = NULL) {
+  who <- if (is.null(model_name)) {
+    "The fitted mean"
+  } else {
+    paste0("The fitted ", model_name, " mean")
+  }
+  if (length(labels) != ncol(prd_out)) {
+    labels <- as.character(seq_len(ncol(prd_out)))
+  }
+  denom <- sqrt(var_out)
+  obs_mat <- matrix(obs_y, nrow(prd_out), ncol(prd_out), byrow = TRUE)
+  prd_sr <- ((obs_mat - prd_out) / denom)^2
+  sim_sr <- ((ppd_out - prd_out) / denom)^2
+  # A variance that is not finite is neither of the two cases below and no
+  # accepted family should produce one. It is excluded from both sums and
+  # reported, rather than left to disappear into the na.rm below.
+  unusable <- !is.finite(var_out)
+  degenerate <- var_out == 0
+  degenerate[unusable] <- FALSE
+  disagreeing <- degenerate & obs_mat != prd_out
+  prd_sr[unusable | (degenerate & !disagreeing)] <- NA
+  sim_sr[unusable | degenerate] <- NA
+  # na.rm drops the excluded terms rather than the draw. A draw in which every
+  # observation is excluded and none of them disagrees sums to 0/0, and is
+  # returned as NA so that estimates_summary() excludes it as it does a
+  # censored ECx draw. Where such a draw does have a disagreeing observation
+  # the observed sum is Inf and the ratio stays Inf, which is the verdict that
+  # case earns.
+  n_used <- rowSums(!degenerate & !unusable)
+  disp <- rowSums(prd_sr, na.rm = TRUE) / rowSums(sim_sr, na.rm = TRUE)
+  disp[n_used == 0 & rowSums(disagreeing) == 0] <- NA_real_
+  if (any(unusable)) {
+    warning(who, "'s variance is not finite at ",
+            n_obs_phrase(sum(colSums(unusable) > 0)), " (",
+            paste(labels[which(colSums(unusable) > 0)], collapse = ", "),
+            "). Those observations are excluded from the dispersion ",
+            "statistic.", call. = FALSE)
+  }
+  excluded <- which(colSums(degenerate & !disagreeing) > 0)
+  if (length(excluded) > 0) {
+    message(who, " has zero variance at ", length(excluded), " of ",
+            ncol(prd_out), " observations (", paste(labels[excluded],
+            collapse = ", "), ") which the model reproduces exactly. Those ",
+            "observations carry no information about dispersion and are ",
+            "excluded from the statistic; all draws are retained.")
+  }
+  infinite <- which(colSums(disagreeing) > 0)
+  if (length(infinite) > 0) {
+    warning(who, " has zero variance at ",
+            n_obs_phrase(length(infinite)), " (",
+            paste(labels[infinite], collapse = ", "),
+            ") whose response is not the fitted value. The Pearson residual ",
+            "is infinite there and the dispersion statistic is reported as ",
+            "Inf. This is a property of the fit rather than a numerical ",
+            "limit: the model has assigned zero variance to a value it did ",
+            "not predict.", call. = FALSE)
+  }
+  disp
+}
+
+#' @noRd
+n_obs_phrase <- function(n) {
+  paste(n, if (n == 1) "observation" else "observations")
 }

--- a/R/dispersion.R
+++ b/R/dispersion.R
@@ -148,10 +148,7 @@ dispersion <- function(model, summary = FALSE, seed = 10) {
         # than a plain multiple. dispersion() does not accept negbinomial at
         # all -- see allowed_fams above -- so there is nothing to get wrong
         # today, but whoever widens that list must derive the negbinomial case
-        # rather than copying this line. See #136. Such a change also reaches
-        # pearson_dispersion(), whose classification of a zero denominator
-        # assumes the variance and the mean underflow together; that holds for
-        # binomial and Poisson and not for a Gamma-style variance.
+        # rather than copying this line. See #136.
         prd_var_y <- prd_var_y * model$data[[rate_var]]
       }
       var_out[i, ] <- prd_var_y
@@ -231,16 +228,6 @@ dispersion <- function(model, summary = FALSE, seed = 10) {
 #' warning rather than an error because \code{dispersion()} is called once per
 #' equation from \code{expand_nec()}, so stopping would abandon construction of
 #' a whole \code{\link{bayesmanecfit}} for one candidate whose shape is wrong.
-#'
-#' The classification of a zero denominator assumes that the variance and the
-#' mean underflow together, which holds for the two families
-#' \code{dispersion()} accepts: \code{1 - mu} is exactly 1 for any \code{mu}
-#' below machine epsilon, so \code{mu (1 - mu) n} and \code{mu n} are the same
-#' product. It does not hold for a family whose variance underflows first --- a
-#' Gamma-style \code{mu^2 / shape} is zero at \code{mu = 1e-170} --- where a
-#' response of zero would be classified as a disagreement and the statistic
-#' reported as \code{Inf}. See the note on \code{allowed_fams} in
-#' \code{dispersion()}.
 #'
 #' @return A \code{\link[base]{numeric}} vector with one element per draw.
 #' \code{NA} for a draw in which no observation contributes a residual.

--- a/R/dispersion.R
+++ b/R/dispersion.R
@@ -15,14 +15,18 @@
 #'
 #' @return A \code{\link[base]{numeric}} vector. If \code{summary} is FALSE, an
 #' n-long vector containing the dispersion metric, where n is the number of post
-#' warm-up posterior draws from the \code{\link[brms]{brmsfit}} object. If
+#' warm-up posterior draws from the \code{\link[brms]{brmsfit}} object. An
+#' element of that vector is \code{Inf} for a draw containing an observation of
+#' zero fitted variance whose response is not the fitted value, and \code{NA}
+#' for a draw in which no observation contributes a residual; both cases are
+#' described under Details and both are reported when they arise. If
 #' TRUE, then a \code{\link[base]{data.frame}} containing the summary stats
 #' (median, 95% credible interval, and the posterior probability of
 #' over-dispersion) of the dispersion metric.
 #'
 #' @details The statistic is the ratio of the observed to the simulated Pearson
 #' residual sum of squares, whose null value is 1. With \code{summary = TRUE}
-#' the returned vector carries \code{P(>1)}, the posterior probability that the
+#' the returned vector reports \code{P(>1)}, the posterior probability that the
 #' ratio exceeds 1. It uses the whole posterior rather than a point estimate or
 #' a single tail quantile, and it is symmetric: \code{1 - P(>1)} is the
 #' posterior probability of under-dispersion, which no other summary here
@@ -34,11 +38,22 @@
 #' \code{mu} for a Poisson both do so for a curve that decays fast enough. An
 #' observation whose response equals that fitted value contributes \code{0/0}
 #' to both sums and says nothing about dispersion in either direction, so it is
-#' excluded from both and every draw is retained. The number of observations
-#' excluded is reported. Where instead the response differs from a fitted value
+#' excluded from both and every draw is retained. The exclusion is the limit
+#' rather than an approximation to it: as the fitted mean tends to zero with a
+#' response of zero the observed term tends to zero, and the simulated term
+#' does the same, because a predictive distribution of vanishing variance
+#' returns its mean with probability approaching one. Excluding a term is
+#' arithmetically identical to contributing zero to both sums, so it introduces
+#' no bias in either direction, and the ratio is self-normalising --- under the
+#' null each retained observation contributes approximately 1 to the
+#' denominator, so the null value of 1 holds whatever the size of the retained
+#' set. The exclusion is made draw by draw, since an observation whose fitted
+#' mean underflows in one draw gives an ordinary residual in another, and the
+#' number of observations and of draws affected is reported. Where instead the response differs from a fitted value
 #' of zero variance, the model has assigned zero variance to a value it did not
-#' predict; the Pearson residual is infinite, the statistic is reported as
-#' \code{Inf}, and a warning names the observations. An empty vector is
+#' predict; the statistic is reported as \code{Inf} and a warning names the
+#' observations. The infinity is the underflow --- in exact arithmetic the
+#' residual there is large and finite --- but the misfit it reports is real. An empty vector is
 #' returned only where every observation has zero variance and is reproduced
 #' exactly, in which case there are no residuals to compare.
 #'
@@ -87,9 +102,7 @@ dispersion <- function(model, summary = FALSE, seed = 10) {
   # once per equation, so an unnamed message on a model set says only that
   # something somewhere was excluded, which is not enough to act on.
   mod_name <- model$model
-  if (is.null(mod_name)) {
-    mod_name <- "fitted"
-  }
+  mod_label <- if (is.null(mod_name)) "fitted" else mod_name
   formula <- model$bayesnecformula
   model <- model$fit
   mod_dat <- model.frame(formula, data = model$data)
@@ -135,7 +148,10 @@ dispersion <- function(model, summary = FALSE, seed = 10) {
         # than a plain multiple. dispersion() does not accept negbinomial at
         # all -- see allowed_fams above -- so there is nothing to get wrong
         # today, but whoever widens that list must derive the negbinomial case
-        # rather than copying this line. See #136.
+        # rather than copying this line. See #136. Such a change also reaches
+        # pearson_dispersion(), whose classification of a zero denominator
+        # assumes the variance and the mean underflow together; that holds for
+        # binomial and Poisson and not for a Gamma-style variance.
         prd_var_y <- prd_var_y * model$data[[rate_var]]
       }
       var_out[i, ] <- prd_var_y
@@ -144,10 +160,13 @@ dispersion <- function(model, summary = FALSE, seed = 10) {
                                labels = rownames(model$data),
                                model_name = mod_name)
     if (all(is.na(disp))) {
-      message("Every observation has a fitted variance of zero and is",
-              " reproduced exactly by the ", mod_name, " model, so there are",
-              " no residuals to compare. The dispersion statistic is not",
-              " defined for this fit.")
+      # Reached when no draw retains an observation. The usual cause is that
+      # every observation has zero variance and is reproduced exactly, but the
+      # message states the condition tested rather than assuming the cause.
+      message("No observation contributes a residual to compare in any draw of",
+              " the ", mod_label, " model, so the dispersion statistic is not",
+              " defined for this fit. Where the fitted mean underflows this is",
+              " because the model reproduces every observation exactly.")
       numeric()
     } else {
       if (summary) {
@@ -203,21 +222,33 @@ dispersion <- function(model, summary = FALSE, seed = 10) {
 #' since underflow requires a fast decay.
 #'
 #' Where the response differs from the fitted value, the model has assigned zero
-#' variance to a value it did not predict. That is a severe misfit rather than a
-#' numerical artefact, so its infinite observed term is kept and the statistic
-#' is reported as \code{Inf}. Only the simulated term is excluded, because a
+#' variance to a value it did not predict. The infinity is produced by the
+#' underflow, since in exact arithmetic the residual there is large and finite,
+#' but the misfit it reports is real, so the observed term is kept and the
+#' statistic is reported as \code{Inf}. Only the simulated term is excluded, because a
 #' degenerate predictive distribution cannot deviate from its mean and is
 #' \code{0/0} whichever case holds. A warning names the observations. It is a
 #' warning rather than an error because \code{dispersion()} is called once per
 #' equation from \code{expand_nec()}, so stopping would abandon construction of
 #' a whole \code{\link{bayesmanecfit}} for one candidate whose shape is wrong.
 #'
+#' The classification of a zero denominator assumes that the variance and the
+#' mean underflow together, which holds for the two families
+#' \code{dispersion()} accepts: \code{1 - mu} is exactly 1 for any \code{mu}
+#' below machine epsilon, so \code{mu (1 - mu) n} and \code{mu n} are the same
+#' product. It does not hold for a family whose variance underflows first --- a
+#' Gamma-style \code{mu^2 / shape} is zero at \code{mu = 1e-170} --- where a
+#' response of zero would be classified as a disagreement and the statistic
+#' reported as \code{Inf}. See the note on \code{allowed_fams} in
+#' \code{dispersion()}.
+#'
 #' @return A \code{\link[base]{numeric}} vector with one element per draw.
-#' \code{NA} for a draw in which every observation is degenerate and agreeing.
+#' \code{NA} for a draw in which no observation contributes a residual.
 #'
 #' @noRd
 pearson_dispersion <- function(obs_y, prd_out, ppd_out, var_out,
                                labels = NULL, model_name = NULL) {
+  who_short <- if (is.null(model_name)) "fitted model" else model_name
   who <- if (is.null(model_name)) {
     "The fitted mean"
   } else {
@@ -226,53 +257,84 @@ pearson_dispersion <- function(obs_y, prd_out, ppd_out, var_out,
   if (length(labels) != ncol(prd_out)) {
     labels <- as.character(seq_len(ncol(prd_out)))
   }
-  denom <- sqrt(var_out)
   obs_mat <- matrix(obs_y, nrow(prd_out), ncol(prd_out), byrow = TRUE)
-  prd_sr <- ((obs_mat - prd_out) / denom)^2
-  sim_sr <- ((ppd_out - prd_out) / denom)^2
-  # A variance that is not finite is neither of the two cases below and no
-  # accepted family should produce one. It is excluded from both sums and
-  # reported, rather than left to disappear into the na.rm below.
-  unusable <- !is.finite(var_out)
+  # A variance that is negative or not finite is neither of the two cases below
+  # and no accepted family should produce one. It is excluded from both sums and
+  # reported, rather than left to disappear into the na.rm below. The negative
+  # test is needed as well as is.finite(): a negative variance is finite, and
+  # sqrt() would otherwise turn it into a NaN term that na.rm drops in silence,
+  # under base R's unattributed "NaNs produced" warning. Setting it missing
+  # before the square root keeps that warning from being raised at all.
+  unusable <- !is.finite(var_out) | var_out < 0
+  var_out[unusable] <- NA_real_
   degenerate <- var_out == 0
   degenerate[unusable] <- FALSE
   disagreeing <- degenerate & obs_mat != prd_out
-  prd_sr[unusable | (degenerate & !disagreeing)] <- NA
-  sim_sr[unusable | degenerate] <- NA
+  denom <- sqrt(var_out)
+  prd_sr <- ((obs_mat - prd_out) / denom)^2
+  sim_sr <- ((ppd_out - prd_out) / denom)^2
+  prd_sr[degenerate & !disagreeing] <- NA
+  # Defensive rather than load-bearing: a predictive distribution with zero
+  # variance is a point mass at its mean, so ppd_out equals prd_out and the
+  # term is already 0/0 whichever of the two cases holds.
+  sim_sr[degenerate] <- NA
   # na.rm drops the excluded terms rather than the draw. A draw in which every
-  # observation is excluded and none of them disagrees sums to 0/0, and is
-  # returned as NA so that estimates_summary() excludes it as it does a
-  # censored ECx draw. Where such a draw does have a disagreeing observation
-  # the observed sum is Inf and the ratio stays Inf, which is the verdict that
-  # case earns.
-  n_used <- rowSums(!degenerate & !unusable)
+  # term is excluded sums to 0/0, and the NaN that produces is replaced with NA
+  # so that the returned vector reads as missing rather than as an arithmetic
+  # accident; is.na() treats the two alike, so nothing downstream depends on
+  # the substitution. estimates_summary() then excludes such a draw as it does
+  # a censored ECx draw. A draw with a disagreeing observation divides Inf by
+  # the sum of what is left and stays Inf, which is the verdict that case
+  # earns.
   disp <- rowSums(prd_sr, na.rm = TRUE) / rowSums(sim_sr, na.rm = TRUE)
-  disp[n_used == 0 & rowSums(disagreeing) == 0] <- NA_real_
+  disp[is.nan(disp)] <- NA_real_
   if (any(unusable)) {
-    warning(who, "'s variance is not finite at ",
+    warning(who, "'s variance is negative or not finite at ",
             n_obs_phrase(sum(colSums(unusable) > 0)), " (",
             paste(labels[which(colSums(unusable) > 0)], collapse = ", "),
             "). Those observations are excluded from the dispersion ",
             "statistic.", call. = FALSE)
   }
-  excluded <- which(colSums(degenerate & !disagreeing) > 0)
+  reproduced <- degenerate & !disagreeing
+  excluded <- which(colSums(reproduced) > 0)
   if (length(excluded) > 0) {
+    # The count of draws is reported alongside the count of observations
+    # because the exclusion is elementwise and not a fixed set: an observation
+    # whose fitted mean underflows in a steep draw gives an ordinary residual
+    # in a shallower one. Naming only the observations would describe a set
+    # that is dropped from the whole posterior, which is a different and more
+    # damaging operation than the one performed. See #300.
     message(who, " has zero variance at ", length(excluded), " of ",
             ncol(prd_out), " observations (", paste(labels[excluded],
-            collapse = ", "), ") which the model reproduces exactly. Those ",
-            "observations carry no information about dispersion and are ",
-            "excluded from the statistic; all draws are retained.")
+            collapse = ", "), ") which the model reproduces exactly, in ",
+            sum(rowSums(reproduced) > 0), " of ", nrow(prd_out), " draws. ",
+            "Such a term says nothing about dispersion in either direction, ",
+            "and is excluded from both sums in the draws where it arises; ",
+            "every draw is retained.")
+  }
+  n_missing <- sum(is.na(disp))
+  if (n_missing > 0 && n_missing < length(disp)) {
+    # The same account nsec_off_curve() gives of a censored draw: the draws
+    # that return NA are named rather than left to be dropped by the na.rm in
+    # estimates_summary() and in P(>1). See #39.
+    message("No observation contributes a residual in ", n_missing, " of ",
+            length(disp), " draws of the ", who_short, ". Those draws return ",
+            "NA and are excluded from the summary, which is computed from the ",
+            "remainder.")
   }
   infinite <- which(colSums(disagreeing) > 0)
   if (length(infinite) > 0) {
     warning(who, " has zero variance at ",
             n_obs_phrase(length(infinite)), " (",
             paste(labels[infinite], collapse = ", "),
-            ") whose response is not the fitted value. The Pearson residual ",
-            "is infinite there and the dispersion statistic is reported as ",
-            "Inf. This is a property of the fit rather than a numerical ",
-            "limit: the model has assigned zero variance to a value it did ",
-            "not predict.", call. = FALSE)
+            ") whose response is not the fitted value. The statistic is ",
+            "reported as Inf. The infinity itself is the underflow --- in ",
+            "exact arithmetic the Pearson residual there is large and finite ",
+            "--- but the misfit it reports is real. For a converged binomial ",
+            "or Poisson fit this is close to unreachable, because the ",
+            "likelihood rejects a draw that assigns zero probability to an ",
+            "observed value, so the first thing to check is that the response ",
+            "and the fitted mean are on the same scale.", call. = FALSE)
   }
   disp
 }

--- a/man/dispersion.Rd
+++ b/man/dispersion.Rd
@@ -19,7 +19,11 @@ vector? Defaults to FALSE.}
 \value{
 A \code{\link[base]{numeric}} vector. If \code{summary} is FALSE, an
 n-long vector containing the dispersion metric, where n is the number of post
-warm-up posterior draws from the \code{\link[brms]{brmsfit}} object. If
+warm-up posterior draws from the \code{\link[brms]{brmsfit}} object. An
+element of that vector is \code{Inf} for a draw containing an observation of
+zero fitted variance whose response is not the fitted value, and \code{NA}
+for a draw in which no observation contributes a residual; both cases are
+described under Details and both are reported when they arise. If
 TRUE, then a \code{\link[base]{data.frame}} containing the summary stats
 (median, 95\% credible interval, and the posterior probability of
 over-dispersion) of the dispersion metric.
@@ -34,7 +38,7 @@ squares.
 
 The statistic is the ratio of the observed to the simulated Pearson
 residual sum of squares, whose null value is 1. With \code{summary = TRUE}
-the returned vector carries \code{P(>1)}, the posterior probability that the
+the returned vector reports \code{P(>1)}, the posterior probability that the
 ratio exceeds 1. It uses the whole posterior rather than a point estimate or
 a single tail quantile, and it is symmetric: \code{1 - P(>1)} is the
 posterior probability of under-dispersion, which no other summary here
@@ -46,11 +50,22 @@ the fitted mean underflows --- \code{mu (1 - mu) n} for a binomial and
 \code{mu} for a Poisson both do so for a curve that decays fast enough. An
 observation whose response equals that fitted value contributes \code{0/0}
 to both sums and says nothing about dispersion in either direction, so it is
-excluded from both and every draw is retained. The number of observations
-excluded is reported. Where instead the response differs from a fitted value
+excluded from both and every draw is retained. The exclusion is the limit
+rather than an approximation to it: as the fitted mean tends to zero with a
+response of zero the observed term tends to zero, and the simulated term
+does the same, because a predictive distribution of vanishing variance
+returns its mean with probability approaching one. Excluding a term is
+arithmetically identical to contributing zero to both sums, so it introduces
+no bias in either direction, and the ratio is self-normalising --- under the
+null each retained observation contributes approximately 1 to the
+denominator, so the null value of 1 holds whatever the size of the retained
+set. The exclusion is made draw by draw, since an observation whose fitted
+mean underflows in one draw gives an ordinary residual in another, and the
+number of observations and of draws affected is reported. Where instead the response differs from a fitted value
 of zero variance, the model has assigned zero variance to a value it did not
-predict; the Pearson residual is infinite, the statistic is reported as
-\code{Inf}, and a warning names the observations. An empty vector is
+predict; the statistic is reported as \code{Inf} and a warning names the
+observations. The infinity is the underflow --- in exact arithmetic the
+residual there is large and finite --- but the misfit it reports is real. An empty vector is
 returned only where every observation has zero variance and is reproduced
 exactly, in which case there are no residuals to compare.
 

--- a/man/dispersion.Rd
+++ b/man/dispersion.Rd
@@ -40,6 +40,20 @@ a single tail quantile, and it is symmetric: \code{1 - P(>1)} is the
 posterior probability of under-dispersion, which no other summary here
 addresses.
 
+\bold{An observation the model reproduces exactly is excluded.} The Pearson
+denominator is the fitted standard deviation, which is exactly zero wherever
+the fitted mean underflows --- \code{mu (1 - mu) n} for a binomial and
+\code{mu} for a Poisson both do so for a curve that decays fast enough. An
+observation whose response equals that fitted value contributes \code{0/0}
+to both sums and says nothing about dispersion in either direction, so it is
+excluded from both and every draw is retained. The number of observations
+excluded is reported. Where instead the response differs from a fitted value
+of zero variance, the model has assigned zero variance to a value it did not
+predict; the Pearson residual is infinite, the statistic is reported as
+\code{Inf}, and a warning names the observations. An empty vector is
+returned only where every observation has zero variance and is reproduced
+exactly, in which case there are no residuals to compare.
+
 \bold{A beta-binomial fit does not address under-dispersion.}
 \code{beta_binomial} adds a variance component to the binomial, so it can
 represent a variance above the binomial's and not one below it. Where

--- a/tests/testthat/test-dispersion.R
+++ b/tests/testthat/test-dispersion.R
@@ -126,15 +126,76 @@ test_that("a draw with nothing left to compare returns NA", {
   expect_true(all(is.na(disp)))
 })
 
-test_that("a non-finite variance is excluded and reported", {
+test_that("a variance that is not finite is excluded and reported", {
   d <- degenerate_input()
   d$var_out[1, 3] <- NA_real_
   d$var_out[2, 3] <- 5
   expect_warning(
     disp <- pearson_dispersion(d$obs_y, d$prd_out, d$ppd_out, d$var_out),
-    "not finite"
+    "negative or not finite"
   )
   expect_true(all(is.finite(disp)))
+})
+
+test_that("a negative variance is excluded rather than dropped by na.rm", {
+  # is.finite(-1) is TRUE, so the guard tests the sign as well. Without it
+  # sqrt() returns NaN, na.rm drops the term, and the observation is still
+  # counted as contributing.
+  d <- degenerate_input()
+  d$var_out[, 3] <- c(-1, -1)
+  expect_warning(
+    disp <- pearson_dispersion(d$obs_y, d$prd_out, d$ppd_out, d$var_out),
+    "negative or not finite"
+  )
+  keep <- 1:2
+  obs_mat <- matrix(d$obs_y, 2, 3, byrow = TRUE)[, keep]
+  wanted <- rowSums(((obs_mat - d$prd_out[, keep]) /
+                       sqrt(d$var_out[, keep]))^2) /
+    rowSums(((d$ppd_out[, keep] - d$prd_out[, keep]) /
+               sqrt(d$var_out[, keep]))^2)
+  expect_equal(unname(disp), unname(wanted))
+})
+
+test_that("the exclusion is reported per draw, not as a fixed set", {
+  # The exclusion is elementwise. Reporting only the observations would
+  # describe a set dropped from the whole posterior, which is a different
+  # operation: measured on the fixture below, 229 of 400 draws exclude nothing.
+  d <- degenerate_input()
+  d$var_out[2, 3] <- 5
+  expect_message(
+    pearson_dispersion(d$obs_y, d$prd_out, d$ppd_out, d$var_out),
+    "1 of 3 observations \\(3\\) which the model reproduces exactly, in 1 of 2 draws"
+  )
+})
+
+test_that("draws that return NA are named rather than silently dropped", {
+  # #39's account of a censored draw, applied here: a draw in which no
+  # observation contributes a residual is excluded from the summary by the
+  # na.rm in estimates_summary(), so the count is reported.
+  d <- degenerate_input()
+  d$var_out[1, ] <- 0
+  d$prd_out[1, ] <- d$obs_y
+  d$ppd_out[1, ] <- d$obs_y
+  # capture_messages() rather than expect_message(), which lets the exclusion
+  # message this input also raises through to the console.
+  msgs <- capture_messages(
+    disp <- pearson_dispersion(d$obs_y, d$prd_out, d$ppd_out, d$var_out)
+  )
+  expect_match(paste(msgs, collapse = " "),
+               "No observation contributes a residual in 1 of 2 draws")
+  expect_true(is.na(disp[1]))
+  expect_true(is.finite(disp[2]))
+})
+
+test_that("the report reads correctly with no equation name", {
+  # The name was pre-filled with "fitted" and then interpolated into "The
+  # fitted <name> mean", which printed "The fitted fitted mean".
+  d <- degenerate_input()
+  msg <- capture_messages(
+    pearson_dispersion(d$obs_y, d$prd_out, d$ppd_out, d$var_out)
+  )
+  expect_match(msg[1], "^The fitted mean has zero variance")
+  expect_no_match(msg[1], "fitted fitted")
 })
 
 test_that("the statistic is unchanged where no observation is degenerate", {
@@ -149,22 +210,52 @@ test_that("the statistic is unchanged where no observation is degenerate", {
   expect_equal(unname(disp), unname(wanted))
 })
 
+# Fitted once and reused: two tests need the same fit and it takes minutes to
+# sample. At the two highest doses nothing survived, and nec3param's fitted mean
+# underflows to exactly zero there.
+degenerate_fit <- local({
+  cached <- NULL
+  function() {
+    if (is.null(cached)) {
+      d <- data.frame(x = rep(c(0, 1, 2, 3, 4), each = 3), trials = 10,
+                      y = c(10, 10, 10, 10, 9, 10, 9, 8, 9, 0, 0, 0, 0, 0, 0))
+      cached <<- bnec(y | trials(trials) ~ crf(x, model = "nec3param"),
+                      data = d, family = "binomial", iter = 400, warmup = 200,
+                      chains = 2, seed = 298, refresh = 0,
+                      open_progress = FALSE) |>
+        suppressMessages() |>
+        suppressWarnings()
+    }
+    cached
+  }
+})
+
 test_that("a fit that reproduces a group exactly still reports a statistic", {
-  # The same failure end to end. At the two highest doses nothing survived and
-  # nec3param's fitted mean underflows to exactly zero there, so six of the
-  # fifteen observations are degenerate. Before #298 every draw was NaN, the
-  # returned vector was empty, and expand_nec() wrote NA into the dispersion
-  # columns of the weights table.
-  d <- data.frame(x = rep(c(0, 1, 2, 3, 4), each = 3), trials = 10,
-                  y = c(10, 10, 10, 10, 9, 10, 9, 8, 9, 0, 0, 0, 0, 0, 0))
-  fit <- bnec(y | trials(trials) ~ crf(x, model = "nec3param"), data = d,
-              family = "binomial", iter = 400, warmup = 200, chains = 2,
-              seed = 298, refresh = 0, open_progress = FALSE) |>
-    suppressMessages() |>
-    suppressWarnings()
+  # The same failure end to end. Six of the fifteen observations have a fitted
+  # variance of exactly zero in at least one draw. Before #298 every draw was
+  # NaN, the returned vector was empty, and expand_nec() wrote NA into the
+  # dispersion columns of the weights table.
+  fit <- degenerate_fit()
   expect_true(any(brms::posterior_linpred(pull_brmsfit(fit)) == 0))
-  expect_message(disp <- dispersion(fit, summary = TRUE), "reproduces exactly")
+  expect_message(disp <- dispersion(fit, summary = TRUE),
+                 "6 of 15 observations .* in [0-9]+ of 400 draws")
   expect_length(disp, 4)
   expect_true(all(is.finite(disp)))
   expect_false(is.na(fit$dispersion[["Estimate"]]))
+})
+
+test_that("a fit with nothing left to compare returns an empty vector", {
+  # The remaining branch: every draw is NA, so there is no statistic. Reaching
+  # it from a real fit needs a model degenerate at every observation, which is
+  # not a fit anyone would produce, so the return of pearson_dispersion() is
+  # substituted instead.
+  fit <- degenerate_fit()
+  local_mocked_bindings(
+    pearson_dispersion = function(obs_y, prd_out, ...) {
+      rep(NA_real_, nrow(prd_out))
+    }
+  )
+  expect_message(disp <- dispersion(fit), "not\\s+defined for this fit")
+  expect_length(disp, 0)
+  expect_length(suppressMessages(dispersion(fit, summary = TRUE)), 0)
 })

--- a/tests/testthat/test-dispersion.R
+++ b/tests/testthat/test-dispersion.R
@@ -61,3 +61,110 @@ test_that("dispersion detects genuine overdispersion", {
   disp <- dispersion(fit, summary = TRUE)
   expect_gt(disp[["Q2.5"]], 2)
 })
+
+# The tests below concern #298: an observation whose fitted variance is exactly
+# zero made the ratio NaN for every draw, and the whole statistic was discarded
+# with a message diagnosing a bad model fit. They exercise pearson_dispersion()
+# directly rather than through a fitted model, because an underflowed fitted
+# mean needs a contrived dataset and a long fit to produce, while the
+# arithmetic it triggers is deterministic.
+
+degenerate_input <- function(obs_y = c(5, 3, 0)) {
+  list(obs_y = obs_y,
+       prd_out = rbind(c(4.5, 2.5, 0), c(5.5, 3.5, 0)),
+       ppd_out = rbind(c(6, 2, 0), c(4, 4, 0)),
+       var_out = rbind(c(4, 2, 0), c(5, 3, 0)))
+}
+
+test_that("an exactly reproduced observation is excluded and all draws kept", {
+  d <- degenerate_input()
+  expect_message(
+    disp <- pearson_dispersion(d$obs_y, d$prd_out, d$ppd_out, d$var_out),
+    "reproduces exactly"
+  )
+  expect_length(disp, 2)
+  expect_true(all(is.finite(disp)))
+  # The value is the statistic computed on the two usable observations.
+  obs_mat <- matrix(d$obs_y, 2, 3, byrow = TRUE)
+  keep <- 1:2
+  wanted <- rowSums(((obs_mat - d$prd_out) / sqrt(d$var_out))[, keep]^2) /
+    rowSums(((d$ppd_out - d$prd_out) / sqrt(d$var_out))[, keep]^2)
+  expect_equal(unname(disp), unname(wanted))
+})
+
+test_that("a zero-variance disagreement is reported rather than dropped", {
+  # Case 2: the model has assigned zero variance to a value it did not predict.
+  # The Pearson residual is infinite and that is a result, not an artefact.
+  d <- degenerate_input(obs_y = c(5, 3, 2))
+  expect_warning(
+    disp <- pearson_dispersion(d$obs_y, d$prd_out, d$ppd_out, d$var_out),
+    "not the fitted value"
+  )
+  expect_equal(unname(disp), c(Inf, Inf))
+})
+
+test_that("the observations are named in the message and the warning", {
+  d <- degenerate_input()
+  labs <- c("a", "b", "c")
+  expect_message(
+    pearson_dispersion(d$obs_y, d$prd_out, d$ppd_out, d$var_out, labels = labs),
+    "\\(c\\)"
+  )
+  d2 <- degenerate_input(obs_y = c(5, 3, 2))
+  expect_warning(
+    pearson_dispersion(d2$obs_y, d2$prd_out, d2$ppd_out, d2$var_out,
+                       labels = labs),
+    "\\(c\\)"
+  )
+})
+
+test_that("a draw with nothing left to compare returns NA", {
+  zero <- matrix(0, 2, 3)
+  disp <- suppressMessages(
+    pearson_dispersion(c(0, 0, 0), zero, zero, zero)
+  )
+  expect_true(all(is.na(disp)))
+})
+
+test_that("a non-finite variance is excluded and reported", {
+  d <- degenerate_input()
+  d$var_out[1, 3] <- NA_real_
+  d$var_out[2, 3] <- 5
+  expect_warning(
+    disp <- pearson_dispersion(d$obs_y, d$prd_out, d$ppd_out, d$var_out),
+    "not finite"
+  )
+  expect_true(all(is.finite(disp)))
+})
+
+test_that("the statistic is unchanged where no observation is degenerate", {
+  d <- degenerate_input()
+  d$var_out[, 3] <- c(1, 1)
+  obs_mat <- matrix(d$obs_y, 2, 3, byrow = TRUE)
+  wanted <- rowSums(((obs_mat - d$prd_out) / sqrt(d$var_out))^2) /
+    rowSums(((d$ppd_out - d$prd_out) / sqrt(d$var_out))^2)
+  expect_silent(
+    disp <- pearson_dispersion(d$obs_y, d$prd_out, d$ppd_out, d$var_out)
+  )
+  expect_equal(unname(disp), unname(wanted))
+})
+
+test_that("a fit that reproduces a group exactly still reports a statistic", {
+  # The same failure end to end. At the two highest doses nothing survived and
+  # nec3param's fitted mean underflows to exactly zero there, so six of the
+  # fifteen observations are degenerate. Before #298 every draw was NaN, the
+  # returned vector was empty, and expand_nec() wrote NA into the dispersion
+  # columns of the weights table.
+  d <- data.frame(x = rep(c(0, 1, 2, 3, 4), each = 3), trials = 10,
+                  y = c(10, 10, 10, 10, 9, 10, 9, 8, 9, 0, 0, 0, 0, 0, 0))
+  fit <- bnec(y | trials(trials) ~ crf(x, model = "nec3param"), data = d,
+              family = "binomial", iter = 400, warmup = 200, chains = 2,
+              seed = 298, refresh = 0, open_progress = FALSE) |>
+    suppressMessages() |>
+    suppressWarnings()
+  expect_true(any(brms::posterior_linpred(pull_brmsfit(fit)) == 0))
+  expect_message(disp <- dispersion(fit, summary = TRUE), "reproduces exactly")
+  expect_length(disp, 4)
+  expect_true(all(is.finite(disp)))
+  expect_false(is.na(fit$dispersion[["Estimate"]]))
+})


### PR DESCRIPTION
## What

`dispersion()` returned an empty vector, and reported a bad model fit, whenever
a single observation had a fitted variance of exactly zero. It now excludes such
an observation from the statistic and keeps every posterior draw.

## Why it matters

The Pearson denominator underflows to zero only for a curve that decays fast,
so the statistic was lost precisely for the equations that describe a steep
concentration-response best, and the accompanying message sent the user to look
for a problem that is not there. `expand_nec()` writes the four `dispersion_*`
columns of the weights table from this vector, so those columns were blank for
the same equations.

## Evidence

A fifteen-row binomial fixture with the two highest doses at zero survival,
`nec3param`, R 4.6.1, brms 2.23.0, 2026-09-09: the fitted mean underflows to
exactly zero at six of the fifteen observations. Before this change the fit
returned an empty vector and wrote `NA` into the weights table; it now reports a
dispersion of 0.97 with a 95% interval of 0.30 to 2.48, and names the six
observations it excluded. This fixture is added as a test. The reported case,
from `vignette("example9")`, is the `nassarius` contaminant A survival set,
where `ecxsigm` at 0.767 of the model weight and a Bayesian R-squared of 0.91
reported `NA` while `ecxexp` at 0.002 of the weight reported a value.

`tests/testthat/test-dispersion.R` passes with 36 tests, 0 failures, 0 warnings,
`NOT_CRAN=true`.

<details>
<summary>Implementation detail</summary>

### The two cases

The per-draw loop in `dispersion()` now collects only the fitted variance, and
the residual arithmetic moves to a new internal `pearson_dispersion()`, which
handles the whole draws-by-observations matrix at once. That is where the two
routes to a zero denominator are separated.

1. **Zero variance, response equal to the fitted value.** Both the observed and
   the simulated term are `0/0` and the observation says nothing about
   dispersion in either direction, so it is excluded from both sums and every
   draw is retained. The exclusion is elementwise rather than a fixed set --- an
   observation whose fitted mean underflows in a steep draw gives an ordinary
   residual in a shallower one --- and the message names the observations and
   the draws affected. Measured on the fixture, 400 draws: 229 exclude nothing,
   60 exclude three observations and 111 exclude six. A draw in which no
   observation contributes a residual returns `NA`, and that count is named too,
   following `nsec_off_curve()`.
2. **Zero variance, response not equal to the fitted value.** The model has
   assigned zero variance to a value it did not predict. The observed Pearson
   term is infinite and is kept, so the statistic is reported as `Inf`, and a
   warning names the observations. The infinity is the underflow --- in exact
   arithmetic the residual there is large and finite --- but the misfit it
   reports is real. For a converged fit the case is close to unreachable, since
   the likelihood rejects a draw assigning zero probability to an observed
   value, so the warning says to check that the response and the fitted mean are
   on the same scale.

Case 2 warns rather than stops, which is the question the issue reserved.
`dispersion()` is called once per equation from `expand_nec()` and that call is
not wrapped, so an error would abandon construction of the whole
`bayesmanecfit` for one candidate whose shape is wrong. This is the placement
argument already recorded in `R/bnec.R` for `check_data()`.

A third case not raised in the issue is handled the same way: a variance that is
negative or not finite reaches the same `na.rm` and would otherwise disappear in
silence, so it is excluded explicitly and reported. It is set missing before the
square root, so base R raises no unattributed "NaNs produced" warning of its
own.

### Also

- The empty vector and its message are now reserved for the case where every
  observation is degenerate, and the message no longer diagnoses a bad model
  fit. The "most likely cause by" wording is gone with it.
- Each report names the equation, because `bnec()` calls this once per model.
- A draw in which every observation is excluded returns `NA`, which
  `estimates_summary()` already drops as it does a censored ECx draw.

### Tests

Ten unit tests exercise `pearson_dispersion()` directly on small deterministic
matrices --- exclusion, the `Inf` case, the labels, the all-degenerate return,
the non-finite and the negative variance, the per-draw report, the named `NA`
draws, the report with no equation name, and equality with the plain formula
where nothing is degenerate. Two tests use the fitted fixture: the end-to-end
case, and the empty-vector branch of `dispersion()`, reached by substituting the
return of `pearson_dispersion()` since a fit degenerate at every observation is
not one anyone would produce. The fixture is fitted once and reused; the file
runs in 5m22s.

### Not in this pull request

The `vignette("example9")` passage that explains the `NA` is on the branch of
#238, so it is narrowed there in a separate commit rather than here. That
vignette needs a re-knit before #238 merges, which it needs in any case.

</details>

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGpuM3TVYB7RtMn9sj7Gk7
