### PR TITLE
Fit the model set under the user's future plan (#184)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,6 +28,8 @@ Suggests:
     knitr,
     rmarkdown,
     R.utils,
+    future,
+    future.apply,
     testthat (>= 3.1.8)
 VignetteBuilder: knitr
 URL: https://open-aims.github.io/bayesnec/

--- a/NEWS.md
+++ b/NEWS.md
@@ -608,12 +608,13 @@
   across chains already, so models in parallel on top of that would request
   `workers x chains` processes --- sixteen for four workers and the default
   `chains = 4`. Under a parallel plan of more than one worker `bnec()` passes
-  `cores = 1` to `brm()`, which also stops a `mc.cores` set in a profile from
-  applying per worker. Passing `cores` yourself is left alone and is how the two
-  levels are nested deliberately. A plan that names a parallel strategy but
+  `cores = 1` to `brm()`. Passing `cores` yourself is left alone and is how the
+  two levels are nested deliberately. A plan that names a parallel strategy but
   resolves to a single worker --- `plan(multicore)` wherever forking is
   unavailable, which includes Windows --- is clamped in neither respect, and
-  says so.
+  says so. Note that `future` already sets `mc.cores` to 1 inside a worker, so
+  a value set in a profile does not reach `brms` there in any case; `cores = 1`
+  makes that a property of this package rather than of `future`'s internals.
 
   **Each fitted model reproduces exactly under a parallel plan, for the same
   `seed`.** This needed making true rather than being inherited:
@@ -626,14 +627,15 @@
 
   **The model-averaged quantities are the exception.** `expand_manec()` draws
   the seed for the weighted posterior draw from the session's RNG stream after
-  the models are fitted. Fitted in sequence that stream has been advanced by
-  every model's initial-value search and so is fixed by `seed`; fitted in
-  parallel those searches run in workers and it is not. The averaged `nec`, its
-  interval and the stored prediction grid therefore differ between the two
-  plans, as two valid realisations of the same weighting. `bnec()` leaves the
-  stream undisturbed under a parallel plan, so `set.seed()` in the calling
-  session fixes that draw and two parallel runs agree --- which is what
-  `expand_manec()` intends it to answer to (#216).
+  the models are fitted. A sequential run advances that stream, through the
+  `set.seed(seed)` each initial-value search makes, so the draw is fixed by
+  `seed`; under a parallel plan the model loop leaves the stream alone. The
+  averaged `nec`, its interval and the stored prediction grid therefore differ
+  between the two plans, as two valid realisations of the same weighting.
+  `set.seed()` in the calling session fixes that draw under a parallel plan, so
+  two parallel runs agree --- which is what `expand_manec()` intends it to
+  answer to (#216). One further consequence: a parallel call does not advance
+  the calling session's RNG stream, where a sequential one does.
 
 - **`bnec_record()`** reports what `bnec()` did to the request before fitting:
   the candidate set as requested, the set attempted, the equations excluded with

--- a/NEWS.md
+++ b/NEWS.md
@@ -607,19 +607,33 @@
   **Chains are sampled in sequence inside each worker.** `brm()` parallelises
   across chains already, so models in parallel on top of that would request
   `workers x chains` processes --- sixteen for four workers and the default
-  `chains = 4`. Under a parallel plan `bnec()` passes `cores = 1` to `brm()`,
-  which also stops a `mc.cores` set in a profile from applying per worker.
-  Supplying `cores` in `brm_args` is left alone and is how the two levels are
-  nested deliberately.
+  `chains = 4`. Under a parallel plan of more than one worker `bnec()` passes
+  `cores = 1` to `brm()`, which also stops a `mc.cores` set in a profile from
+  applying per worker. Passing `cores` yourself is left alone and is how the two
+  levels are nested deliberately. A plan that names a parallel strategy but
+  resolves to a single worker --- `plan(multicore)` wherever forking is
+  unavailable, which includes Windows --- is clamped in neither respect, and
+  says so.
 
-  **A parallel run reproduces the sequential run exactly for the same `seed`.**
-  This needed making true rather than being inherited: `future.seed = TRUE`
-  installs an L'Ecuyer-CMRG generator in each worker, `set.seed()` does not
-  restore the generator kind, and the initial-value search would therefore have
-  drawn different starting values in a worker from the same seed --- silently,
-  with no error and no warning. The worker restores the parent's RNG kind before
-  fitting. Without a `seed` the search reseeds from entropy and no run repeats,
-  under a plan or otherwise, which is unchanged.
+  **Each fitted model reproduces exactly under a parallel plan, for the same
+  `seed`.** This needed making true rather than being inherited:
+  `future.seed = TRUE` installs an L'Ecuyer-CMRG generator in each worker,
+  `set.seed()` does not restore the generator kind, and the initial-value search
+  would therefore have drawn different starting values in a worker from the same
+  seed --- silently, with no error and no warning. The worker restores the
+  parent's RNG kind before fitting. Without a `seed` the search reseeds from
+  entropy and no run repeats, under a plan or otherwise, which is unchanged.
+
+  **The model-averaged quantities are the exception.** `expand_manec()` draws
+  the seed for the weighted posterior draw from the session's RNG stream after
+  the models are fitted. Fitted in sequence that stream has been advanced by
+  every model's initial-value search and so is fixed by `seed`; fitted in
+  parallel those searches run in workers and it is not. The averaged `nec`, its
+  interval and the stored prediction grid therefore differ between the two
+  plans, as two valid realisations of the same weighting. `bnec()` leaves the
+  stream undisturbed under a parallel plan, so `set.seed()` in the calling
+  session fixes that draw and two parallel runs agree --- which is what
+  `expand_manec()` intends it to answer to (#216).
 
 - **`bnec_record()`** reports what `bnec()` did to the request before fitting:
   the candidate set as requested, the set attempted, the equations excluded with

--- a/NEWS.md
+++ b/NEWS.md
@@ -595,6 +595,32 @@
 
 ## New
 
+- **A model set can now be fitted in parallel.** `bnec()` and `amend()` fit
+  their models under whatever `future` plan is set when they are called, so
+  `plan(multisession, workers = 4)` before the call fits four models at a time
+  and `plan(sequential)`, or no plan at all, fits them one at a time exactly as
+  every earlier version did. There is no new argument: the plan already holds
+  that state, and a `cores` argument beside it would be ambiguous the moment a
+  user set both. `future` and `future.apply` are Suggests, so a session without
+  them takes the sequential path and reports nothing (#184).
+
+  **Chains are sampled in sequence inside each worker.** `brm()` parallelises
+  across chains already, so models in parallel on top of that would request
+  `workers x chains` processes --- sixteen for four workers and the default
+  `chains = 4`. Under a parallel plan `bnec()` passes `cores = 1` to `brm()`,
+  which also stops a `mc.cores` set in a profile from applying per worker.
+  Supplying `cores` in `brm_args` is left alone and is how the two levels are
+  nested deliberately.
+
+  **A parallel run reproduces the sequential run exactly for the same `seed`.**
+  This needed making true rather than being inherited: `future.seed = TRUE`
+  installs an L'Ecuyer-CMRG generator in each worker, `set.seed()` does not
+  restore the generator kind, and the initial-value search would therefore have
+  drawn different starting values in a worker from the same seed --- silently,
+  with no error and no warning. The worker restores the parent's RNG kind before
+  fitting. Without a `seed` the search reseeds from entropy and no run repeats,
+  under a plan or otherwise, which is unchanged.
+
 - **`bnec_record()`** reports what `bnec()` did to the request before fitting:
   the candidate set as requested, the set attempted, the equations excluded with
   the reason for each, and any substitution made in the response. Both were

--- a/R/amend.R
+++ b/R/amend.R
@@ -239,65 +239,88 @@ amend_model_set <- function(object, mod_fits, old_method, drop = NULL,
   mod_fits <- vector(mode = "list", length = length(model_set))
   names(mod_fits) <- model_set
   failed <- list()
-  for (m in seq_along(model_set)) {
+  # Which models this call has to fit. A model already in the set is carried
+  # over from old_fits without a brm() call, so a set of twenty with one
+  # addition is a one-model run, and only the additions decide whether a
+  # parallel plan is worth using.
+  needs_fit <- !vapply(model_set, function(model) {
+    inherits(try(old_fits[[model]], silent = TRUE), "prebayesnecfit")
+  }, logical(1))
+  # Carried over here, in the parent, rather than returned from the applied
+  # function. Under a parallel plan the alternative serialises every existing
+  # fit out to a worker and straight back again, for a model that is not
+  # refitted -- the memory hazard #184 raises, incurred for nothing.
+  for (m in which(!needs_fit)) {
+    mod_fits[[model_set[m]]] <- old_fits[[model_set[m]]]
+  }
+  # amend() rebuilds brm_args per model from the stored simdat rather than
+  # taking one from the user, so what plan_model_set() decides has to be
+  # passed into the loop body and merged there.
+  set_plan <- plan_model_set(list(), sum(needs_fit), caller = "amend")
+  attempts <- bnec_model_lapply(which(needs_fit), function(m) {
     model <- model_set[m]
-    mod_m <- try(old_fits[[model]], silent = TRUE)
-    if (!inherits(mod_m, "prebayesnecfit")) {
-      # No `init`. This branch is reached only for a model that is not already
-      # in the set, and simdat$init holds the stanfit initial values of a model
-      # that is -- values named for another equation's parameters, which are
-      # meaningless here. add_brm_defaults() overwrote them with its own search
-      # in every case, so omitting them changes nothing that happened; what it
-      # changes is that the search is now requested by the absence of `init`
-      # rather than compelled by skip_check. See #290.
-      brm_args <- list(
+    # No `init`. This branch is reached only for a model that is not already
+    # in the set, and simdat$init holds the stanfit initial values of a model
+    # that is -- values named for another equation's parameters, which are
+    # meaningless here. add_brm_defaults() overwrote them with its own search
+    # in every case, so omitting them changes nothing that happened; what it
+    # changes is that the search is now requested by the absence of `init`
+    # rather than compelled by skip_check. See #290.
+    brm_args <- c(
+      list(
         family = family, iter = simdat$iter, thin = simdat$thin,
         warmup = simdat$warmup, chains = simdat$chains,
         sample_prior = simdat$sample_prior
-      )
-      brm_args$prior <- priors
-      model_priors <- try(validate_priors(brm_args$prior, model),
-                          silent = TRUE)
-      if (inherits(model_priors, "try-error")) {
-        x <- retrieve_var(bdat, "x_var", error = TRUE)
-        y <- retrieve_var(bdat, "y_var", error = TRUE)
-        custom_name <- check_custom_name(family)
-        if (family$family == "binomial" || family$family == "beta_binomial") {
-          tr <- retrieve_var(bdat, "trials_var", error = TRUE)
-          y <- y / tr
-        }
-        # The rate denominator, for the same reason as trials above: this path
-        # rebuilds priors for a model added to an existing set, and they have to
-        # be on the same scale as the ones the original fit used. See #136.
-        denom <- retrieve_var(bdat, "rate_var")
-        if (!is.null(denom)) {
-          y <- y / denom
-        }
-        # Note this path still does not pass disp_spec, which predates #245
-        # and is left alone here rather than changed as a side effect.
-        brm_args$prior <- define_prior(
-          model, family, x, y, prior_type = prior_type,
-          group_spec = parse_group_terms(formula, model)
-        )
-      } else {
-        brm_args$prior <- model_priors
+      ),
+      set_plan$brm_args
+    )
+    brm_args$prior <- priors
+    model_priors <- try(validate_priors(brm_args$prior, model),
+                        silent = TRUE)
+    if (inherits(model_priors, "try-error")) {
+      x <- retrieve_var(bdat, "x_var", error = TRUE)
+      y <- retrieve_var(bdat, "y_var", error = TRUE)
+      custom_name <- check_custom_name(family)
+      if (family$family == "binomial" || family$family == "beta_binomial") {
+        tr <- retrieve_var(bdat, "trials_var", error = TRUE)
+        y <- y / tr
       }
-      fit_m <- try(
-        fit_bayesnec(
-          formula = formula, data = data, model = model,
-          brm_args = brm_args, skip_check = TRUE, prior_type = prior_type,
-          timeout = timeout
-        ),
-        silent = FALSE
-      )
-      if (!inherits(fit_m, "try-error")) {
-        mod_fits[[model]] <- fit_m
-      } else {
-        mod_fits[[model]] <- NA
-        failed[[model]] <- failure_record(model, attr(fit_m, "condition"))
+      # The rate denominator, for the same reason as trials above: this path
+      # rebuilds priors for a model added to an existing set, and they have to
+      # be on the same scale as the ones the original fit used. See #136.
+      denom <- retrieve_var(bdat, "rate_var")
+      if (!is.null(denom)) {
+        y <- y / denom
       }
+      # Note this path still does not pass disp_spec, which predates #245
+      # and is left alone here rather than changed as a side effect.
+      brm_args$prior <- define_prior(
+        model, family, x, y, prior_type = prior_type,
+        group_spec = parse_group_terms(formula, model)
+      )
     } else {
-      mod_fits[[m]] <- mod_m
+      brm_args$prior <- model_priors
+    }
+    try(
+      fit_bayesnec(
+        formula = formula, data = data, model = model,
+        brm_args = brm_args, skip_check = TRUE, prior_type = prior_type,
+        timeout = timeout
+      ),
+      silent = FALSE
+    )
+  }, parallel = set_plan$parallel)
+  # Assembled in the parent, as in bnec(): what the applied function returns is
+  # the fit, or the try-error holding its condition, and failure_record() then
+  # reads the same object whichever plan produced it.
+  for (i in seq_along(attempts)) {
+    model <- model_set[which(needs_fit)[i]]
+    fit_m <- attempts[[i]]
+    if (!inherits(fit_m, "try-error")) {
+      mod_fits[[model]] <- fit_m
+    } else {
+      mod_fits[[model]] <- NA
+      failed[[model]] <- failure_record(model, attr(fit_m, "condition"))
     }
   }
   formulas <- lapply(mod_fits, extract_formula)

--- a/R/amend.R
+++ b/R/amend.R
@@ -248,8 +248,10 @@ amend_model_set <- function(object, mod_fits, old_method, drop = NULL,
   }, logical(1))
   # Carried over here, in the parent, rather than returned from the applied
   # function. Under a parallel plan the alternative serialises every existing
-  # fit out to a worker and straight back again, for a model that is not
-  # refitted -- the memory hazard #184 raises, incurred for nothing.
+  # fit out to a worker and straight back again for a model that is not
+  # refitted, which is the memory multiplication #184 raises. Doing it here is
+  # necessary and not sufficient: old_fits also has to stay out of what the
+  # applied function exports, which is what narrow_environment() below is for.
   for (m in which(!needs_fit)) {
     mod_fits[[model_set[m]]] <- old_fits[[model_set[m]]]
   }
@@ -257,61 +259,75 @@ amend_model_set <- function(object, mod_fits, old_method, drop = NULL,
   # taking one from the user, so what plan_model_set() decides has to be
   # passed into the loop body and merged there.
   set_plan <- plan_model_set(list(), sum(needs_fit), caller = "amend")
-  attempts <- bnec_model_lapply(which(needs_fit), function(m) {
-    model <- model_set[m]
-    # No `init`. This branch is reached only for a model that is not already
-    # in the set, and simdat$init holds the stanfit initial values of a model
-    # that is -- values named for another equation's parameters, which are
-    # meaningless here. add_brm_defaults() overwrote them with its own search
-    # in every case, so omitting them changes nothing that happened; what it
-    # changes is that the search is now requested by the absence of `init`
-    # rather than compelled by skip_check. See #290.
-    brm_args <- c(
-      list(
-        family = family, iter = simdat$iter, thin = simdat$thin,
-        warmup = simdat$warmup, chains = simdat$chains,
-        sample_prior = simdat$sample_prior
-      ),
-      set_plan$brm_args
-    )
-    brm_args$prior <- priors
-    model_priors <- try(validate_priors(brm_args$prior, model),
-                        silent = TRUE)
-    if (inherits(model_priors, "try-error")) {
-      x <- retrieve_var(bdat, "x_var", error = TRUE)
-      y <- retrieve_var(bdat, "y_var", error = TRUE)
-      custom_name <- check_custom_name(family)
-      if (family$family == "binomial" || family$family == "beta_binomial") {
-        tr <- retrieve_var(bdat, "trials_var", error = TRUE)
-        y <- y / tr
-      }
-      # The rate denominator, for the same reason as trials above: this path
-      # rebuilds priors for a model added to an existing set, and they have to
-      # be on the same scale as the ones the original fit used. See #136.
-      denom <- retrieve_var(bdat, "rate_var")
-      if (!is.null(denom)) {
-        y <- y / denom
-      }
-      # Note this path still does not pass disp_spec, which predates #245
-      # and is left alone here rather than changed as a side effect.
-      brm_args$prior <- define_prior(
-        model, family, x, y, prior_type = prior_type,
-        group_spec = parse_group_terms(formula, model)
+  # narrow_environment(), for the reason bnec() gives at its own call: future
+  # exports the applied function with its enclosing environment, and this frame
+  # holds old_fits and the partly filled mod_fits. Carrying existing fits over
+  # in the parent saves nothing unless they are also kept out of what is
+  # exported, which is what this does.
+  fit_one <- narrow_environment(
+    function(m) {
+      model <- model_set[m]
+      # No `init`. This branch is reached only for a model that is not already
+      # in the set, and simdat$init holds the stanfit initial values of a model
+      # that is -- values named for another equation's parameters, which are
+      # meaningless here. add_brm_defaults() overwrote them with its own search
+      # in every case, so omitting them changes nothing that happened; what it
+      # changes is that the search is now requested by the absence of `init`
+      # rather than compelled by skip_check. See #290.
+      brm_args <- c(
+        list(
+          family = family, iter = simdat$iter, thin = simdat$thin,
+          warmup = simdat$warmup, chains = simdat$chains,
+          sample_prior = simdat$sample_prior
+        ),
+        set_plan$brm_args
       )
-    } else {
-      brm_args$prior <- model_priors
-    }
-    try(
-      fit_bayesnec(
-        formula = formula, data = data, model = model,
-        brm_args = brm_args, skip_check = TRUE, prior_type = prior_type,
-        timeout = timeout
-      ),
-      silent = FALSE
-    )
-  }, parallel = set_plan$parallel)
+      brm_args$prior <- priors
+      model_priors <- try(validate_priors(brm_args$prior, model),
+                          silent = TRUE)
+      if (inherits(model_priors, "try-error")) {
+        x <- retrieve_var(bdat, "x_var", error = TRUE)
+        y <- retrieve_var(bdat, "y_var", error = TRUE)
+        custom_name <- check_custom_name(family)
+        if (family$family == "binomial" || family$family == "beta_binomial") {
+          tr <- retrieve_var(bdat, "trials_var", error = TRUE)
+          y <- y / tr
+        }
+        # The rate denominator, for the same reason as trials above: this path
+        # rebuilds priors for a model added to an existing set, and they have to
+        # be on the same scale as the ones the original fit used. See #136.
+        denom <- retrieve_var(bdat, "rate_var")
+        if (!is.null(denom)) {
+          y <- y / denom
+        }
+        # Note this path still does not pass disp_spec, which predates #245
+        # and is left alone here rather than changed as a side effect.
+        brm_args$prior <- define_prior(
+          model, family, x, y, prior_type = prior_type,
+          group_spec = parse_group_terms(formula, model)
+        )
+      } else {
+        brm_args$prior <- model_priors
+      }
+      try(
+        fit_bayesnec(
+          formula = formula, data = data, model = model,
+          brm_args = brm_args, skip_check = TRUE, prior_type = prior_type,
+          timeout = timeout
+        ),
+        silent = FALSE
+      )
+    },
+    list(model_set = model_set, family = family, simdat = simdat,
+         set_plan = set_plan, priors = priors, bdat = bdat,
+         formula = formula, data = data, prior_type = prior_type,
+         timeout = timeout)
+  )
+  attempts <- bnec_model_lapply(which(needs_fit), fit_one,
+                                parallel = set_plan$parallel)
   # Assembled in the parent, as in bnec(): what the applied function returns is
-  # the fit, or the try-error holding its condition, and failure_record() then
+  # the fit, or the try-error whose condition attribute records it, and
+  # failure_record() then
   # reads the same object whichever plan produced it.
   for (i in seq_along(attempts)) {
     model <- model_set[which(needs_fit)[i]]

--- a/R/bnec.R
+++ b/R/bnec.R
@@ -537,9 +537,12 @@
 #' where a sequential one does; if you are drawing from that stream after the
 #' fit, the two plans leave you in different places.
 #'
-#' Supplying \code{init} yourself skips the search altogether, so a sequential
-#' run does not advance the stream then either and its averaging draw answers
-#' to your session's seed in the same way.
+#' Supplying \code{init} and a \code{seed} yourself skips the search
+#' altogether, so a sequential run does not advance the stream then either and
+#' its averaging draw answers to your session's seed in the same way. Both are
+#' needed: \pkg{brms} defaults \code{seed} to \code{NA} and \pkg{rstan}
+#' then draws one itself, from your stream, once per \code{\link[brms]{brm}}
+#' call.
 #'
 #' Console output from a worker is not ordered. The per-model
 #' messages \code{\link{bnec}} emits come from a worker process and arrive
@@ -571,7 +574,10 @@
 #' function it is that function's frame, and everything in the frame goes with
 #' it -- measured at 6.18 MiB for a formula built in a frame holding a 6.2 MB
 #' matrix. So if a limit is reached and the data are not large, look at where
-#' the formula was created.
+#' the formula was created. The same holds for any \emph{function} passed
+#' through \code{...} -- \code{init} most likely. Families, priors, stanvars
+#' and a \code{control} list do not behave this way: their closures bind to
+#' \pkg{stats} and \pkg{brms}, not to where you wrote them.
 #'
 #' \code{\link{bnec_group}} fits one model set per level of the grouping
 #' variable, so under a parallel plan each level is parallelised in turn and

--- a/R/bnec.R
+++ b/R/bnec.R
@@ -491,16 +491,39 @@
 #' \code{\link{bnec}} therefore passes \code{cores = 1} to
 #' \code{\link[brms]{brm}}. Nest the two levels deliberately by passing
 #' \code{cores} yourself, which is left alone: \code{bnec(..., cores = 2)}
-#' with \code{workers = 4} uses up to eight processes. Note that this is also
-#' the only way \code{getOption("mc.cores")} stops applying: without it a value
-#' set in a profile would give every worker four chains at once without having
-#' been asked for.
+#' with \code{workers = 4} runs four worker processes sampling eight chains
+#' between them. Passing \code{cores} is also what makes
+#' \code{getOption("mc.cores")} irrelevant: bayesnec's own \code{cores = 1}
+#' already overrides it, and without either, a value set in a profile would
+#' give every worker four chains at once without having been asked for.
 #'
-#' \strong{Supply a seed if the run has to be reproducible.} A parallel run
-#' reproduces the sequential run exactly for the same \code{seed} passed on to
-#' \code{\link[brms]{brm}}, and that is tested. Without one the initial-value
-#' search reseeds from entropy, so neither a sequential nor a parallel run
-#' repeats -- which is true of this package with or without a plan set.
+#' A plan that names a parallel strategy but resolves to one worker gets
+#' neither treatment: nothing is clamped and \code{\link{bnec}} says so.
+#' \code{plan(multicore)} resolves that way wherever forking is unavailable,
+#' which is Windows, and \pkg{RStudio} or \pkg{Positron} on Linux and macOS.
+#' \code{plan(multisession)} works everywhere.
+#'
+#' \strong{Reproducibility, and the one place it stops.} Each fitted model
+#' reproduces exactly under a parallel plan, given the same \code{seed} passed
+#' on to \code{\link[brms]{brm}}, and that is tested. Without a \code{seed}
+#' the initial-value search reseeds from entropy and nothing repeats under
+#' either plan, which is what this package does today with or without one.
+#'
+#' The model-averaged quantities are the exception, and the reason is worth
+#' stating because nothing announces it. Once the models are fitted,
+#' \code{expand_manec()} draws a seed from the session's RNG stream and uses
+#' it to decide which posterior draws each equation contributes to the averaged
+#' estimate. Fitted in sequence, the loop leaves that stream in a state fixed
+#' by \code{seed}, because every initial-value search ran in this process;
+#' fitted in parallel the searches run in workers and the stream is untouched.
+#' The averaged \code{nec}, its interval and the stored prediction grid
+#' therefore differ between the two plans -- as two valid realisations of the
+#' same weighting, not as one being wrong.
+#'
+#' \code{\link{bnec}} does not disturb the stream under a parallel plan, so
+#' \code{set.seed()} in your session before the call fixes that draw, and two
+#' parallel runs agree. That is what \code{expand_manec()} intends the draw to
+#' answer to.
 #'
 #' \strong{Console output from a worker is not ordered.} The per-model
 #' messages \code{\link{bnec}} emits come from a worker process and arrive
@@ -510,9 +533,32 @@
 #' beyond the running commentary. \code{timeout} continues to apply per model
 #' inside its worker.
 #'
-#' Every worker is sent the data and the formula. \pkg{future} refuses to
-#' export more than 500 MB by default and says so; raise
-#' \code{options(future.globals.maxSize = )} if a large dataset trips it.
+#' One failure is not caught that way. A worker killed from outside R, which in
+#' practice means the operating system reclaiming memory, cannot raise a
+#' condition for \code{try()} to catch, and \pkg{future} reports it in the
+#' parent as an error that ends the whole call rather than one model of it.
+#' Fewer workers is the remedy, and it is the reason to think about how many
+#' before setting a plan: memory, not cores, is usually what binds on a set of
+#' this kind.
+#'
+#' Each model is sent to a worker with the data, the formula, the priors and
+#' the \pkg{brms} arguments, and nothing else \code{\link{bnec}} or
+#' \code{\link{amend}} has built -- in particular not the fits an
+#' \code{\link{amend}} call already holds. \pkg{future} refuses to export
+#' more than 500 MiB by default and says so, naming the applied function rather
+#' than what is inside it; raise
+#' \code{options(future.globals.maxSize = )} if a large dataset reaches it.
+#'
+#' \code{\link{bnec_group}} fits one model set per level of the grouping
+#' variable, so under a parallel plan each level is parallelised in turn and
+#' the note above is printed once per level.
+#'
+#' Starting a worker is not free for this package. A \code{multisession} or
+#' \code{cluster} worker is a fresh R process that has to load \pkg{bayesnec}
+#' and with it \pkg{brms}, \pkg{Rcpp} and \pkg{rstan} before it can fit
+#' anything, which took about three seconds per worker on an idle machine and
+#' considerably longer on a busy one. It is paid once per worker, so it is
+#' negligible against a 23-model set and is not against two or three models.
 #'
 #' Two things to be aware of when developing against the package rather than
 #' using it. A \code{multisession} or \code{cluster} worker loads the
@@ -739,17 +785,29 @@ bnec <- function(formula, data, x_range = NA, resolution = 1000, sig_val = 0.01,
     # reported where it happens; from a worker that report reaches the parent
     # only if the backend relays stderr, which is why the failure is recorded
     # in the returned object as well.
-    attempts <- bnec_model_lapply(seq_along(model), function(m) {
-      try(
-        fit_bayesnec(formula = formula, data = data, model = model[m],
-                     brm_args = brm_args, prior_type = prior_type,
-                     timeout = timeout, model_survival = model_survival),
-        silent = FALSE
-      )
-    }, parallel = set_plan$parallel)
+    # narrow_environment(), not a plain closure: future exports the applied
+    # function with its enclosing environment, and that would be this frame,
+    # which holds the data, the model frame, the priors and everything else
+    # bnec() has built. Only the seven names below need to reach a worker.
+    fit_one <- narrow_environment(
+      function(m) {
+        try(
+          fit_bayesnec(formula = formula, data = data, model = model[m],
+                       brm_args = brm_args, prior_type = prior_type,
+                       timeout = timeout, model_survival = model_survival),
+          silent = FALSE
+        )
+      },
+      list(formula = formula, data = data, model = model,
+           brm_args = brm_args, prior_type = prior_type, timeout = timeout,
+           model_survival = model_survival)
+    )
+    attempts <- bnec_model_lapply(seq_along(model), fit_one,
+                                  parallel = set_plan$parallel)
     # Assembled in the parent rather than in the worker so that what a worker
     # returns is exactly what the sequential path returns: the fit, or the
-    # try-error holding its condition. failure_record() then reads the same
+    # try-error whose condition attribute records it. failure_record()
+    # then reads the same
     # object either way.
     for (m in seq_along(model)) {
       fit_m <- attempts[[m]]

--- a/R/bnec.R
+++ b/R/bnec.R
@@ -462,6 +462,66 @@
 #' \code{loo_controls} argument. Individual model fits can be pulled out
 #' for examination using function \code{\link{pull_out}}.
 #'
+#' \bold{Fitting a model set in parallel}
+#'
+#' A model set is fitted one model at a time by default, which is what every
+#' earlier version did. Fitting the models at the same time is asked for by
+#' setting a \pkg{future} plan before the call, and \code{\link{bnec}} then
+#' uses it:
+#'
+#' \preformatted{
+#' library(future)
+#' plan(multisession, workers = 4)
+#' fit <- bnec(y ~ crf(x, model = "decline"), data = my_data, seed = 17)
+#' plan(sequential)
+#' }
+#'
+#' There is no \code{cores} or \code{parallel} argument, because the plan
+#' already holds that state and two ways of setting it would disagree. The
+#' \pkg{future} and \pkg{future.apply} packages are Suggests: with either
+#' absent, or with no plan set, the models are fitted in sequence exactly as
+#' before. \code{\link{amend}} uses the plan in the same way, over the models
+#' it has to fit rather than over the whole set.
+#'
+#' \strong{Chains are sampled in sequence inside each worker.}
+#' \code{\link[brms]{brm}} already parallelises across chains, so models in
+#' parallel on top of that would request \code{workers x chains} processes;
+#' with four workers and the default \code{chains = 4} that is sixteen, and on
+#' most machines it runs slower than fitting in sequence. Under a parallel plan
+#' \code{\link{bnec}} therefore passes \code{cores = 1} to
+#' \code{\link[brms]{brm}}. Nest the two levels deliberately by passing
+#' \code{cores} yourself, which is left alone: \code{bnec(..., cores = 2)}
+#' with \code{workers = 4} uses up to eight processes. Note that this is also
+#' the only way \code{getOption("mc.cores")} stops applying: without it a value
+#' set in a profile would give every worker four chains at once without having
+#' been asked for.
+#'
+#' \strong{Supply a seed if the run has to be reproducible.} A parallel run
+#' reproduces the sequential run exactly for the same \code{seed} passed on to
+#' \code{\link[brms]{brm}}, and that is tested. Without one the initial-value
+#' search reseeds from entropy, so neither a sequential nor a parallel run
+#' repeats -- which is true of this package with or without a plan set.
+#'
+#' \strong{Console output from a worker is not ordered.} The per-model
+#' messages \code{\link{bnec}} emits come from a worker process and arrive
+#' out of order, or not at all, depending on the backend. A model that fails
+#' is still recorded as an \code{NA} entry, the remaining models still fit, and
+#' \code{\link{failed_models}} reports what happened, so nothing is lost
+#' beyond the running commentary. \code{timeout} continues to apply per model
+#' inside its worker.
+#'
+#' Every worker is sent the data and the formula. \pkg{future} refuses to
+#' export more than 500 MB by default and says so; raise
+#' \code{options(future.globals.maxSize = )} if a large dataset trips it.
+#'
+#' Two things to be aware of when developing against the package rather than
+#' using it. A \code{multisession} or \code{cluster} worker loads the
+#' \emph{installed} \pkg{bayesnec}, not one loaded with
+#' \code{pkgload::load_all()}; \code{multicore}, which forks, inherits the
+#' loaded one. And \pkg{future} sets the plan inside a worker to sequential,
+#' so a \code{\link{bnec}} call made from within one does not parallelise
+#' again.
+#'
 #' \bold{Additional technical notes}
 #'
 #' A zero concentration is fitted as recorded. No family constrains the values
@@ -670,20 +730,35 @@ bnec <- function(formula, data, x_range = NA, resolution = 1000, sig_val = 0.01,
     mod_fits <- vector(mode = "list", length = length(model))
     names(mod_fits) <- model
     failed <- list()
-    for (m in seq_along(model)) {
-      model_m <- model[m]
-      fit_m <- try(
-        fit_bayesnec(formula = formula, data = data, model = model_m,
+    set_plan <- plan_model_set(brm_args, length(model))
+    brm_args <- set_plan$brm_args
+    # try() stays inside the applied function, not around the call to it. The
+    # NA-on-failure contract is what several downstream functions read, and
+    # under a parallel plan an error escaping the worker aborts the whole batch
+    # rather than one model of it. silent = FALSE is kept so the failure is
+    # reported where it happens; from a worker that report reaches the parent
+    # only if the backend relays stderr, which is why the failure is recorded
+    # in the returned object as well.
+    attempts <- bnec_model_lapply(seq_along(model), function(m) {
+      try(
+        fit_bayesnec(formula = formula, data = data, model = model[m],
                      brm_args = brm_args, prior_type = prior_type,
                      timeout = timeout, model_survival = model_survival),
         silent = FALSE
       )
+    }, parallel = set_plan$parallel)
+    # Assembled in the parent rather than in the worker so that what a worker
+    # returns is exactly what the sequential path returns: the fit, or the
+    # try-error holding its condition. failure_record() then reads the same
+    # object either way.
+    for (m in seq_along(model)) {
+      fit_m <- attempts[[m]]
       if (!inherits(fit_m, "try-error")) {
         mod_fits[[m]] <- fit_m
       } else {
         mod_fits[[m]] <- NA
-        failed[[model_m]] <- failure_record(model_m,
-                                            attr(fit_m, "condition"))
+        failed[[model[m]]] <- failure_record(model[m],
+                                             attr(fit_m, "condition"))
       }
     }
     formulas <- lapply(mod_fits, extract_formula)

--- a/R/bnec.R
+++ b/R/bnec.R
@@ -537,12 +537,12 @@
 #' where a sequential one does; if you are drawing from that stream after the
 #' fit, the two plans leave you in different places.
 #'
-#' Supplying \code{init} and a \code{seed} yourself skips the search
-#' altogether, so a sequential run does not advance the stream then either and
-#' its averaging draw answers to your session's seed in the same way. Both are
-#' needed: \pkg{brms} defaults \code{seed} to \code{NA} and \pkg{rstan}
-#' then draws one itself, from your stream, once per \code{\link[brms]{brm}}
-#' call.
+#' Supplying \code{init} yourself skips the search altogether. With a
+#' \code{seed} supplied as well, a sequential run then does not advance the
+#' stream either, and its averaging draw answers to your session's seed in the
+#' same way a parallel run's does. The \code{seed} is what makes that second
+#' part true: \pkg{brms} defaults it to \code{NA} and \pkg{rstan} then draws
+#' one itself, from your stream, once per \code{\link[brms]{brm}} call.
 #'
 #' Console output from a worker is not ordered. The per-model
 #' messages \code{\link{bnec}} emits come from a worker process and arrive
@@ -576,8 +576,9 @@
 #' matrix. So if a limit is reached and the data are not large, look at where
 #' the formula was created. The same holds for any \emph{function} passed
 #' through \code{...} -- \code{init} most likely. Families, priors, stanvars
-#' and a \code{control} list do not behave this way: their closures bind to
-#' \pkg{stats} and \pkg{brms}, not to where you wrote them.
+#' and a \code{control} list do not behave this way: a family's closures bind
+#' to \pkg{stats} or \pkg{brms} rather than to where you wrote it, and the
+#' other three hold no closure at all.
 #'
 #' \code{\link{bnec_group}} fits one model set per level of the grouping
 #' variable, so under a parallel plan each level is parallelised in turn and

--- a/R/bnec.R
+++ b/R/bnec.R
@@ -483,49 +483,65 @@
 #' before. \code{\link{amend}} uses the plan in the same way, over the models
 #' it has to fit rather than over the whole set.
 #'
-#' \strong{Chains are sampled in sequence inside each worker.}
-#' \code{\link[brms]{brm}} already parallelises across chains, so models in
-#' parallel on top of that would request \code{workers x chains} processes;
-#' with four workers and the default \code{chains = 4} that is sixteen, and on
-#' most machines it runs slower than fitting in sequence. Under a parallel plan
-#' \code{\link{bnec}} therefore passes \code{cores = 1} to
-#' \code{\link[brms]{brm}}. Nest the two levels deliberately by passing
-#' \code{cores} yourself, which is left alone: \code{bnec(..., cores = 2)}
-#' with \code{workers = 4} runs four worker processes sampling eight chains
-#' between them. Passing \code{cores} is also what makes
-#' \code{getOption("mc.cores")} irrelevant: bayesnec's own \code{cores = 1}
-#' already overrides it, and without either, a value set in a profile would
-#' give every worker four chains at once without having been asked for.
+#' Each model samples its chains in sequence inside its worker.
+#' \code{\link[brms]{brm}} parallelises across chains on its own account, and
+#' models in parallel on top of that would ask for \code{workers x chains}
+#' processes, which on most machines is slower than fitting in sequence. Under
+#' a parallel plan of more than one worker \code{\link{bnec}} therefore passes
+#' \code{cores = 1} to \code{\link[brms]{brm}}. Nest the two levels
+#' deliberately by passing \code{cores} yourself, which is left alone:
+#' \code{bnec(..., cores = 2)} with \code{workers = 4} runs four worker
+#' processes sampling eight chains between them.
 #'
-#' A plan that names a parallel strategy but resolves to one worker gets
-#' neither treatment: nothing is clamped and \code{\link{bnec}} says so.
-#' \code{plan(multicore)} resolves that way wherever forking is unavailable,
-#' which is Windows, and \pkg{RStudio} or \pkg{Positron} on Linux and macOS.
-#' \code{plan(multisession)} works everywhere.
+#' \pkg{future} sets \code{mc.cores} to 1 inside a worker of its own accord,
+#' so a value set in your profile does not in fact reach \pkg{brms} there --
+#' measured at 1 under \code{multisession}, \code{multicore} and
+#' \code{cluster} with \code{options(mc.cores = 7)} in
+#' \code{R_PROFILE_USER}. The \code{cores = 1} above is therefore belt and
+#' braces rather than the only thing standing between you and sixteen
+#' processes. It is kept because it makes what \pkg{brms} is asked to do a
+#' property of this package rather than of \pkg{future}'s internals.
 #'
-#' \strong{Reproducibility, and the one place it stops.} Each fitted model
-#' reproduces exactly under a parallel plan, given the same \code{seed} passed
-#' on to \code{\link[brms]{brm}}, and that is tested. Without a \code{seed}
-#' the initial-value search reseeds from entropy and nothing repeats under
-#' either plan, which is what this package does today with or without one.
+#' A plan that names a parallel strategy but resolves to a single worker is
+#' clamped in neither respect, and \code{\link{bnec}} says which case it is
+#' in. \code{plan(multicore)} resolves that way wherever forking is
+#' unavailable, which is Windows, and \pkg{RStudio} or \pkg{Positron} on
+#' Linux and macOS; \code{plan(multisession)} works everywhere. A
+#' \code{cluster} plan naming one node also reports one worker, and there the
+#' fitting does happen in another process.
 #'
-#' The model-averaged quantities are the exception, and the reason is worth
+#' Each fitted model reproduces exactly under a parallel plan, given the
+#' same \code{seed} passed on to \code{\link[brms]{brm}}, and that is tested.
+#' Without a \code{seed} the initial-value search reseeds from entropy and
+#' nothing repeats under either plan, which is what this package does today
+#' with or without one.
+#'
+#' The model-averaged quantities are the exception, and the reason needs
 #' stating because nothing announces it. Once the models are fitted,
-#' \code{expand_manec()} draws a seed from the session's RNG stream and uses
-#' it to decide which posterior draws each equation contributes to the averaged
-#' estimate. Fitted in sequence, the loop leaves that stream in a state fixed
-#' by \code{seed}, because every initial-value search ran in this process;
-#' fitted in parallel the searches run in workers and the stream is untouched.
-#' The averaged \code{nec}, its interval and the stored prediction grid
-#' therefore differ between the two plans -- as two valid realisations of the
-#' same weighting, not as one being wrong.
+#' \code{expand_manec()} draws a seed from the session's RNG stream and uses it
+#' to decide which posterior draws each equation contributes to the averaged
+#' estimate. Fitted in sequence the loop advances that stream, because
+#' \code{set.seed(seed)} and the initial-value search it governs run in this
+#' process, and the state the draw is taken from is therefore fixed by
+#' \code{seed}. Under a parallel plan the loop leaves the stream alone. The
+#' averaged \code{nec}, its interval and the stored prediction grid therefore
+#' differ between the two plans -- as two valid realisations of the same
+#' weighting, not as one being wrong.
 #'
-#' \code{\link{bnec}} does not disturb the stream under a parallel plan, so
-#' \code{set.seed()} in your session before the call fixes that draw, and two
-#' parallel runs agree. That is what \code{expand_manec()} intends the draw to
-#' answer to.
+#' Two consequences follow from that, and they are properties of the plan
+#' rather than of where the fitting happened, so they hold for a parallel plan
+#' that resolves to a single worker as much as for one with eight.
+#' \code{set.seed()} in your session before the call fixes the averaging draw,
+#' which is what \code{expand_manec()} intends it to answer to, so two parallel
+#' runs agree. And a parallel call does not move your session's RNG stream on,
+#' where a sequential one does; if you are drawing from that stream after the
+#' fit, the two plans leave you in different places.
 #'
-#' \strong{Console output from a worker is not ordered.} The per-model
+#' Supplying \code{init} yourself skips the search altogether, so a sequential
+#' run does not advance the stream then either and its averaging draw answers
+#' to your session's seed in the same way.
+#'
+#' Console output from a worker is not ordered. The per-model
 #' messages \code{\link{bnec}} emits come from a worker process and arrive
 #' out of order, or not at all, depending on the backend. A model that fails
 #' is still recorded as an \code{NA} entry, the remaining models still fit, and
@@ -546,8 +562,16 @@
 #' \code{\link{amend}} has built -- in particular not the fits an
 #' \code{\link{amend}} call already holds. \pkg{future} refuses to export
 #' more than 500 MiB by default and says so, naming the applied function rather
-#' than what is inside it; raise
-#' \code{options(future.globals.maxSize = )} if a large dataset reaches it.
+#' than what is inside it; raise \code{options(future.globals.maxSize = )} if
+#' a large dataset reaches it.
+#'
+#' A formula is the one thing sent that brings more than itself: it keeps the
+#' environment it was written in. Written at the top level that is the global
+#' environment, which is sent by reference and adds nothing. Written inside a
+#' function it is that function's frame, and everything in the frame goes with
+#' it -- measured at 6.18 MiB for a formula built in a frame holding a 6.2 MB
+#' matrix. So if a limit is reached and the data are not large, look at where
+#' the formula was created.
 #'
 #' \code{\link{bnec_group}} fits one model set per level of the grouping
 #' variable, so under a parallel plan each level is parallelised in turn and

--- a/R/parallel_models.R
+++ b/R/parallel_models.R
@@ -57,7 +57,7 @@ bnec_plan_is_parallel <- function() {
 #' not what stands between the user and sixteen processes; \pkg{future}
 #' already does that. It is kept because it makes what \pkg{brms} is asked to
 #' do a property of this package rather than of an implementation detail of
-#' another, and because it is what a supplied \code{cores} then overrides. A
+#' another. A
 #' \code{cores} the user passed to \code{\link{bnec}}, which arrives here in
 #' \code{brm_args} by way of its \code{...}, is left alone: nesting the two
 #' levels is a legitimate thing to want where there are cores to spare, and
@@ -110,10 +110,10 @@ plan_model_set <- function(brm_args, n_models, caller = "bnec") {
       # be beside the point. What is true of every one-worker plan is that the
       # models are fitted one at a time and that nothing here is clamped.
       paste0("The future plan in effect resolves to a single worker, so the ",
-             n_models, " models are fitted one at a time and nothing is",
-             " changed about how brms samples its chains. plan(multicore)",
-             " resolves this way wherever forking is unavailable, which",
-             " includes Windows and most IDEs.")
+             n_models, " models are fitted one at a time and bayesnec applies",
+             " no cores limit here. plan(multicore) resolves this way",
+             " wherever forking is unavailable, which includes Windows,",
+             " RStudio and Positron.")
     } else {
       paste0(
         "Fitting ", n_models, " models in parallel over ", workers,

--- a/R/parallel_models.R
+++ b/R/parallel_models.R
@@ -42,14 +42,22 @@ bnec_plan_is_parallel <- function() {
 #' every model in the amended set is carried over from the object.
 #'
 #' \bold{Under a parallel plan of more than one worker, each model samples its
-#' chains in sequence.}
-#' \code{\link[brms]{brm}} already parallelises across chains, so fitting
-#' models in parallel on top of that requests \code{workers x chains}
-#' processes. bayesnec passes no \code{cores} argument of its own, so
-#' \pkg{brms} falls back to \code{getOption("mc.cores")}; a user who set that
-#' in their profile would get four chains per worker without having asked for
-#' them, and a four-worker plan with the default \code{chains = 4} would then
-#' require sixteen processes on a machine that may not have them. A
+#' chains in sequence.} \code{\link[brms]{brm}} already parallelises across
+#' chains, so fitting models in parallel on top of that requests
+#' \code{workers x chains} processes, and bayesnec passes no \code{cores}
+#' argument of its own.
+#'
+#' It is worth being exact about what this prevents, because the obvious
+#' account of it is wrong. \pkg{future} sets \code{mc.cores} to 1 inside a
+#' worker itself, so \pkg{brms} does not in fact reach a value set in the
+#' user's profile: measured 2026-09-11 with \code{options(mc.cores = 7)} in
+#' \code{R_PROFILE_USER}, \code{getOption("mc.cores")} inside a future is 1
+#' under \code{multisession} at two and four workers, under \code{multicore},
+#' and under a two-node \code{cluster}. Passing \code{cores = 1} is therefore
+#' not what stands between the user and sixteen processes; \pkg{future}
+#' already does that. It is kept because it makes what \pkg{brms} is asked to
+#' do a property of this package rather than of an implementation detail of
+#' another, and because it is what a supplied \code{cores} then overrides. A
 #' \code{cores} the user passed to \code{\link{bnec}}, which arrives here in
 #' \code{brm_args} by way of its \code{...}, is left alone: nesting the two
 #' levels is a legitimate thing to want where there are cores to spare, and
@@ -96,11 +104,16 @@ plan_model_set <- function(brm_args, n_models, caller = "bnec") {
   }
   message(
     if (one_worker) {
+      # No advice about which plan to use instead. A single-node cluster plan
+      # reports one worker too, and there the fitting genuinely does move to
+      # another process, so telling that user to switch to multisession would
+      # be beside the point. What is true of every one-worker plan is that the
+      # models are fitted one at a time and that nothing here is clamped.
       paste0("The future plan in effect resolves to a single worker, so the ",
-             n_models, " models are fitted one at a time and chain",
-             " parallelism is left as it is. plan(multicore) does this",
-             " wherever forking is unavailable; plan(multisession) works",
-             " everywhere.")
+             n_models, " models are fitted one at a time and nothing is",
+             " changed about how brms samples its chains. plan(multicore)",
+             " resolves this way wherever forking is unavailable, which",
+             " includes Windows and most IDEs.")
     } else {
       paste0(
         "Fitting ", n_models, " models in parallel over ", workers,
@@ -199,8 +212,15 @@ plan_model_set <- function(brm_args, n_models, caller = "bnec") {
 #' while the others idle; and a worker holds every fit in its chunk until the
 #' chunk ends, which is the memory multiplication \#184 warns about in its
 #' worst form. One element per future gives the assignment dynamically and
-#' holds one fit at a time. The extra exports this implies are what the narrow
-#' environment above is for.
+#' holds one fit at a time.
+#'
+#' The trade is that the data, the formula and the priors are sent once per
+#' model rather than once per worker, which for 23 models over four workers is
+#' about six times the transfer. \code{narrow_environment()} does not offset
+#' that -- those are the objects a fit genuinely needs -- it removes everything
+#' else. Load balancing and holding one fit rather than six are judged the
+#' larger effects on a set whose equations differ in fitting time by an order
+#' of magnitude, but no timing has been taken either way.
 #'
 #' @param X A \code{\link[base]{vector}} to apply over.
 #' @param FUN A \code{\link[base]{function}} taking one element of \code{X}.

--- a/R/parallel_models.R
+++ b/R/parallel_models.R
@@ -1,0 +1,172 @@
+#' Is the user's \pkg{future} plan a parallel one?
+#'
+#' The decision is read from the plan rather than from an argument to
+#' \code{\link{bnec}}. A \code{cores} or \code{parallel} argument would
+#' duplicate state the plan already holds, and the two become ambiguous the
+#' moment a user sets both. See \code{?bnec} under \emph{Fitting a model set in
+#' parallel}.
+#'
+#' Tested on the strategy rather than on \code{future::nbrOfWorkers()}. A
+#' \code{cluster} plan pointed at a single remote node reports one worker but
+#' is still a parallel plan, and the question here is whether the user asked
+#' for one, not how many workers it has.
+#'
+#' Returns \code{FALSE} where either package is absent, which is what keeps the
+#' sequential path free of the dependency.
+#'
+#' @return A \code{\link[base]{logical}} vector of length 1.
+#'
+#' @noRd
+bnec_plan_is_parallel <- function() {
+  if (!requireNamespace("future", quietly = TRUE) ||
+        !requireNamespace("future.apply", quietly = TRUE)) {
+    return(FALSE)
+  }
+  strategy <- try(future::plan("list")[[1]], silent = TRUE)
+  if (inherits(strategy, "try-error")) {
+    return(FALSE)
+  }
+  !inherits(strategy, "sequential")
+}
+
+#' Decide how a model set will be fitted, and say so
+#'
+#' Called once, before the loop, by \code{\link{bnec}} and \code{\link{amend}}.
+#' Returns the decision and the \code{\link[brms]{brm}} arguments that go with
+#' it, so the two are made in one place and cannot disagree.
+#'
+#' \bold{Fewer than two models to fit is never parallel.} A parallel plan
+#' provides no benefit over a single \code{\link[brms]{brm}} call, and treating
+#' it as parallel would apply the \code{cores} limit below and so make a lone
+#' fit slower than it is today. \code{\link{amend}} reaches this case whenever
+#' every model in the amended set is carried over from the object.
+#'
+#' \bold{Under a parallel plan each model samples its chains in sequence.}
+#' \code{\link[brms]{brm}} already parallelises across chains, so fitting
+#' models in parallel on top of that requests \code{workers x chains}
+#' processes. bayesnec passes no \code{cores} argument of its own, so
+#' \pkg{brms} falls back to \code{getOption("mc.cores")}; a user who set that
+#' in their profile would get four chains per worker without having asked for
+#' them, and a four-worker plan with the default \code{chains = 4} would then
+#' require sixteen processes on a machine that may not have them. A
+#' \code{cores} the user passed to \code{\link{bnec}}, which arrives here in
+#' \code{brm_args} by way of its \code{...}, is left alone: nesting the two
+#' levels is a legitimate thing to want where there are cores to spare, and
+#' that argument is how it is asked for. \code{\link{amend}} has no such
+#' argument -- it rebuilds \code{brm_args} from the stored \code{simdat} --
+#' so \code{caller} decides whether the message offers that advice or says it
+#' is unavailable.
+#'
+#' The decision is reported because a parallel run emits its per-model messages
+#' out of order or not at all, depending on the backend, so the user otherwise
+#' has no way to tell which path was taken.
+#'
+#' @param brm_args A named \code{\link[base]{list}} of arguments for
+#' \code{\link[brms]{brm}}.
+#' @param n_models A \code{\link[base]{numeric}} vector of length 1 giving the
+#' number of models that will actually be fitted.
+#' @param caller A \code{\link[base]{character}} vector of length 1, either
+#' \code{"bnec"} or \code{"amend"}.
+#'
+#' @return A \code{\link[base]{list}} with elements \code{parallel}, a
+#' \code{\link[base]{logical}} vector of length 1, and \code{brm_args}.
+#'
+#' @noRd
+plan_model_set <- function(brm_args, n_models, caller = "bnec") {
+  if (n_models < 2 || !bnec_plan_is_parallel()) {
+    return(list(parallel = FALSE, brm_args = brm_args))
+  }
+  workers <- try(future::nbrOfWorkers(), silent = TRUE)
+  if (inherits(workers, "try-error")) {
+    workers <- NA_integer_
+  }
+  supplied_cores <- "cores" %in% names(brm_args)
+  if (!supplied_cores) {
+    brm_args$cores <- 1
+  }
+  message(
+    "Fitting ", n_models, " models in parallel over ", workers,
+    " workers, under the future plan already set.\n",
+    if (supplied_cores) {
+      paste0("Each model samples its chains over cores = ", brm_args$cores,
+             ", as you supplied, so up to ", workers, " x ", brm_args$cores,
+             " processes may run at once.")
+    } else {
+      paste0("Each model samples its chains in sequence (cores = 1);",
+             if (identical(caller, "amend")) {
+               paste0(" amend() takes no brms arguments, so to nest the two",
+                      " levels of parallelism refit the set with bnec().")
+             } else {
+               " pass `cores` to bnec() to nest the two levels of parallelism."
+             })
+    },
+    "\nPer-model messages from a worker may arrive out of order, or not at",
+    " all. A model that fails is recorded either way; see ?failed_models."
+  )
+  list(parallel = TRUE, brm_args = brm_args)
+}
+
+#' Apply a function over a model set, in parallel where asked
+#'
+#' \code{\link[base]{lapply}} when \code{parallel} is \code{FALSE}, which is
+#' every call made today. That path is what the acceptance criterion
+#' "sequential behaviour is identical to current output for the same seed"
+#' rests on, and it touches neither \pkg{future} nor the RNG.
+#'
+#' \bold{The RNG kind is restored inside the worker}, and this is the part that
+#' fails silently if it is left out. \code{future.seed = TRUE} installs an
+#' L'Ecuyer-CMRG stream in each worker so that draws are parallel-safe.
+#' bayesnec then seeds its own initial-value search with
+#' \code{set.seed(brm_args$seed)} in \code{make_good_inits()}, and
+#' \code{\link[base]{set.seed}} called with \code{kind = NULL} -- the default --
+#' leaves the current generator kind in place. The same seed therefore draws
+#' from L'Ecuyer-CMRG in a worker and from the session's kind, normally
+#' Mersenne-Twister, in the parent, and the two give different initial values.
+#' Nothing errors and nothing warns: the fits simply differ from the sequential
+#' run. Restoring the parent's kind first makes the seed mean the same thing in
+#' both places. \code{weighted_draw_index()} records the same trap on the
+#' post-fit side.
+#'
+#' \code{future.seed = TRUE} is kept rather than dropped to \code{NULL}, even
+#' though the stream it installs is then discarded. \code{NULL} leaves the
+#' worker's RNG state to the backend, which makes correctness a property of
+#' every code path inside \code{fit_bayesnec()} seeding itself rather than of
+#' the dispatcher, and that is not something anyone maintains. \code{TRUE}
+#' gives each element a well-defined independent stream whatever the body does.
+#' (\code{future.seed = FALSE}, the \code{future_lapply} default, is not an
+#' option at all: it reports \code{UNRELIABLE VALUE} for a body that uses the
+#' RNG, which every fit does. \code{NULL} is silent.)
+#'
+#' Discarding the stream does not leave the workers drawing in step.
+#' \code{\link[base]{RNGkind}} re-initialises \code{.Random.seed} from the
+#' clock and the process id, so each worker starts somewhere different, and
+#' bayesnec then seeds the search itself. Measured 2026-09-11 under
+#' \code{plan(multicore, workers = 3)}: three of three draws distinct with the
+#' restore in place, as without it.
+#'
+#' Where no \code{seed} is supplied the search calls \code{set.seed(NULL)},
+#' which reseeds from entropy, so the run is not reproducible under either plan
+#' -- which is what it does today, with or without a plan set.
+#'
+#' @param X A \code{\link[base]{vector}} to apply over.
+#' @param FUN A \code{\link[base]{function}} taking one element of \code{X}.
+#' @param parallel A \code{\link[base]{logical}} vector of length 1, as
+#' returned by \code{plan_model_set()}.
+#'
+#' @return A \code{\link[base]{list}} of the same length as \code{X}.
+#'
+#' @noRd
+bnec_model_lapply <- function(X, FUN, parallel = FALSE) {
+  if (!parallel) {
+    return(lapply(X, FUN))
+  }
+  rng_kind <- RNGkind()
+  future.apply::future_lapply(
+    X,
+    function(x) {
+      do.call(RNGkind, as.list(rng_kind))
+      FUN(x)
+    },
+    future.seed = TRUE
+  )
+}

--- a/R/parallel_models.R
+++ b/R/parallel_models.R
@@ -41,7 +41,8 @@ bnec_plan_is_parallel <- function() {
 #' fit slower than it is today. \code{\link{amend}} reaches this case whenever
 #' every model in the amended set is carried over from the object.
 #'
-#' \bold{Under a parallel plan each model samples its chains in sequence.}
+#' \bold{Under a parallel plan of more than one worker, each model samples its
+#' chains in sequence.}
 #' \code{\link[brms]{brm}} already parallelises across chains, so fitting
 #' models in parallel on top of that requests \code{workers x chains}
 #' processes. bayesnec passes no \code{cores} argument of its own, so
@@ -77,31 +78,53 @@ plan_model_set <- function(brm_args, n_models, caller = "bnec") {
     return(list(parallel = FALSE, brm_args = brm_args))
   }
   workers <- try(future::nbrOfWorkers(), silent = TRUE)
-  if (inherits(workers, "try-error")) {
+  if (inherits(workers, "try-error") || !is.numeric(workers)) {
     workers <- NA_integer_
   }
+  # The clamp is on the worker count, not on the strategy. A plan can name a
+  # parallel strategy and still resolve to one worker -- plan(multicore) does
+  # exactly that on Windows, and on Linux and macOS inside RStudio or Positron,
+  # where parallelly::supportsMulticore() is FALSE and future falls back to
+  # evaluating in the parent. Clamping there would fit one model at a time with
+  # its chains in sequence, which for a user who has set mc.cores is slower
+  # than the release, while the message said the opposite. Unknown reads as
+  # more than one, since the risk being guarded is oversubscription.
+  one_worker <- isTRUE(workers == 1)
   supplied_cores <- "cores" %in% names(brm_args)
-  if (!supplied_cores) {
+  if (!supplied_cores && !one_worker) {
     brm_args$cores <- 1
   }
   message(
-    "Fitting ", n_models, " models in parallel over ", workers,
-    " workers, under the future plan already set.\n",
-    if (supplied_cores) {
-      paste0("Each model samples its chains over cores = ", brm_args$cores,
-             ", as you supplied, so up to ", workers, " x ", brm_args$cores,
-             " processes may run at once.")
+    if (one_worker) {
+      paste0("The future plan in effect resolves to a single worker, so the ",
+             n_models, " models are fitted one at a time and chain",
+             " parallelism is left as it is. plan(multicore) does this",
+             " wherever forking is unavailable; plan(multisession) works",
+             " everywhere.")
     } else {
-      paste0("Each model samples its chains in sequence (cores = 1);",
-             if (identical(caller, "amend")) {
-               paste0(" amend() takes no brms arguments, so to nest the two",
-                      " levels of parallelism refit the set with bnec().")
-             } else {
-               " pass `cores` to bnec() to nest the two levels of parallelism."
-             })
-    },
-    "\nPer-model messages from a worker may arrive out of order, or not at",
-    " all. A model that fails is recorded either way; see ?failed_models."
+      paste0(
+        "Fitting ", n_models, " models in parallel over ", workers,
+        " workers, under the future plan already set.\n",
+        if (supplied_cores) {
+          paste0("Each model samples its chains over cores = ",
+                 brm_args$cores, ", as you supplied, so up to ", workers,
+                 " x ", brm_args$cores, " chains may sample at once.")
+        } else {
+          paste0("Each model samples its chains in sequence (cores = 1);",
+                 if (identical(caller, "amend")) {
+                   paste0(" amend() takes no brms arguments, so to nest the",
+                          " two levels of parallelism refit the set with",
+                          " bnec().")
+                 } else {
+                   paste0(" pass `cores` to bnec() to nest the two levels of",
+                          " parallelism.")
+                 })
+        },
+        "\nPer-model messages from a worker may arrive out of order, or not",
+        " at all. A model that fails is recorded either way; see",
+        " ?failed_models."
+      )
+    }
   )
   list(parallel = TRUE, brm_args = brm_args)
 }
@@ -127,6 +150,27 @@ plan_model_set <- function(brm_args, n_models, caller = "bnec") {
 #' both places. \code{weighted_draw_index()} records the same trap on the
 #' post-fit side.
 #'
+#' \bold{The caller's RNG stream is left where it was found.} A parallel loop
+#' advances the parent's \code{.Random.seed} by generating the per-element
+#' streams, and initialises it from entropy where the session had not yet used
+#' the RNG, so what \code{expand_manec()} draws next -- \code{w_draw_seed},
+#' and through it which draws each equation contributes to the model-averaged
+#' estimate -- would otherwise differ between two parallel runs of the same
+#' call. Restoring makes that draw answer to a \code{set.seed()} in the
+#' caller's session, which is what \code{expand_manec()} says it is for, and
+#' stops a fit resetting a user's simulation seed. \code{weighted_draw_index()}
+#' restores for the same reason and in the same order: the kind first, because
+#' the generator is encoded in \code{.Random.seed[1]}.
+#'
+#' It does not make the model-averaging draw match the sequential run's. Run in
+#' sequence the loop advances the parent's stream, because every model's
+#' \code{set.seed(brm_args$seed)} and initial-value search happen there; run in
+#' parallel they happen in a worker and nothing can replay them. The fitted
+#' models reproduce exactly; \code{w_draw_seed} and \code{w_draw_index} do not.
+#' Closing that gap means deriving the draw from \code{brm_args$seed} rather
+#' than from the ambient stream, which is a change to \code{expand_manec()} and
+#' to what \#216 decided deliberately.
+#'
 #' \code{future.seed = TRUE} is kept rather than dropped to \code{NULL}, even
 #' though the stream it installs is then discarded. \code{NULL} leaves the
 #' worker's RNG state to the backend, which makes correctness a property of
@@ -148,6 +192,16 @@ plan_model_set <- function(brm_args, n_models, caller = "bnec") {
 #' which reseeds from entropy, so the run is not reproducible under either plan
 #' -- which is what it does today, with or without a plan set.
 #'
+#' \bold{One model per chunk.} \code{future_lapply()} otherwise divides the set
+#' into one chunk per worker and runs each chunk in sequence, which for
+#' bayesnec is wrong twice over. The 23 equations differ in fitting time by an
+#' order of magnitude, so a worker that draws the slow ones sets the wall clock
+#' while the others idle; and a worker holds every fit in its chunk until the
+#' chunk ends, which is the memory multiplication \#184 warns about in its
+#' worst form. One element per future gives the assignment dynamically and
+#' holds one fit at a time. The extra exports this implies are what the narrow
+#' environment above is for.
+#'
 #' @param X A \code{\link[base]{vector}} to apply over.
 #' @param FUN A \code{\link[base]{function}} taking one element of \code{X}.
 #' @param parallel A \code{\link[base]{logical}} vector of length 1, as
@@ -161,12 +215,64 @@ bnec_model_lapply <- function(X, FUN, parallel = FALSE) {
     return(lapply(X, FUN))
   }
   rng_kind <- RNGkind()
+  has_seed <- exists(".Random.seed", envir = globalenv(), inherits = FALSE)
+  old_seed <- if (has_seed) {
+    get(".Random.seed", envir = globalenv(), inherits = FALSE)
+  } else {
+    NULL
+  }
+  on.exit({
+    suppressWarnings(do.call(RNGkind, as.list(rng_kind)))
+    if (is.null(old_seed)) {
+      suppressWarnings(rm(".Random.seed", envir = globalenv()))
+    } else {
+      assign(".Random.seed", old_seed, envir = globalenv())
+    }
+  }, add = TRUE)
   future.apply::future_lapply(
     X,
     function(x) {
-      do.call(RNGkind, as.list(rng_kind))
+      # suppressWarnings for the sample.kind = "Rounding" notice, which a
+      # session set to the pre-3.6.0 sampler would otherwise have relayed once
+      # per model. weighted_draw_index() suppresses it at its own restore.
+      suppressWarnings(do.call(RNGkind, as.list(rng_kind)))
       FUN(x)
     },
-    future.seed = TRUE
+    future.seed = TRUE,
+    future.chunk.size = 1
   )
+}
+
+#' Rebuild a function so that only what it names travels to a worker
+#'
+#' \pkg{future} exports the applied function together with its enclosing
+#' environment, and that environment is by default the frame of
+#' \code{\link{bnec}} or \code{amend_model_set()}. Those frames hold
+#' everything the function has computed by that point -- for \code{amend()},
+#' every fit already in the set -- so a closure that reads a handful of small
+#' objects serialises all of it, once per future. Measured on the two-equation
+#' \code{manec_example}, 2026-09-11: the applied function reported 14.1 MiB
+#' against 75 bytes for the arguments it actually reads, and the same closure
+#' over a 32 MB object was refused outright at
+#' \code{future.globals.maxSize = 10 MiB}, naming \code{FUN}, which tells the
+#' user nothing about the cause.
+#'
+#' The replacement environment's parent is the package namespace, so package
+#' internals resolve as before and are exported by reference rather than by
+#' value.
+#'
+#' Applied on the sequential path as well as the parallel one, deliberately. A
+#' name left out of \code{vars} then fails on the first ordinary call rather
+#' than only for whoever sets a plan.
+#'
+#' @param fn A \code{\link[base]{function}}.
+#' @param vars A named \code{\link[base]{list}} of everything \code{fn}
+#' reads from its enclosing scope.
+#'
+#' @return \code{fn}, with its environment replaced.
+#'
+#' @noRd
+narrow_environment <- function(fn, vars) {
+  environment(fn) <- list2env(vars, parent = asNamespace("bayesnec"))
+  fn
 }

--- a/man/bnec.Rd
+++ b/man/bnec.Rd
@@ -439,6 +439,66 @@ posterior predictions, with weights derived using functions
 \code{loo_controls} argument. Individual model fits can be pulled out
 for examination using function \code{\link{pull_out}}.
 
+\bold{Fitting a model set in parallel}
+
+A model set is fitted one model at a time by default, which is what every
+earlier version did. Fitting the models at the same time is asked for by
+setting a \pkg{future} plan before the call, and \code{\link{bnec}} then
+uses it:
+
+\preformatted{
+library(future)
+plan(multisession, workers = 4)
+fit <- bnec(y ~ crf(x, model = "decline"), data = my_data, seed = 17)
+plan(sequential)
+}
+
+There is no \code{cores} or \code{parallel} argument, because the plan
+already holds that state and two ways of setting it would disagree. The
+\pkg{future} and \pkg{future.apply} packages are Suggests: with either
+absent, or with no plan set, the models are fitted in sequence exactly as
+before. \code{\link{amend}} uses the plan in the same way, over the models
+it has to fit rather than over the whole set.
+
+\strong{Chains are sampled in sequence inside each worker.}
+\code{\link[brms]{brm}} already parallelises across chains, so models in
+parallel on top of that would request \code{workers x chains} processes;
+with four workers and the default \code{chains = 4} that is sixteen, and on
+most machines it runs slower than fitting in sequence. Under a parallel plan
+\code{\link{bnec}} therefore passes \code{cores = 1} to
+\code{\link[brms]{brm}}. Nest the two levels deliberately by passing
+\code{cores} yourself, which is left alone: \code{bnec(..., cores = 2)}
+with \code{workers = 4} uses up to eight processes. Note that this is also
+the only way \code{getOption("mc.cores")} stops applying: without it a value
+set in a profile would give every worker four chains at once without having
+been asked for.
+
+\strong{Supply a seed if the run has to be reproducible.} A parallel run
+reproduces the sequential run exactly for the same \code{seed} passed on to
+\code{\link[brms]{brm}}, and that is tested. Without one the initial-value
+search reseeds from entropy, so neither a sequential nor a parallel run
+repeats -- which is true of this package with or without a plan set.
+
+\strong{Console output from a worker is not ordered.} The per-model
+messages \code{\link{bnec}} emits come from a worker process and arrive
+out of order, or not at all, depending on the backend. A model that fails
+is still recorded as an \code{NA} entry, the remaining models still fit, and
+\code{\link{failed_models}} reports what happened, so nothing is lost
+beyond the running commentary. \code{timeout} continues to apply per model
+inside its worker.
+
+Every worker is sent the data and the formula. \pkg{future} refuses to
+export more than 500 MB by default and says so; raise
+\code{options(future.globals.maxSize = )} if a large dataset trips it.
+
+Two things to be aware of when developing against the package rather than
+using it. A \code{multisession} or \code{cluster} worker loads the
+\emph{installed} \pkg{bayesnec}, not one loaded with
+\code{pkgload::load_all()}; \code{multicore}, which forks, inherits the
+loaded one. And \pkg{future} sets the plan inside a worker to sequential,
+so a \code{\link{bnec}} call made from within one does not parallelise
+again.
+
 \bold{Additional technical notes}
 
 A zero concentration is fitted as recorded. No family constrains the values

--- a/man/bnec.Rd
+++ b/man/bnec.Rd
@@ -514,9 +514,12 @@ runs agree. And a parallel call does not move your session's RNG stream on,
 where a sequential one does; if you are drawing from that stream after the
 fit, the two plans leave you in different places.
 
-Supplying \code{init} yourself skips the search altogether, so a sequential
-run does not advance the stream then either and its averaging draw answers
-to your session's seed in the same way.
+Supplying \code{init} and a \code{seed} yourself skips the search
+altogether, so a sequential run does not advance the stream then either and
+its averaging draw answers to your session's seed in the same way. Both are
+needed: \pkg{brms} defaults \code{seed} to \code{NA} and \pkg{rstan}
+then draws one itself, from your stream, once per \code{\link[brms]{brm}}
+call.
 
 Console output from a worker is not ordered. The per-model
 messages \code{\link{bnec}} emits come from a worker process and arrive
@@ -548,7 +551,10 @@ environment, which is sent by reference and adds nothing. Written inside a
 function it is that function's frame, and everything in the frame goes with
 it -- measured at 6.18 MiB for a formula built in a frame holding a 6.2 MB
 matrix. So if a limit is reached and the data are not large, look at where
-the formula was created.
+the formula was created. The same holds for any \emph{function} passed
+through \code{...} -- \code{init} most likely. Families, priors, stanvars
+and a \code{control} list do not behave this way: their closures bind to
+\pkg{stats} and \pkg{brms}, not to where you wrote them.
 
 \code{\link{bnec_group}} fits one model set per level of the grouping
 variable, so under a parallel plan each level is parallelised in turn and

--- a/man/bnec.Rd
+++ b/man/bnec.Rd
@@ -468,16 +468,39 @@ most machines it runs slower than fitting in sequence. Under a parallel plan
 \code{\link{bnec}} therefore passes \code{cores = 1} to
 \code{\link[brms]{brm}}. Nest the two levels deliberately by passing
 \code{cores} yourself, which is left alone: \code{bnec(..., cores = 2)}
-with \code{workers = 4} uses up to eight processes. Note that this is also
-the only way \code{getOption("mc.cores")} stops applying: without it a value
-set in a profile would give every worker four chains at once without having
-been asked for.
+with \code{workers = 4} runs four worker processes sampling eight chains
+between them. Passing \code{cores} is also what makes
+\code{getOption("mc.cores")} irrelevant: bayesnec's own \code{cores = 1}
+already overrides it, and without either, a value set in a profile would
+give every worker four chains at once without having been asked for.
 
-\strong{Supply a seed if the run has to be reproducible.} A parallel run
-reproduces the sequential run exactly for the same \code{seed} passed on to
-\code{\link[brms]{brm}}, and that is tested. Without one the initial-value
-search reseeds from entropy, so neither a sequential nor a parallel run
-repeats -- which is true of this package with or without a plan set.
+A plan that names a parallel strategy but resolves to one worker gets
+neither treatment: nothing is clamped and \code{\link{bnec}} says so.
+\code{plan(multicore)} resolves that way wherever forking is unavailable,
+which is Windows, and \pkg{RStudio} or \pkg{Positron} on Linux and macOS.
+\code{plan(multisession)} works everywhere.
+
+\strong{Reproducibility, and the one place it stops.} Each fitted model
+reproduces exactly under a parallel plan, given the same \code{seed} passed
+on to \code{\link[brms]{brm}}, and that is tested. Without a \code{seed}
+the initial-value search reseeds from entropy and nothing repeats under
+either plan, which is what this package does today with or without one.
+
+The model-averaged quantities are the exception, and the reason is worth
+stating because nothing announces it. Once the models are fitted,
+\code{expand_manec()} draws a seed from the session's RNG stream and uses
+it to decide which posterior draws each equation contributes to the averaged
+estimate. Fitted in sequence, the loop leaves that stream in a state fixed
+by \code{seed}, because every initial-value search ran in this process;
+fitted in parallel the searches run in workers and the stream is untouched.
+The averaged \code{nec}, its interval and the stored prediction grid
+therefore differ between the two plans -- as two valid realisations of the
+same weighting, not as one being wrong.
+
+\code{\link{bnec}} does not disturb the stream under a parallel plan, so
+\code{set.seed()} in your session before the call fixes that draw, and two
+parallel runs agree. That is what \code{expand_manec()} intends the draw to
+answer to.
 
 \strong{Console output from a worker is not ordered.} The per-model
 messages \code{\link{bnec}} emits come from a worker process and arrive
@@ -487,9 +510,32 @@ is still recorded as an \code{NA} entry, the remaining models still fit, and
 beyond the running commentary. \code{timeout} continues to apply per model
 inside its worker.
 
-Every worker is sent the data and the formula. \pkg{future} refuses to
-export more than 500 MB by default and says so; raise
-\code{options(future.globals.maxSize = )} if a large dataset trips it.
+One failure is not caught that way. A worker killed from outside R, which in
+practice means the operating system reclaiming memory, cannot raise a
+condition for \code{try()} to catch, and \pkg{future} reports it in the
+parent as an error that ends the whole call rather than one model of it.
+Fewer workers is the remedy, and it is the reason to think about how many
+before setting a plan: memory, not cores, is usually what binds on a set of
+this kind.
+
+Each model is sent to a worker with the data, the formula, the priors and
+the \pkg{brms} arguments, and nothing else \code{\link{bnec}} or
+\code{\link{amend}} has built -- in particular not the fits an
+\code{\link{amend}} call already holds. \pkg{future} refuses to export
+more than 500 MiB by default and says so, naming the applied function rather
+than what is inside it; raise
+\code{options(future.globals.maxSize = )} if a large dataset reaches it.
+
+\code{\link{bnec_group}} fits one model set per level of the grouping
+variable, so under a parallel plan each level is parallelised in turn and
+the note above is printed once per level.
+
+Starting a worker is not free for this package. A \code{multisession} or
+\code{cluster} worker is a fresh R process that has to load \pkg{bayesnec}
+and with it \pkg{brms}, \pkg{Rcpp} and \pkg{rstan} before it can fit
+anything, which took about three seconds per worker on an idle machine and
+considerably longer on a busy one. It is paid once per worker, so it is
+negligible against a 23-model set and is not against two or three models.
 
 Two things to be aware of when developing against the package rather than
 using it. A \code{multisession} or \code{cluster} worker loads the

--- a/man/bnec.Rd
+++ b/man/bnec.Rd
@@ -460,49 +460,65 @@ absent, or with no plan set, the models are fitted in sequence exactly as
 before. \code{\link{amend}} uses the plan in the same way, over the models
 it has to fit rather than over the whole set.
 
-\strong{Chains are sampled in sequence inside each worker.}
-\code{\link[brms]{brm}} already parallelises across chains, so models in
-parallel on top of that would request \code{workers x chains} processes;
-with four workers and the default \code{chains = 4} that is sixteen, and on
-most machines it runs slower than fitting in sequence. Under a parallel plan
-\code{\link{bnec}} therefore passes \code{cores = 1} to
-\code{\link[brms]{brm}}. Nest the two levels deliberately by passing
-\code{cores} yourself, which is left alone: \code{bnec(..., cores = 2)}
-with \code{workers = 4} runs four worker processes sampling eight chains
-between them. Passing \code{cores} is also what makes
-\code{getOption("mc.cores")} irrelevant: bayesnec's own \code{cores = 1}
-already overrides it, and without either, a value set in a profile would
-give every worker four chains at once without having been asked for.
+Each model samples its chains in sequence inside its worker.
+\code{\link[brms]{brm}} parallelises across chains on its own account, and
+models in parallel on top of that would ask for \code{workers x chains}
+processes, which on most machines is slower than fitting in sequence. Under
+a parallel plan of more than one worker \code{\link{bnec}} therefore passes
+\code{cores = 1} to \code{\link[brms]{brm}}. Nest the two levels
+deliberately by passing \code{cores} yourself, which is left alone:
+\code{bnec(..., cores = 2)} with \code{workers = 4} runs four worker
+processes sampling eight chains between them.
 
-A plan that names a parallel strategy but resolves to one worker gets
-neither treatment: nothing is clamped and \code{\link{bnec}} says so.
-\code{plan(multicore)} resolves that way wherever forking is unavailable,
-which is Windows, and \pkg{RStudio} or \pkg{Positron} on Linux and macOS.
-\code{plan(multisession)} works everywhere.
+\pkg{future} sets \code{mc.cores} to 1 inside a worker of its own accord,
+so a value set in your profile does not in fact reach \pkg{brms} there --
+measured at 1 under \code{multisession}, \code{multicore} and
+\code{cluster} with \code{options(mc.cores = 7)} in
+\code{R_PROFILE_USER}. The \code{cores = 1} above is therefore belt and
+braces rather than the only thing standing between you and sixteen
+processes. It is kept because it makes what \pkg{brms} is asked to do a
+property of this package rather than of \pkg{future}'s internals.
 
-\strong{Reproducibility, and the one place it stops.} Each fitted model
-reproduces exactly under a parallel plan, given the same \code{seed} passed
-on to \code{\link[brms]{brm}}, and that is tested. Without a \code{seed}
-the initial-value search reseeds from entropy and nothing repeats under
-either plan, which is what this package does today with or without one.
+A plan that names a parallel strategy but resolves to a single worker is
+clamped in neither respect, and \code{\link{bnec}} says which case it is
+in. \code{plan(multicore)} resolves that way wherever forking is
+unavailable, which is Windows, and \pkg{RStudio} or \pkg{Positron} on
+Linux and macOS; \code{plan(multisession)} works everywhere. A
+\code{cluster} plan naming one node also reports one worker, and there the
+fitting does happen in another process.
 
-The model-averaged quantities are the exception, and the reason is worth
+Each fitted model reproduces exactly under a parallel plan, given the
+same \code{seed} passed on to \code{\link[brms]{brm}}, and that is tested.
+Without a \code{seed} the initial-value search reseeds from entropy and
+nothing repeats under either plan, which is what this package does today
+with or without one.
+
+The model-averaged quantities are the exception, and the reason needs
 stating because nothing announces it. Once the models are fitted,
-\code{expand_manec()} draws a seed from the session's RNG stream and uses
-it to decide which posterior draws each equation contributes to the averaged
-estimate. Fitted in sequence, the loop leaves that stream in a state fixed
-by \code{seed}, because every initial-value search ran in this process;
-fitted in parallel the searches run in workers and the stream is untouched.
-The averaged \code{nec}, its interval and the stored prediction grid
-therefore differ between the two plans -- as two valid realisations of the
-same weighting, not as one being wrong.
+\code{expand_manec()} draws a seed from the session's RNG stream and uses it
+to decide which posterior draws each equation contributes to the averaged
+estimate. Fitted in sequence the loop advances that stream, because
+\code{set.seed(seed)} and the initial-value search it governs run in this
+process, and the state the draw is taken from is therefore fixed by
+\code{seed}. Under a parallel plan the loop leaves the stream alone. The
+averaged \code{nec}, its interval and the stored prediction grid therefore
+differ between the two plans -- as two valid realisations of the same
+weighting, not as one being wrong.
 
-\code{\link{bnec}} does not disturb the stream under a parallel plan, so
-\code{set.seed()} in your session before the call fixes that draw, and two
-parallel runs agree. That is what \code{expand_manec()} intends the draw to
-answer to.
+Two consequences follow from that, and they are properties of the plan
+rather than of where the fitting happened, so they hold for a parallel plan
+that resolves to a single worker as much as for one with eight.
+\code{set.seed()} in your session before the call fixes the averaging draw,
+which is what \code{expand_manec()} intends it to answer to, so two parallel
+runs agree. And a parallel call does not move your session's RNG stream on,
+where a sequential one does; if you are drawing from that stream after the
+fit, the two plans leave you in different places.
 
-\strong{Console output from a worker is not ordered.} The per-model
+Supplying \code{init} yourself skips the search altogether, so a sequential
+run does not advance the stream then either and its averaging draw answers
+to your session's seed in the same way.
+
+Console output from a worker is not ordered. The per-model
 messages \code{\link{bnec}} emits come from a worker process and arrive
 out of order, or not at all, depending on the backend. A model that fails
 is still recorded as an \code{NA} entry, the remaining models still fit, and
@@ -523,8 +539,16 @@ the \pkg{brms} arguments, and nothing else \code{\link{bnec}} or
 \code{\link{amend}} has built -- in particular not the fits an
 \code{\link{amend}} call already holds. \pkg{future} refuses to export
 more than 500 MiB by default and says so, naming the applied function rather
-than what is inside it; raise
-\code{options(future.globals.maxSize = )} if a large dataset reaches it.
+than what is inside it; raise \code{options(future.globals.maxSize = )} if
+a large dataset reaches it.
+
+A formula is the one thing sent that brings more than itself: it keeps the
+environment it was written in. Written at the top level that is the global
+environment, which is sent by reference and adds nothing. Written inside a
+function it is that function's frame, and everything in the frame goes with
+it -- measured at 6.18 MiB for a formula built in a frame holding a 6.2 MB
+matrix. So if a limit is reached and the data are not large, look at where
+the formula was created.
 
 \code{\link{bnec_group}} fits one model set per level of the grouping
 variable, so under a parallel plan each level is parallelised in turn and

--- a/man/bnec.Rd
+++ b/man/bnec.Rd
@@ -514,12 +514,12 @@ runs agree. And a parallel call does not move your session's RNG stream on,
 where a sequential one does; if you are drawing from that stream after the
 fit, the two plans leave you in different places.
 
-Supplying \code{init} and a \code{seed} yourself skips the search
-altogether, so a sequential run does not advance the stream then either and
-its averaging draw answers to your session's seed in the same way. Both are
-needed: \pkg{brms} defaults \code{seed} to \code{NA} and \pkg{rstan}
-then draws one itself, from your stream, once per \code{\link[brms]{brm}}
-call.
+Supplying \code{init} yourself skips the search altogether. With a
+\code{seed} supplied as well, a sequential run then does not advance the
+stream either, and its averaging draw answers to your session's seed in the
+same way a parallel run's does. The \code{seed} is what makes that second
+part true: \pkg{brms} defaults it to \code{NA} and \pkg{rstan} then draws
+one itself, from your stream, once per \code{\link[brms]{brm}} call.
 
 Console output from a worker is not ordered. The per-model
 messages \code{\link{bnec}} emits come from a worker process and arrive
@@ -553,8 +553,9 @@ it -- measured at 6.18 MiB for a formula built in a frame holding a 6.2 MB
 matrix. So if a limit is reached and the data are not large, look at where
 the formula was created. The same holds for any \emph{function} passed
 through \code{...} -- \code{init} most likely. Families, priors, stanvars
-and a \code{control} list do not behave this way: their closures bind to
-\pkg{stats} and \pkg{brms}, not to where you wrote them.
+and a \code{control} list do not behave this way: a family's closures bind
+to \pkg{stats} or \pkg{brms} rather than to where you wrote it, and the
+other three hold no closure at all.
 
 \code{\link{bnec_group}} fits one model set per level of the grouping
 variable, so under a parallel plan each level is parallelised in turn and

--- a/tests/testthat/test-parallel_models.R
+++ b/tests/testthat/test-parallel_models.R
@@ -151,6 +151,73 @@ test_that("the initial-value search draws the same values in a worker", {
   expect_identical(parallel, sequential)
 })
 
+test_that("a parallel run leaves the caller's RNG stream where it was", {
+  skip_unless_future()
+  # expand_manec() draws w_draw_seed from the ambient stream immediately after
+  # the model loop, and through it the index deciding which draws each equation
+  # contributes to the model-averaged estimate. A parallel loop advances that
+  # stream by generating its per-element seeds, so without this restore two
+  # parallel runs of one call would not agree with each other. It does not make
+  # the draw match the sequential run's, which advances the stream by running
+  # every init search in the parent; see ?bnec.
+  set.seed(9)
+  before <- get(".Random.seed", envir = globalenv())
+  out <- with_parallel_plan({
+    skip_unless_worker_sees_internals()
+    bnec_model_lapply(1:4, function(i) i, parallel = TRUE)
+  })
+  expect_length(out, 4)
+  expect_identical(get(".Random.seed", envir = globalenv()), before)
+  # And with no stream to begin with, none is left behind.
+  suppressWarnings(rm(".Random.seed", envir = globalenv()))
+  with_parallel_plan({
+    skip_unless_worker_sees_internals()
+    bnec_model_lapply(1:2, function(i) i, parallel = TRUE)
+  })
+  expect_false(exists(".Random.seed", envir = globalenv(), inherits = FALSE))
+})
+
+test_that("a one-worker parallel plan does not take chains away from brms", {
+  skip_unless_future()
+  # plan(multicore) resolves to a single worker wherever forking is
+  # unavailable -- Windows, and RStudio or Positron on Linux and macOS. Setting
+  # cores = 1 there would fit one model at a time with its chains in sequence,
+  # which for a user who has set mc.cores is slower than fitting sequentially,
+  # while the message claimed models were being fitted in parallel.
+  old_limit <- options(parallelly.maxWorkers.localhost = Inf)
+  on.exit(options(old_limit), add = TRUE)
+  old <- future::plan(future::multisession, workers = 1)
+  on.exit(future::plan(old), add = TRUE)
+  out <- suppressMessages(plan_model_set(list(chains = 4), 5))
+  expect_null(out$brm_args$cores)
+  expect_message(plan_model_set(list(chains = 4), 5),
+                 "resolves to a single worker")
+  # More than one worker still gets the clamp.
+  many <- suppressMessages(with_parallel_plan(plan_model_set(list(), 5)))
+  expect_identical(many$brm_args$cores, 1)
+})
+
+test_that("only what the applied function names travels to a worker", {
+  # future exports the applied function with its enclosing environment, so an
+  # ordinary closure written inside bnec() or amend_model_set() would ship
+  # every object those functions have built -- for amend(), every fit already
+  # in the set. narrow_environment() is what stops that, and it is applied on
+  # the sequential path too so that a name left out of its list fails on the
+  # first ordinary call rather than only for whoever sets a plan.
+  bulky <- matrix(0, 500, 500)
+  build <- function() {
+    hidden <- bulky
+    wanted <- 1:3
+    narrow_environment(function(m) wanted[m], list(wanted = wanted))
+  }
+  fn <- build()
+  expect_identical(fn(2), 2L)
+  expect_identical(ls(environment(fn)), "wanted")
+  expect_false(exists("hidden", envir = environment(fn)))
+  # Package internals still resolve, because the namespace is the parent.
+  expect_identical(parent.env(environment(fn)), asNamespace("bayesnec"))
+})
+
 test_that("future's own seeding would have changed those draws", {
   skip_unless_future()
   # The evidence for restoring RNGkind inside the worker, kept as a test
@@ -174,11 +241,6 @@ test_that("future's own seeding would have changed those draws", {
     future.apply::future_lapply(1:4, draw, future.seed = TRUE)
   })
   expect_false(isTRUE(all.equal(unrestored, sequential)))
-  kind <- with_parallel_plan(
-    future.apply::future_lapply(1, function(i) RNGkind()[1],
-                                future.seed = TRUE)[[1]]
-  )
-  expect_identical(kind, "L'Ecuyer-CMRG")
 })
 
 test_that("a failing element yields its condition and the rest still run", {
@@ -215,9 +277,6 @@ test_that("a failing element yields its condition and the rest still run", {
 })
 
 test_that("a model set fitted in parallel reproduces the sequential fit", {
-  if (Sys.getenv("NOT_CRAN") == "") {
-    skip_on_cran()
-  }
   skip_unless_future()
   # The acceptance criterion end to end, on the smallest set that exercises it:
   # two models, two chains, 200 iterations, one seed. Asserted on the posterior
@@ -249,6 +308,11 @@ test_that("a model set fitted in parallel reproduces the sequential fit", {
   })
   expect_s3_class(parallel, "bayesmanecfit")
   expect_identical(names(parallel$mod_fits), names(sequential$mod_fits))
+  # The fitted models are what reproduces. w_draw_seed and w_draw_index do not,
+  # and are deliberately not asserted here: expand_manec() draws them from the
+  # ambient RNG stream, which the parallel loop cannot leave in the state the
+  # sequential loop leaves it in. The test above pins what is true instead --
+  # that the loop does not disturb the caller's stream at all.
   for (m in names(sequential$mod_fits)) {
     expect_equal(
       brms::as_draws_matrix(parallel$mod_fits[[m]]$fit),
@@ -259,9 +323,6 @@ test_that("a model set fitted in parallel reproduces the sequential fit", {
 })
 
 test_that("a timeout ends a parallel run exactly as it ends a sequential one", {
-  if (Sys.getenv("NOT_CRAN") == "") {
-    skip_on_cran()
-  }
   skip_unless_future()
   skip_if_not_installed("R.utils")
   # timeout is the only way to make a model fail on demand without inventing

--- a/tests/testthat/test-parallel_models.R
+++ b/tests/testthat/test-parallel_models.R
@@ -15,6 +15,27 @@ with_parallel_plan <- function(code, workers = 2) {
   code
 }
 
+# Run `code` under a forking plan. Skips where forking is unavailable, which
+# is Windows, and RStudio or Positron everywhere.
+#
+# multisession is the backend the rest of the file uses because it is available
+# on every platform and serialises the round trip. Forking takes a different
+# path through all three of the things this file is about: the worker inherits
+# the parent's memory rather than being sent globals, it inherits the RNG state
+# at the fork rather than being given a stream, and it shares the parent's
+# stderr. None of that is exercised by multisession, so on the platforms where
+# forking works it is worth checking that the same guarantees hold.
+with_fork_plan <- function(code, workers = 2) {
+  skip_if_not_installed("parallelly")
+  skip_if_not(parallelly::supportsMulticore(),
+              "forking is not available on this platform")
+  old_limit <- options(parallelly.maxWorkers.localhost = Inf)
+  on.exit(options(old_limit), add = TRUE)
+  old <- future::plan(future::multicore, workers = workers)
+  on.exit(future::plan(old), add = TRUE)
+  code
+}
+
 skip_unless_future <- function() {
   skip_on_cran()
   skip_if_not_installed("future")
@@ -149,6 +170,41 @@ test_that("the initial-value search draws the same values in a worker", {
     bnec_model_lapply(models, draw_inits, parallel = TRUE)
   }))
   expect_identical(parallel, sequential)
+})
+
+test_that("a forking plan gives the same guarantees as a socket one", {
+  skip_unless_future()
+  # The three assertions this file turns on, run through the fork path. A
+  # forked worker inherits the parent's RNG state at the fork instead of being
+  # given a stream, so the kind restore has to hold there for a different
+  # reason than it does under multisession, and it is the backend on which
+  # sharing the parent's memory could hide a missing binding in
+  # narrow_environment().
+  draw <- function(i) {
+    set.seed(100 + i)
+    stats::runif(3)
+  }
+  sequential <- bnec_model_lapply(1:4, draw, parallel = FALSE)
+  set.seed(9)
+  before <- get(".Random.seed", envir = globalenv())
+  parallel <- with_fork_plan(bnec_model_lapply(1:4, draw, parallel = TRUE))
+  expect_identical(parallel, sequential)
+  expect_identical(get(".Random.seed", envir = globalenv()), before)
+  # And the failure contract, which under forking returns the try-error
+  # through shared memory rather than through serialisation.
+  out <- with_fork_plan(bnec_model_lapply(1:3, function(i) {
+    try(
+      if (i == 2) {
+        stop(fit_failure_condition("nec3param", "boom", NULL, NULL))
+      } else {
+        i
+      },
+      silent = TRUE
+    )
+  }, parallel = TRUE))
+  expect_true(inherits(out[[2]], "try-error"))
+  expect_identical(out[[3]], 3L)
+  expect_true(inherits(attr(out[[2]], "condition"), "bnec_fit_failure"))
 })
 
 test_that("a parallel run leaves the caller's RNG stream where it was", {

--- a/tests/testthat/test-parallel_models.R
+++ b/tests/testthat/test-parallel_models.R
@@ -1,0 +1,286 @@
+# Run `code` under a multisession plan, restoring the caller's plan after.
+#
+# multisession rather than multicore: it is the only backend available on every
+# platform bayesnec is checked on, and it is the one that serialises globals
+# and results, so it exercises the round trip that a forking backend skips.
+with_parallel_plan <- function(code, workers = 2) {
+  # setup.R sets mc.cores = 1 so that the suite does not oversubscribe, and
+  # parallelly reads that as the core budget and warns about every worker past
+  # the first. Raised for the duration of the call rather than suppressed at
+  # each site, so the warning is still available where it means something.
+  old_limit <- options(parallelly.maxWorkers.localhost = Inf)
+  on.exit(options(old_limit), add = TRUE)
+  old <- future::plan(future::multisession, workers = workers)
+  on.exit(future::plan(old), add = TRUE)
+  code
+}
+
+skip_unless_future <- function() {
+  skip_on_cran()
+  skip_if_not_installed("future")
+  skip_if_not_installed("future.apply")
+}
+
+# A multisession worker loads the INSTALLED bayesnec, not one loaded with
+# pkgload::load_all(), so under devtools::test() against an older installation
+# the internals these tests exercise are simply absent and every parallel
+# assertion fails for a reason that has nothing to do with the code under test.
+# R CMD check installs the package first, so this skip does not fire there.
+# Measured 2026-09-11, R 4.6.1, future 1.70.0: a load_all() session reports
+# "object 'bnec_model_lapply' not found" from a multisession worker and works
+# under multicore, which forks and so inherits the loaded namespace.
+skip_unless_worker_sees_internals <- function() {
+  ok <- tryCatch(
+    future.apply::future_lapply(1, function(i) {
+      exists("bnec_model_lapply", envir = asNamespace("bayesnec"),
+             inherits = FALSE)
+    }, future.seed = TRUE)[[1]],
+    error = function(e) FALSE
+  )
+  skip_if(!isTRUE(ok),
+          "worker cannot reach the bayesnec internals under test")
+}
+
+test_that("a sequential plan is not a parallel one, and a multisession is", {
+  skip_unless_future()
+  old <- future::plan(future::sequential)
+  on.exit(future::plan(old), add = TRUE)
+  expect_false(bnec_plan_is_parallel())
+  expect_true(with_parallel_plan(bnec_plan_is_parallel()))
+})
+
+test_that("fewer than two models to fit is never parallel", {
+  skip_unless_future()
+  # A parallel plan provides no benefit over one brm() call, and treating it as
+  # parallel would set cores = 1 and so make a lone fit slower than it is
+  # today. amend() reaches this whenever the amended set needs no new fit.
+  out <- with_parallel_plan(plan_model_set(list(chains = 4), 1))
+  expect_false(out$parallel)
+  expect_identical(out$brm_args, list(chains = 4))
+  out0 <- with_parallel_plan(plan_model_set(list(), 0))
+  expect_false(out0$parallel)
+})
+
+test_that("a parallel set samples its chains in sequence unless told not to", {
+  skip_unless_future()
+  out <- suppressMessages(
+    with_parallel_plan(plan_model_set(list(chains = 4), 5))
+  )
+  expect_true(out$parallel)
+  expect_identical(out$brm_args$cores, 1)
+  # A cores the user supplied is left alone: nesting the two levels is a
+  # legitimate thing to want, and this argument is how it is asked for.
+  kept <- suppressMessages(
+    with_parallel_plan(plan_model_set(list(chains = 4, cores = 2), 5))
+  )
+  expect_true(kept$parallel)
+  expect_identical(kept$brm_args$cores, 2)
+  expect_message(with_parallel_plan(plan_model_set(list(), 5)),
+                 "Fitting 5 models in parallel")
+  # amend() has no `...` to pass brms arguments through, so the advice bnec()
+  # gives about nesting the two levels does not apply there and is not given.
+  expect_message(
+    with_parallel_plan(plan_model_set(list(), 5, caller = "amend")),
+    "refit the set with bnec"
+  )
+})
+
+test_that("no plan and no future leaves brm_args untouched", {
+  old <- if (requireNamespace("future", quietly = TRUE)) {
+    future::plan(future::sequential)
+  } else {
+    NULL
+  }
+  if (!is.null(old)) {
+    on.exit(future::plan(old), add = TRUE)
+  }
+  out <- plan_model_set(list(chains = 4), 23)
+  expect_false(out$parallel)
+  # No cores is added on the sequential path: adding one would change what
+  # every existing call passes to brm().
+  expect_identical(out$brm_args, list(chains = 4))
+})
+
+test_that("the sequential path is lapply() and leaves the RNG alone", {
+  seed_before <- {
+    set.seed(1)
+    get(".Random.seed", envir = globalenv())
+  }
+  out <- bnec_model_lapply(1:3, function(i) i^2, parallel = FALSE)
+  expect_identical(out, lapply(1:3, function(i) i^2))
+  expect_identical(get(".Random.seed", envir = globalenv()), seed_before)
+})
+
+test_that("a parallel run draws the same initial values as a sequential one", {
+  skip_unless_future()
+  # The acceptance criterion of #184, reduced to the mechanism it depends on.
+  # make_good_inits() opens with set.seed(brm_args$seed), so what has to hold
+  # is that the same seed produces the same draws in a worker as in the parent.
+  draw <- function(i) {
+    set.seed(100 + i)
+    stats::runif(3)
+  }
+  sequential <- bnec_model_lapply(1:4, draw, parallel = FALSE)
+  parallel <- with_parallel_plan({
+    skip_unless_worker_sees_internals()
+    bnec_model_lapply(1:4, draw, parallel = TRUE)
+  })
+  expect_identical(parallel, sequential)
+})
+
+test_that("the initial-value search draws the same values in a worker", {
+  skip_unless_future()
+  # The same assertion as above at the call site that matters, and without
+  # sampling anything. make_good_inits() is where bayesnec's reproducibility
+  # comes from: it opens with set.seed(seed), and the L'Ecuyer generator a
+  # worker is given would have changed every value it returns.
+  draw_inits <- function(model) {
+    fam <- brms::Beta(link = "identity")
+    pr <- define_prior(model, fam, nec_data$x, nec_data$y)
+    make_good_inits(model, nec_data$x, nec_data$y, family = fam,
+                    priors = pr, chains = 2, seed = 184)
+  }
+  models <- c("nec3param", "nec4param")
+  sequential <- suppressMessages(
+    bnec_model_lapply(models, draw_inits, parallel = FALSE)
+  )
+  parallel <- with_parallel_plan(suppressMessages({
+    skip_unless_worker_sees_internals()
+    bnec_model_lapply(models, draw_inits, parallel = TRUE)
+  }))
+  expect_identical(parallel, sequential)
+})
+
+test_that("future's own seeding would have changed those draws", {
+  skip_unless_future()
+  # The evidence for restoring RNGkind inside the worker, kept as a test
+  # because the failure it prevents is silent. future.seed = TRUE installs an
+  # L'Ecuyer-CMRG stream, set.seed() with the default kind = NULL does not put
+  # the generator back, and the same seed then draws from a different
+  # generator. Measured 2026-09-11 under future 1.70.0 on R 4.6.1: set.seed(43)
+  # then runif(1) gives 0.48503768 in the parent and 0.47899959 in a worker,
+  # under plan(sequential) as much as under plan(multisession).
+  #
+  # A failure here means future has changed how future.seed = TRUE seeds a
+  # worker, not that bayesnec is broken; the restore would then be redundant
+  # rather than wrong.
+  draw <- function(i) {
+    set.seed(100 + i)
+    stats::runif(3)
+  }
+  sequential <- lapply(1:4, draw)
+  unrestored <- with_parallel_plan({
+    skip_unless_worker_sees_internals()
+    future.apply::future_lapply(1:4, draw, future.seed = TRUE)
+  })
+  expect_false(isTRUE(all.equal(unrestored, sequential)))
+  kind <- with_parallel_plan(
+    future.apply::future_lapply(1, function(i) RNGkind()[1],
+                                future.seed = TRUE)[[1]]
+  )
+  expect_identical(kind, "L'Ecuyer-CMRG")
+})
+
+test_that("a failing element yields its condition and the rest still run", {
+  skip_unless_future()
+  # The NA-on-failure contract several downstream functions read. try() is
+  # inside the applied function, so an error becomes one element rather than
+  # aborting the batch -- which under a parallel plan would lose every model.
+  body <- function(i) {
+    try(
+      if (i == 2) {
+        stop(fit_failure_condition("nec3param", "boom", NULL, NULL))
+      } else {
+        i
+      },
+      silent = TRUE
+    )
+  }
+  check <- function(out) {
+    expect_true(inherits(out[[2]], "try-error"))
+    expect_identical(out[[1]], 1L)
+    expect_identical(out[[3]], 3L)
+    # failure_record() reads the condition off the try-error, and the custom
+    # fields fit_failure_condition() attaches have to survive the trip back
+    # from a worker or ?failed_models loses the priors and inits.
+    cnd <- attr(out[[2]], "condition")
+    expect_true(inherits(cnd, "bnec_fit_failure"))
+    expect_match(conditionMessage(cnd), "boom")
+  }
+  check(bnec_model_lapply(1:3, body, parallel = FALSE))
+  check(with_parallel_plan({
+    skip_unless_worker_sees_internals()
+    bnec_model_lapply(1:3, body, parallel = TRUE)
+  }))
+})
+
+test_that("a model set fitted in parallel reproduces the sequential fit", {
+  if (Sys.getenv("NOT_CRAN") == "") {
+    skip_on_cran()
+  }
+  skip_unless_future()
+  # The acceptance criterion end to end, on the smallest set that exercises it:
+  # two models, two chains, 200 iterations, one seed. Asserted on the posterior
+  # draws rather than on the whole object, which also stores the call.
+  #
+  # Both equations have to be valid for the family bnec() guesses, or the set
+  # collapses to one model, plan_model_set() declines to parallelise it, and
+  # the test passes while exercising nothing. nec_data is fitted as Beta with
+  # an identity link, for which ecxlin is dropped; nec3param and nec4param are
+  # both retained.
+  # Arguments for brm() are passed through bnec()'s `...`, not a list.
+  set_call <- function() {
+    suppressMessages(suppressWarnings(
+      bnec(y ~ crf(x, model = c("nec3param", "nec4param")), data = nec_data,
+           seed = 184, chains = 2, iter = 200, refresh = 0)
+    ))
+  }
+  sequential <- set_call()
+  # The skip reason names what came back. A set that collapsed to one model
+  # reports as a bayesnecfit here, which is a defect in this test rather than
+  # an environment that cannot sample, and the two are not otherwise
+  # distinguishable from a skipped run.
+  skip_if(!inherits(sequential, "bayesmanecfit"),
+          paste("expected a bayesmanecfit from the two-model set, got",
+                paste(class(sequential), collapse = "/")))
+  parallel <- with_parallel_plan({
+    skip_unless_worker_sees_internals()
+    set_call()
+  })
+  expect_s3_class(parallel, "bayesmanecfit")
+  expect_identical(names(parallel$mod_fits), names(sequential$mod_fits))
+  for (m in names(sequential$mod_fits)) {
+    expect_equal(
+      brms::as_draws_matrix(parallel$mod_fits[[m]]$fit),
+      brms::as_draws_matrix(sequential$mod_fits[[m]]$fit),
+      info = m
+    )
+  }
+})
+
+test_that("a timeout ends a parallel run exactly as it ends a sequential one", {
+  if (Sys.getenv("NOT_CRAN") == "") {
+    skip_on_cran()
+  }
+  skip_unless_future()
+  skip_if_not_installed("R.utils")
+  # timeout is the only way to make a model fail on demand without inventing
+  # data that fails for some other reason. What is asserted is agreement
+  # between the two plans rather than any particular outcome: whatever
+  # R.utils::withTimeout does to a fit, moving the fit into a worker must not
+  # change it. A timeout this short fires before brm() reaches the sampler, so
+  # nothing is compiled and the test spends no sampling time.
+  run <- function() {
+    suppressMessages(suppressWarnings(tryCatch(
+      bnec(y ~ crf(x, model = c("nec3param", "nec4param")), data = nec_data,
+           timeout = 0.001, seed = 184, chains = 2, iter = 200, refresh = 0),
+      error = conditionMessage
+    )))
+  }
+  sequential <- run()
+  parallel <- with_parallel_plan({
+    skip_unless_worker_sees_internals()
+    run()
+  })
+  expect_identical(parallel, sequential)
+})

--- a/tests/testthat/test-parallel_models.R
+++ b/tests/testthat/test-parallel_models.R
@@ -26,13 +26,17 @@ with_parallel_plan <- function(code, workers = 2) {
 # stderr. None of that is exercised by multisession, so on the platforms where
 # forking works it is worth checking that the same guarantees hold.
 with_fork_plan <- function(code, workers = 2) {
-  skip_if_not_installed("parallelly")
-  skip_if_not(parallelly::supportsMulticore(),
-              "forking is not available on this platform")
   old_limit <- options(parallelly.maxWorkers.localhost = Inf)
   on.exit(options(old_limit), add = TRUE)
-  old <- future::plan(future::multicore, workers = workers)
+  old <- suppressWarnings(future::plan(future::multicore, workers = workers))
   on.exit(future::plan(old), add = TRUE)
+  # future falls back to evaluating in the parent where forking is
+  # unavailable, and reports one worker when it does, so the worker count is
+  # the test for whether this platform actually forks. Asked of future rather
+  # than of supportsMulticore() in parallelly, a namespaced call to which is an
+  # undeclared import and fails R CMD check under error_on = "warning".
+  skip_if(future::nbrOfWorkers() < workers,
+          "forking is not available on this platform")
   code
 }
 
@@ -185,11 +189,15 @@ test_that("a forking plan gives the same guarantees as a socket one", {
     stats::runif(3)
   }
   sequential <- bnec_model_lapply(1:4, draw, parallel = FALSE)
-  set.seed(9)
-  before <- get(".Random.seed", envir = globalenv())
-  parallel <- with_fork_plan(bnec_model_lapply(1:4, draw, parallel = TRUE))
-  expect_identical(parallel, sequential)
-  expect_identical(get(".Random.seed", envir = globalenv()), before)
+  res <- with_fork_plan({
+    set.seed(9)
+    before <- get(".Random.seed", envir = globalenv())
+    out <- bnec_model_lapply(1:4, draw, parallel = TRUE)
+    list(out = out, before = before,
+         after = get(".Random.seed", envir = globalenv()))
+  })
+  expect_identical(res$out, sequential)
+  expect_identical(res$after, res$before)
   # And the failure contract, which under forking returns the try-error
   # through shared memory rather than through serialisation.
   out <- with_fork_plan(bnec_model_lapply(1:3, function(i) {
@@ -216,21 +224,31 @@ test_that("a parallel run leaves the caller's RNG stream where it was", {
   # parallel runs of one call would not agree with each other. It does not make
   # the draw match the sequential run's, which advances the stream by running
   # every init search in the parent; see ?bnec.
-  set.seed(9)
-  before <- get(".Random.seed", envir = globalenv())
-  out <- with_parallel_plan({
+  #
+  # The baseline is taken inside the plan and after the skip check, not before
+  # it. skip_unless_worker_sees_internals() calls future_lapply() itself, which
+  # advances the parent's stream; a baseline taken ahead of it is a state the
+  # loop was never given, and the comparison then fails for that reason alone.
+  # It did, on macOS, at 2026-09-11.
+  res <- with_parallel_plan({
     skip_unless_worker_sees_internals()
-    bnec_model_lapply(1:4, function(i) i, parallel = TRUE)
+    set.seed(9)
+    before <- get(".Random.seed", envir = globalenv())
+    out <- bnec_model_lapply(1:4, function(i) i, parallel = TRUE)
+    list(out = out, before = before,
+         after = get(".Random.seed", envir = globalenv()))
   })
-  expect_length(out, 4)
-  expect_identical(get(".Random.seed", envir = globalenv()), before)
-  # And with no stream to begin with, none is left behind.
-  suppressWarnings(rm(".Random.seed", envir = globalenv()))
-  with_parallel_plan({
+  expect_length(res$out, 4)
+  expect_identical(res$after, res$before)
+  # And with no stream to begin with, none is left behind. The removal comes
+  # after the skip check for the same reason.
+  left_behind <- with_parallel_plan({
     skip_unless_worker_sees_internals()
+    suppressWarnings(rm(".Random.seed", envir = globalenv()))
     bnec_model_lapply(1:2, function(i) i, parallel = TRUE)
+    exists(".Random.seed", envir = globalenv(), inherits = FALSE)
   })
-  expect_false(exists(".Random.seed", envir = globalenv(), inherits = FALSE))
+  expect_false(left_behind)
 })
 
 test_that("a one-worker parallel plan does not take chains away from brms", {


### PR DESCRIPTION
## What

`bnec()` and `amend()` now fit their model sets under whatever `future` plan is
set when they are called. Setting `plan(multisession, workers = 4)` before the
call fits four models at a time; no plan, or `plan(sequential)`, fits them one
at a time exactly as every earlier version did.

```r
library(future)
plan(multisession, workers = 4)
fit <- bnec(y ~ crf(x, model = "decline"), data = my_data, seed = 17)
plan(sequential)
```

There is no new argument to `bnec()` and no new hard dependency. `future` and
`future.apply` are Suggests, reached through `requireNamespace()` the way
`R.utils` is for `timeout`.

## Why it matters

A 23-model run is 23 sequential `brm()` calls, each of which leaves most of the
machine idle. Fitting the models at the same time is the largest speed-up
available for a multi-model run, which is the normal way the package is used.

Two things had to be made true rather than assumed, and the first is the reason
this issue was held for attended work:

**Each fitted model reproduces exactly under a parallel plan, for the same
seed.** It would not have, by default, and nothing would have said so.
`future.seed = TRUE` installs an L'Ecuyer-CMRG generator in each worker.
`make_good_inits()` seeds the initial-value search with
`set.seed(brm_args$seed)`, and `set.seed()` called with the default
`kind = NULL` sets a seed without restoring the generator kind. The same seed
therefore draws from a different generator in a worker, and the fits differ. No
error, no warning. The worker now restores the parent's RNG kind before fitting.

**The model-averaged quantities are the exception, and it is stated rather than
papered over.** After the models are fitted, `expand_manec()` draws a seed from
the session's RNG stream and uses it to decide which posterior draws each
equation contributes to the averaged estimate. Fitted in sequence, that stream
has been advanced by every model's initial-value search and so is fixed by
`seed`; fitted in parallel those searches run in workers and it is not. The
averaged `nec`, its interval and the stored prediction grid therefore differ
between the two plans, as two valid realisations of the same weighting.

`bnec()` now leaves the stream undisturbed under a parallel plan, so
`set.seed()` in the calling session fixes that draw and two parallel runs agree
— which is what `expand_manec()` says the draw is for (#216). Closing the
remaining gap means deriving it from `seed` rather than from the ambient stream,
which is a change to `expand_manec()` and to what #216 decided deliberately. It
is not attempted here.

**Chains are sampled in sequence inside each worker.** `brm()` parallelises
across chains already, so models in parallel on top of that requests
`workers x chains` processes, which on most machines is slower than fitting in
sequence. Under a parallel plan of more than one worker `bnec()` therefore
passes `cores = 1` to `brm()`. A `cores` you passed yourself is left alone and
reaches `brm()` through `...` as it always did, which is how the two levels are
nested deliberately: `bnec(..., cores = 2)` with `workers = 4` runs four worker
processes sampling eight chains between them.

Worth being exact about what the clamp prevents, because the obvious account of
it is wrong and this PR asserted it for two rounds. `future` sets `mc.cores` to
1 inside a worker of its own accord, so a value set in a profile does not in
fact reach `brms` there — measured at 1 under `multisession`, `multicore` and
`cluster` with `options(mc.cores = 7)` in `R_PROFILE_USER`. `cores = 1` is
therefore belt and braces, not the only thing standing between you and sixteen
processes. It is kept because it makes what `brms` is asked to do a property of
this package rather than of `future`'s internals.

A plan that names a parallel strategy can still resolve to a single worker —
`plan(multicore)` does exactly that wherever forking is unavailable, which is
Windows, and RStudio or Positron on Linux and macOS. Clamping there would fit one
model at a time with its chains in sequence, slower than the current release for
anyone who has set `mc.cores`. Neither the clamp nor the parallel announcement
applies in that case.

## Evidence

The `future`/WSL testing pass this issue asked for before implementation is
posted as a comment on #184. In summary: all five local backends work under WSL2
(`sequential`, `multisession`, `multicore`, `cluster`, and an explicit
`makeClusterPSOCK`), as do five plan transitions within one session; `try()` and
custom conditions survive the round trip; `R.utils::withTimeout` still fires
inside a worker; and the trouble reported under WSL was not reproduced across
three runs.

The RNG defect above, measured 2026-09-11 under R 4.6.1, `future` 1.70.0, on
every backend including `plan(sequential)`:

| body | parent | worker |
|---|---|---|
| `set.seed(43); runif(1)` | 0.48503768 | 0.47899959 |

Restoring the RNG kind removes the difference on all five backends.

No timing is reported. The development machine was running three other R
sessions' simulations throughout, and a wall-clock figure taken under that load
would not mean anything. What the mechanism does to run time on an idle machine
is therefore not established by this PR, and the acceptance criterion asking for
a measured speed-up is not met. The correctness criteria are.

Three further measurements, all made while responding to review:

| what | before | after |
|---|---|---|
| applied function, serialised, over an 8 MB object in the calling frame | 7.630 MiB | 0.000 MiB |
| `draw_seed` over two parallel runs of one call | differed | identical, and equal to an undisturbed stream |
| `cores` under `plan(multicore, workers = 4)` with forking unavailable | 1 | unset |

`future` exports the applied function together with its enclosing environment,
and that environment was the `bnec()` or `amend_model_set()` frame — which holds
the data, the model frame, the priors, and for `amend()` every fit already in the
set. `narrow_environment()` rebuilds the function with only the names it reads,
parented on the package namespace. It is applied on the sequential path too, so a
name left out of the list fails on the first ordinary call rather than only for
whoever sets a plan.

`future_lapply()` also chunks one-per-worker by default, so a worker held every
fit in its chunk until the chunk finished and a worker drawing the slow equations
set the wall clock. `future.chunk.size = 1` assigns dynamically and holds one fit
at a time.

Compilation is not duplicated by this change. Each bayesnec equation is a
distinct Stan program, so a set of *n* models compiles *n* programs whether they
are fitted in sequence or at the same time; what changes is that the compiles
overlap. The `cmdstanr` backend #308 adopted caches a compiled program by the
hash of its Stan source, so a second run of the same set reuses it, which is
strictly better under a parallel plan than under a sequential one.

<details>
<summary>Implementation detail</summary>

### Files

`R/parallel_models.R` is new and holds three internals:

- `bnec_plan_is_parallel()` reads the strategy off `future::plan("list")[[1]]`
  rather than counting workers. A `cluster` plan pointed at one remote node
  reports a single worker but is still a parallel plan, and the question is
  whether the user asked for one. Returns `FALSE` where either package is
  absent, which is what keeps the sequential path free of the dependency.
- `plan_model_set(brm_args, n_models)` makes the decision and returns the
  `brm_args` that go with it, so the two are made in one place and cannot
  disagree. Fewer than two models to fit is never parallel: a parallel plan
  provides no benefit over one `brm()` call, and applying the `cores` limit to a
  lone fit would make it slower than it is today. It also reports what it
  decided, because a parallel run emits its per-model messages out of order or
  not at all.
- `bnec_model_lapply(X, FUN, parallel)` is `lapply()` when `parallel` is
  `FALSE`, which is every call made today, and `future.apply::future_lapply()`
  with the RNG-kind restore when it is not.

`R/bnec.R` and `R/amend.R` each replace their `for` loop with a call to
`bnec_model_lapply()`. `try()` stays *inside* the applied function: the
`NA`-on-failure contract is what several downstream functions read, and an error
escaping a worker aborts the whole batch rather than one model of it. The
assembly of `mod_fits` and `failed` stays in the parent, so what the applied
function returns is exactly what the sequential path returned -- the fit, or the
`try-error` holding its condition -- and `failure_record()` reads the same object
either way.

`amend()` needed one thing `bnec()` did not. Its loop carries an existing fit
over from `old_fits` without a `brm()` call, and returning those from the applied
function would serialise every existing fit out to a worker and straight back for
a model that is not refitted -- the memory hazard the issue raises, incurred for
nothing. Carry-over is done in the parent and only the models needing a fit reach
the applied function, which is also what `plan_model_set()` counts.

### `future.seed = TRUE`, with the kind restored

`future.seed = NULL` also gives draws matching `lapply()`, and was checked rather
than assumed: it is silent, and only `future.seed = FALSE` reports
`UNRELIABLE VALUE`. It was not chosen because it leaves the worker's RNG state to
the backend, making correctness a property of every code path inside
`fit_bayesnec()` seeding itself rather than of the dispatcher.

Restoring the kind discards the L'Ecuyer stream, and does not leave workers
drawing in step: `RNGkind()` re-initialises `.Random.seed` from the clock and
process id. Measured under `plan(multicore, workers = 3)`, three of three draws
distinct, with the restore in place as without it.

Where no seed is supplied, the search calls `set.seed(NULL)` and reseeds from
entropy, so no run repeats under any plan. That is what the package does today.

### Tests

`tests/testthat/test-parallel_models.R`. The plan is restored after each test and
the whole file skips on CRAN.

- the sequential path is `lapply()` and leaves `.Random.seed` untouched;
- `plan_model_set()` declines to parallelise fewer than two models, sets
  `cores = 1` when it does, and leaves a supplied `cores` alone;
- a parallel run draws the same values from the same seed as a sequential one --
  the acceptance criterion, reduced to the mechanism it depends on;
- a canary asserting that `future`'s own seeding *would* have changed those
  draws. A failure there means `future` changed how it seeds a worker, not that
  bayesnec is broken, and the comment says so;
- a failing element yields its `try-error` with the `bnec_fit_failure` condition
  and its fields intact, and the rest still run, on both paths;
- the initial-value search itself draws the same values in a worker as in the
  parent for the same seed, which is the same assertion at the call site that
  matters and costs no sampling time;
- the parallel loop leaves the caller's `.Random.seed` exactly as it found it,
  and leaves none behind where there was none;
- a one-worker parallel plan does not take chains away from `brms`;
- the applied function's environment holds only what it names, and is parented
  on the namespace;
- a two-model `bnec()` set fitted under `plan(multisession)` reproduces the
  sequential fit draw for draw. This one is not cheap: it compiles four Stan
  programs. It is kept because it is the acceptance criterion stated end to end
  rather than at the mechanism;
- a timeout ends a parallel run exactly as it ends a sequential one.

Two things about that last one. `timeout = 0.001` lets the `TimeoutException`
escape `fit_bayesnec()`'s `tryCatch` rather than being recorded as a failure --
identically under both plans, so it is pre-existing behaviour and not something
this change introduced. The test asserts the two agree rather than asserting an
outcome. Worth a separate issue if it is not already one.

### A development trap worth knowing

A `multisession` or `cluster` worker loads the **installed** bayesnec, not one
loaded with `pkgload::load_all()`. Under `devtools::test()` against an older
installation a worker reports `object 'bnec_model_lapply' not found`;
`multicore`, which forks, inherits the loaded namespace. `R CMD check` installs
first, so CI is unaffected, and the test file detects this and skips with a
reason rather than failing. It is also stated in `?bnec`.

Relatedly, `future` sets the plan inside a worker to `sequential`, so a `bnec()`
call made from within one does not parallelise again.

### Out of scope, as the issue asks

`bnec_hurdle()`'s two components stay sequential; each of its `bnec()` calls uses
the plan for its own model set. Nothing in `expand_manec()` or the post-fit path
is changed.

</details>

Addresses #184. Not marked as closing it: the issue's acceptance criteria
include a measured speed-up including compilation, and no timing is reported
here for the reason given above. The correctness criteria are met. Whether to
close on this PR and open a separate benchmarking issue, or hold #184 open for
it, is your call.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgdwdPQL8KNApFDgYWkPeK

