### PR TITLE
Supply the model-averaging weight default wherever a set is assembled

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bayesnec
 Title: A Bayesian No-Effect- Concentration (NEC) Algorithm
-Version: 2.1.3.33
+Version: 2.1.3.34
 Authors@R: c(person("Rebecca", "Fisher", email = "r.fisher@aims.gov.au", role = c("aut", "cre"),comment = c(ORCID = "0000-0001-5148-6731")), person("Diego R.","Barneche",role="aut",comment = c(ORCID = "0000-0002-4568-2362")), person("Gerard F.","Ricardo",role="aut",comment = c(ORCID = "0000-0002-2220-3971")), person("David R.","Fox",role="aut",comment = c(ORCID = "0000-0002-3178-7243")))
 Description: Implementation of No-Effect-Concentration estimation that uses 'brms' (see Burkner (2017)<doi:10.18637/jss.v080.i01>; Burkner (2018)<doi:10.32614/RJ-2018-017>; Carpenter 'et al.' (2017)<doi:10.18637/jss.v076.i01> to fit concentration(dose)-response data using Bayesian methods for the purpose of estimating 'ECx' values, but more particularly 'NEC' (see Fox (2010)<doi:10.1016/j.ecoenv.2009.09.012>), 'NSEC' (see Fisher and Fox (2023)<doi:10.1002/etc.5610>), and 'N(S)EC (see Fisher et al. 2023<doi:10.1002/ieam.4809>). A full description of this package can be found in Fisher 'et al.' (2024)<doi:10.18637/jss.v110.i05>. This package expands and supersedes an original version implemented in 'R2jags' (see Su and Yajima (2020)<https://CRAN.R-project.org/package=R2jags>; Fisher et al. (2020)<doi:10.5281/ZENODO.3966864>).
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -642,12 +642,12 @@
   method at all and reports and ignores one given to it. `amend()` and
   `pull_out()` already preserved the recorded method, but passed an unknown one
   on as `method = NULL`, which `loo` resolves to stacking; an unknown method is
-  now left for the default to fill. `update()`
-  did not preserve it at all and now does, since refitting a set is not a
-  request to reweight it. Because `loo_controls` names its `fitting` and
-  `weights` arguments separately, both `amend()` and `update()` read a call
-  that names only a LOO fitting argument as naming no method, so changing one
-  does not reweight the set as a side effect. `c()` and `+` take no
+  now left for the default to fill. `update()` did not preserve it at all and
+  now does, since refitting a set is not a request to reweight it. Because
+  `loo_controls` names its `fitting` and `weights` arguments separately, both
+  `amend()` and `update()` read a call that names only a LOO fitting argument
+  as naming no method, so changing one does not reweight the set as a side
+  effect. `c()` and `+` take no
   `loo_controls` argument, so they inherit the method where every object being
   combined that records one names the same method, and report the fallback to
   the default where two disagree.

--- a/NEWS.md
+++ b/NEWS.md
@@ -618,6 +618,35 @@
 
 ## Bug fixes
 
+- A model set assembled by `c()`, `+`, `amend()` or `update()` is now weighted
+  by pseudo-BMA, the documented default, rather than by stacking.
+  `expand_manec()` validated the `loo_controls` it was given but supplied no
+  default where the caller named no method, so `method` reached
+  `loo::loo_model_weights()` as `NULL`, `loo` applied its own default of
+  `"stacking"`, and `attr(mod_stats$wi, "method")` recorded nothing. The same
+  set fitted in a single `bnec()` call was weighted by pseudo-BMA, so the
+  weighting method --- and with it the model-averaged NEC, NSEC and ECx
+  estimates --- depended on how the set was assembled rather than on what was
+  requested. Combining single fits with `c()` is a documented workflow and is
+  how the training material introduces model averaging, so this was a common
+  path. Measured on the two packaged `manec_example` fits pulled out and
+  recombined (R 4.6.1, `loo` 2.8.0): stacking placed 0.892 of the weight on
+  `nec4param`, while pseudo-BMA placed between 0.821 and 0.862 over twenty
+  repeats --- it uses a Bayesian bootstrap and so is not deterministic ---
+  against the 0.827 recorded by the `bnec()` call that fitted them. The default
+  is supplied in `expand_manec()`, which is the one point every assembly route
+  reaches (#320).
+
+  Where the set being operated on records a method, that method is kept rather
+  than replaced by the default. `amend()` and `pull_out()` already preserved
+  it, but passed an unknown method on as `method = NULL`, which `loo` resolves
+  to stacking; an unknown method is now left for the default to fill.
+  `update()` did not preserve it at all and now does, since refitting a set is
+  not a request to reweight it. `c()` and `+` take no `loo_controls` argument,
+  so they inherit the method where every object being combined that records one
+  names the same method, and report the fallback to the default where two
+  disagree.
+
 - `dispersion()` no longer discards the statistic where a single observation is
   reproduced exactly. The Pearson denominator is the fitted standard deviation,
   which underflows to exactly zero for a curve that decays fast enough --- `mu

--- a/NEWS.md
+++ b/NEWS.md
@@ -638,9 +638,11 @@
   reaches (#320).
 
   Where the set being operated on records a method, that method is kept unless
-  the caller names another. `amend()` and `pull_out()` already preserved it,
-  but passed an unknown method on as `method = NULL`, which `loo` resolves to
-  stacking; an unknown method is now left for the default to fill. `update()`
+  the caller names another --- `pull_out()` excepted, which takes no weighting
+  method at all and reports and ignores one given to it. `amend()` and
+  `pull_out()` already preserved the recorded method, but passed an unknown one
+  on as `method = NULL`, which `loo` resolves to stacking; an unknown method is
+  now left for the default to fill. `update()`
   did not preserve it at all and now does, since refitting a set is not a
   request to reweight it. Because `loo_controls` names its `fitting` and
   `weights` arguments separately, both `amend()` and `update()` read a call

--- a/NEWS.md
+++ b/NEWS.md
@@ -637,15 +637,18 @@
   is supplied in `expand_manec()`, which is the one point every assembly route
   reaches (#320).
 
-  Where the set being operated on records a method, that method is kept rather
-  than replaced by the default. `amend()` and `pull_out()` already preserved
-  it, but passed an unknown method on as `method = NULL`, which `loo` resolves
-  to stacking; an unknown method is now left for the default to fill.
-  `update()` did not preserve it at all and now does, since refitting a set is
-  not a request to reweight it. `c()` and `+` take no `loo_controls` argument,
-  so they inherit the method where every object being combined that records one
-  names the same method, and report the fallback to the default where two
-  disagree.
+  Where the set being operated on records a method, that method is kept unless
+  the caller names another. `amend()` and `pull_out()` already preserved it,
+  but passed an unknown method on as `method = NULL`, which `loo` resolves to
+  stacking; an unknown method is now left for the default to fill. `update()`
+  did not preserve it at all and now does, since refitting a set is not a
+  request to reweight it. Because `loo_controls` names its `fitting` and
+  `weights` arguments separately, both `amend()` and `update()` read a call
+  that names only a LOO fitting argument as naming no method, so changing one
+  does not reweight the set as a side effect. `c()` and `+` take no
+  `loo_controls` argument, so they inherit the method where every object being
+  combined that records one names the same method, and report the fallback to
+  the default where two disagree.
 
 - `dispersion()` no longer discards the statistic where a single observation is
   reproduced exactly. The Pearson denominator is the fitted standard deviation,

--- a/R/amend.R
+++ b/R/amend.R
@@ -194,7 +194,11 @@ amend_model_set <- function(object, mod_fits, old_method, drop = NULL,
   if (!is.null(loo_controls)) {
     fam_tag <- mod_fits[[1]]$fit$family$family
     loo_controls <- validate_loo_controls(loo_controls, fam_tag)
-    if (!"method" %in% names(loo_controls$weights)) {
+    # is.null() rather than a name test, for the reason define_loo_controls()
+    # gives: a name present with a NULL value is not a request for a method,
+    # and reading it as one had the two functions disagree about the same
+    # argument.
+    if (is.null(loo_controls$weights$method)) {
       loo_controls$weights$method <- old_method
     }
     is_new_method_old <- identical(loo_controls$weights$method, old_method)

--- a/R/amend.R
+++ b/R/amend.R
@@ -82,7 +82,7 @@ amend.bayesmanecfit <- function(object, drop, add, loo_controls, x_range = NA,
 
   amend_model_set(
     object = object, mod_fits = object$mod_fits,
-    old_method = attributes(object$mod_stats$wi)$method,
+    old_method = fit_weights_method(object),
     drop = if (missing(drop)) NULL else drop,
     add = if (missing(add)) NULL else add,
     loo_controls = if (missing(loo_controls)) NULL else loo_controls,
@@ -207,10 +207,12 @@ amend_model_set <- function(object, mod_fits, old_method, drop = NULL,
       }
     }
   } else {
-    # A bayesnecfit carries no weighting method, so leave `weights` empty
-    # rather than passing method = NULL down to loo_model_weights().
-    old_weights <- if (is.null(old_method)) list() else list(method = old_method)
-    loo_controls <- list(fitting = list(), weights = old_weights)
+    # A bayesnecfit records no weighting method, so leave `weights` empty
+    # rather than passing method = NULL down to loo_model_weights(), which
+    # resolves it to stacking. expand_manec() fills an empty `weights` with the
+    # documented default. See #320.
+    loo_controls <- list(fitting = list(),
+                         weights = weights_controls(old_method))
   }
   bnec_rec <- attr(object, "bnec_record")
   model_set <- names(mod_fits)

--- a/R/bnec.R
+++ b/R/bnec.R
@@ -29,11 +29,9 @@
 #' (via "fitting") or to \code{\link[loo]{loo_model_weights}} (via "weights").
 #' If no \code{method} is named in "weights", \pkg{bayesnec} sets the
 #' \code{method} argument of \code{\link[loo]{loo_model_weights}} to
-#' "pseudobma". This applies to every route that assembles a model set, not
-#' only to \code{\link{bnec}}: \code{\link{amend}}, \code{\link{pull_out}}
-#' and \code{update} preserve the method the set being operated on was built
-#' with, and \code{\link[base]{c}} and \code{+} inherit it where the objects
-#' being combined agree, falling back to "pseudobma" otherwise. See
+#' "pseudobma", whichever function assembles the model set. A function that
+#' operates on an existing set instead keeps the method that set was built
+#' with, unless the caller names another. See
 #' ?\code{\link[loo]{loo_model_weights}} for further info.
 #' @param x_var Removed in version 2.0. Use formula instead. Used to be a
 #' \code{\link[base]{character}} indicating the column heading

--- a/R/bnec.R
+++ b/R/bnec.R
@@ -29,10 +29,12 @@
 #' (via "fitting") or to \code{\link[loo]{loo_model_weights}} (via "weights").
 #' If no \code{method} is named in "weights", \pkg{bayesnec} sets the
 #' \code{method} argument of \code{\link[loo]{loo_model_weights}} to
-#' "pseudobma", whichever function assembles the model set. A function that
-#' operates on an existing set instead keeps the method that set was built
-#' with, unless the caller names another. See
-#' ?\code{\link[loo]{loo_model_weights}} for further info.
+#' "pseudobma", whichever function assembles the model set.
+#' \code{\link{amend}}, \code{update} and \code{\link[base]{c}} operate on
+#' an existing set and keep the method that set was built with, unless the
+#' caller names another. \code{\link{pull_out}} takes no weighting method at
+#' all: it reports and ignores one given in "weights" and always keeps the
+#' set's own. See ?\code{\link[loo]{loo_model_weights}} for further info.
 #' @param x_var Removed in version 2.0. Use formula instead. Used to be a
 #' \code{\link[base]{character}} indicating the column heading
 #' containing the predictor (concentration) variable.

--- a/R/bnec.R
+++ b/R/bnec.R
@@ -30,11 +30,13 @@
 #' If no \code{method} is named in "weights", \pkg{bayesnec} sets the
 #' \code{method} argument of \code{\link[loo]{loo_model_weights}} to
 #' "pseudobma", whichever function assembles the model set.
-#' \code{\link{amend}}, \code{update} and \code{\link[base]{c}} operate on
-#' an existing set and keep the method that set was built with, unless the
-#' caller names another. \code{\link{pull_out}} takes no weighting method at
-#' all: it reports and ignores one given in "weights" and always keeps the
-#' set's own. See ?\code{\link[loo]{loo_model_weights}} for further info.
+#' \code{\link{amend}} and \code{update} operate on an existing set and keep
+#' the method that set was built with, unless the caller names another.
+#' \code{\link{pull_out}} takes no weighting method at all: it reports and
+#' ignores one given in "weights" and always keeps the set's own.
+#' \code{\link[base]{c}} and \code{+} take no \code{loo_controls} argument;
+#' see \code{\link{c.bnecfit}} for how they decide the method. See
+#' ?\code{\link[loo]{loo_model_weights}} for further info.
 #' @param x_var Removed in version 2.0. Use formula instead. Used to be a
 #' \code{\link[base]{character}} indicating the column heading
 #' containing the predictor (concentration) variable.

--- a/R/bnec.R
+++ b/R/bnec.R
@@ -27,10 +27,14 @@
 #' ("fitting" and/or "weights"), each being a named \code{\link[base]{list}}
 #' containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 #' (via "fitting") or to \code{\link[loo]{loo_model_weights}} (via "weights").
-#' If "weights" is
-#' not provided by the user, \code{\link{bnec}} will set the default
-#' \code{method} argument in \code{\link[loo]{loo_model_weights}} to
-#' "pseudobma". See ?\code{\link[loo]{loo_model_weights}} for further info.
+#' If no \code{method} is named in "weights", \pkg{bayesnec} sets the
+#' \code{method} argument of \code{\link[loo]{loo_model_weights}} to
+#' "pseudobma". This applies to every route that assembles a model set, not
+#' only to \code{\link{bnec}}: \code{\link{amend}}, \code{\link{pull_out}}
+#' and \code{update} preserve the method the set being operated on was built
+#' with, and \code{\link[base]{c}} and \code{+} inherit it where the objects
+#' being combined agree, falling back to "pseudobma" otherwise. See
+#' ?\code{\link[loo]{loo_model_weights}} for further info.
 #' @param x_var Removed in version 2.0. Use formula instead. Used to be a
 #' \code{\link[base]{character}} indicating the column heading
 #' containing the predictor (concentration) variable.

--- a/R/bnec_group.R
+++ b/R/bnec_group.R
@@ -173,14 +173,20 @@ bnec_group <- function(formula, data, group_var, family = NULL, ...) {
   allot_class(out, c("bayesnecgroupfit", "bnecfit"))
 }
 
-#' The weighting method a single fit actually used
+#' The weighting method a fit actually used
 #'
 #' \code{expand_manec()} stamps it on the weight vector. The attribute does not
-#' survive row-subsetting of \code{mod_stats}, and a single-model level is a
+#' survive row-subsetting of \code{mod_stats}, and a single-model fit is a
 #' bayesnecfit with no \code{mod_stats}, so an absent attribute means "unknown"
 #' rather than "pseudo-BMA" and contributes nothing.
 #'
-#' @param x A fit for one level.
+#' Read per level by \code{crossed_group_weights()}, and on the whole object by
+#' \code{\link{amend}}, \code{\link{pull_out}}, \code{\link[base]{c}} and
+#' \code{update()}, each of which preserves the method of the set it operates
+#' on. See #320.
+#'
+#' @param x A fitted object, or one level of a
+#' \code{\link{bayesnecgroupfit}}.
 #'
 #' @return A length-1 \code{\link[base]{character}}, or \code{NULL}.
 #'

--- a/R/bnec_group.R
+++ b/R/bnec_group.R
@@ -173,7 +173,7 @@ bnec_group <- function(formula, data, group_var, family = NULL, ...) {
   allot_class(out, c("bayesnecgroupfit", "bnecfit"))
 }
 
-#' The weighting method a fit actually used
+#' The weighting method a fit was built with
 #'
 #' \code{expand_manec()} stamps it on the weight vector. The attribute does not
 #' survive row-subsetting of \code{mod_stats}, and a single-model fit is a

--- a/R/bnecfit-methods.R
+++ b/R/bnecfit-methods.R
@@ -2,6 +2,15 @@
 #' \code{\link{bayesmanecfit}} object containing Bayesian model averaging
 #' statistics.
 #'
+#' @details The combined set is weighted by the method the objects being
+#' combined were weighted by, where every input that records one names the same
+#' method. Where none records a method --- combining two
+#' \code{\link{bayesnecfit}} objects, for instance --- or where two inputs
+#' disagree, the \pkg{bayesnec} default of "pseudobma" is used and the
+#' disagreement is reported. \code{\link[base]{c}} takes no
+#' \code{loo_controls} argument; use \code{\link{amend}} to set the
+#' weighting method explicitly.
+#'
 #' @param x An object of class \code{\link{bnecfit}}.
 #' @param ... Additional objects of class \code{\link{bnecfit}}.
 #'
@@ -39,7 +48,23 @@ c.bnecfit <- function(x, ...) {
   }
   mod_fits <- mod_fits[!duplicated(names(mod_fits))]
   formulas <- lapply(mod_fits, extract_formula)
-  out <- expand_manec(mod_fits, formulas)
+  # c() has no loo_controls argument, so the only place an explicit weighting
+  # request can come from is the objects being combined. Inherited where every
+  # input that records a method names the same one, which is what amend() and
+  # pull_out() do for the set they operate on; otherwise the documented default
+  # is supplied by expand_manec(). Two inputs weighted differently have no
+  # answer that is right for both, so the fallback is reported rather than
+  # chosen silently. See #320.
+  methods_in <- unique(unlist(lapply(c(list(x), dots), fit_weights_method)))
+  if (length(methods_in) > 1) {
+    message("The objects being combined were weighted by different methods (",
+            paste0(methods_in, collapse = ", "), "); using the default",
+            " \"pseudobma\". Use ?amend to set the method explicitly.")
+    methods_in <- NULL
+  }
+  loo_controls <- list(fitting = list(),
+                       weights = weights_controls(methods_in))
+  out <- expand_manec(mod_fits, formulas, loo_controls = loo_controls)
   if (length(out) == 1) {
     x
   } else {
@@ -50,6 +75,9 @@ c.bnecfit <- function(x, ...) {
 #' "Add" multiple \code{\link{bnecfit}} objects into one single
 #' \code{\link{bayesmanecfit}} object containing Bayesian model averaging
 #' statistics.
+#'
+#' @details Shares the implementation of \code{\link[base]{c}}, including how
+#' the weighting method of the combined set is decided.
 #'
 #' @param e1 An object of class \code{\link{bnecfit}}.
 #' @param e2 An object of class \code{\link{bnecfit}}.
@@ -147,7 +175,18 @@ update.bnecfit <- function(object, newdata = NULL, recompile = NULL,
   # bnec_record() then returned NULL for a fit this version had recorded --
   # which is the one thing the documented NULL is supposed to rule out.
   bnec_rec <- attr(object, "bnec_record")
+  # Read here for the same reason as the record above, and used only where the
+  # caller named no loo_controls of their own. update() refits an existing set;
+  # it is not a request to reweight it, so the method the set was built with is
+  # the one it keeps. Without this the method was whatever loo defaulted to,
+  # so a set the caller had asked to weight by stacking came back weighted by
+  # something else. See #320.
+  old_method <- fit_weights_method(object)
   object <- recover_prebayesnecfit(object)
+  if (missing(loo_controls)) {
+    loo_controls <- list(fitting = list(),
+                         weights = weights_controls(old_method))
+  }
   dot_args <- list(...)
   # The family is validated at this entry point rather than forwarded untouched
   # to brms::update(). Beta() and Beta(link = "logit") produce identical family

--- a/R/bnecfit-methods.R
+++ b/R/bnecfit-methods.R
@@ -5,11 +5,11 @@
 #' @details The combined set is weighted by the method the objects being
 #' combined were weighted by, where every input that records one names the same
 #' method. Where none records a method --- combining two
-#' \code{\link{bayesnecfit}} objects, for instance --- or where two inputs
-#' disagree, the \pkg{bayesnec} default of "pseudobma" is used and the
-#' disagreement is reported. \code{\link[base]{c}} takes no
-#' \code{loo_controls} argument; use \code{\link{amend}} to set the
-#' weighting method explicitly.
+#' \code{\link{bayesnecfit}} objects, for instance --- the \pkg{bayesnec}
+#' default of "pseudobma" is used. Where two inputs name different methods the
+#' default is used and a message reports the disagreement.
+#' \code{\link[base]{c}} takes no \code{loo_controls} argument; use
+#' \code{\link{amend}} to set the weighting method explicitly.
 #'
 #' @param x An object of class \code{\link{bnecfit}}.
 #' @param ... Additional objects of class \code{\link{bnecfit}}.
@@ -175,17 +175,30 @@ update.bnecfit <- function(object, newdata = NULL, recompile = NULL,
   # bnec_record() then returned NULL for a fit this version had recorded --
   # which is the one thing the documented NULL is supposed to rule out.
   bnec_rec <- attr(object, "bnec_record")
-  # Read here for the same reason as the record above, and used only where the
-  # caller named no loo_controls of their own. update() refits an existing set;
-  # it is not a request to reweight it, so the method the set was built with is
-  # the one it keeps. Without this the method was whatever loo defaulted to,
-  # so a set the caller had asked to weight by stacking came back weighted by
-  # something else. See #320.
+  # Read here for the same reason as the record above. update() refits an
+  # existing set; it is not a request to reweight it, so the method the set was
+  # built with is the one it keeps unless the caller names another. Without
+  # this the method was whatever loo defaulted to, so a set the caller had
+  # asked to weight by stacking came back weighted by something else. See #320.
   old_method <- fit_weights_method(object)
   object <- recover_prebayesnecfit(object)
+  # Filled in on both branches, not only where loo_controls is absent
+  # altogether: loo_controls names `fitting` and `weights` separately, so a
+  # call changing a LOO fitting argument names no method and would otherwise
+  # have the set reweighted as a side effect of asking for something else.
+  # amend_model_set() fills old_method in the same way, and the two have to
+  # agree.
   if (missing(loo_controls)) {
     loo_controls <- list(fitting = list(),
                          weights = weights_controls(old_method))
+  } else {
+    loo_controls <- validate_loo_controls(loo_controls,
+                                          object[[1]]$fit$family$family)
+    if (is.null(loo_controls$weights$method)) {
+      # Assigned into the existing list rather than replacing it, so any other
+      # loo_model_weights() argument the caller set is kept.
+      loo_controls$weights$method <- old_method
+    }
   }
   dot_args <- list(...)
   # The family is validated at this entry point rather than forwarded untouched

--- a/R/expand_classes.R
+++ b/R/expand_classes.R
@@ -293,11 +293,19 @@ expand_manec <- function(object, formula, x_range = NA, resolution = 1000,
   } else if (any(success_models %in% mod_groups$ecx) & any(success_models %in% mod_groups$nec)) {
     ne_lab <- "N(S)EC"
   }
-  if (missing(loo_controls)) {
-    loo_controls <- list(fitting = list(), weights = list())
+  # define_loo_controls() rather than validate_loo_controls(), and on both
+  # branches. Validation alone leaves `weights` empty, `method` is then NULL in
+  # the do.call() below, and loo::loo_model_weights() applies its own default of
+  # "stacking" -- so a set assembled by c(), `+`, amend() or update() was
+  # weighted by stacking while the same set fitted by bnec() was weighted by
+  # pseudo-BMA, and attr(wi, "method") recorded nothing. This is the single
+  # point every route reaches, so the default is supplied here rather than at
+  # each entry point. See #320.
+  fam_tag <- object[[1]]$fit$family$family
+  loo_controls <- if (missing(loo_controls)) {
+    define_loo_controls(family_str = fam_tag)
   } else {
-    fam_tag <- object[[1]]$fit$family$family
-    loo_controls <- validate_loo_controls(loo_controls, fam_tag)
+    define_loo_controls(loo_controls, fam_tag)
   }
   loo_w_controls <- loo_controls$weights
   for (i in seq_along(object)) {

--- a/R/expand_classes.R
+++ b/R/expand_classes.R
@@ -3,6 +3,10 @@
 #' @inheritParams bnec
 #'
 #' @param object An object of class \code{\link{prebayesnecfit}}.
+#' @param loo_controls A named \code{\link[base]{list}} whose "fitting"
+#' element holds arguments to be passed on to \code{\link[brms]{loo}}. A
+#' single model is not weighted, so a "weights" element is accepted and not
+#' read. See \code{\link{bnec}}.
 #' @param ... Further arguments to internal function.
 #'
 #' @return A \code{\link[base]{list}} of model statistical output derived from

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -639,17 +639,52 @@ retrieve_valid_family <- function(named_list, data, link_source = "none") {
   validate_family(family, link_source = link_source)
 }
 
+#' The LOO controls a model-averaged fit is built with
+#'
+#' Supplies the documented default weighting method wherever the caller has
+#' not named one. Every route that assembles a model set passes its
+#' \code{loo_controls} through here, so the method a set is weighted by depends
+#' on what was asked for rather than on which function assembled it. See #320.
+#'
+#' @param loo_controls The caller's \code{loo_controls}, which may be missing.
+#' @param family_str A \code{\link[base]{character}} string naming the family,
+#' used only by \code{validate_loo_controls()}.
+#'
+#' @return A named \code{\link[base]{list}} of two elements, whose
+#' \code{weights$method} is always set.
+#'
 #' @noRd
 define_loo_controls <- function(loo_controls, family_str) {
   if (missing(loo_controls)) {
     loo_controls <- list(fitting = list(), weights = list(method = "pseudobma"))
   } else {
     loo_controls <- validate_loo_controls(loo_controls, family_str)
-    if (!"method" %in% names(loo_controls$weights)) {
+    # is.null() rather than a name test: pull_out() and update.bnecfit() pass
+    # the method they read off the object being operated on, which is NULL for
+    # an object that recorded none. The name is then present with a NULL value,
+    # loo::loo_model_weights() resolves that through match.arg() to its own
+    # first choice of "stacking", and the caller gets stacking without having
+    # asked for it -- which is #320 reached by a second route.
+    if (is.null(loo_controls$weights$method)) {
       loo_controls$weights$method <- "pseudobma"
     }
   }
   loo_controls
+}
+
+#' \code{loo_controls$weights} for a method that may be unknown
+#'
+#' An empty list where the method is \code{NULL}, so that
+#' \code{define_loo_controls()} supplies the default rather than the
+#' caller passing \code{method = NULL} down to \code{loo}.
+#'
+#' @param method A length-1 \code{\link[base]{character}}, or \code{NULL}.
+#'
+#' @return A named \code{\link[base]{list}}, possibly empty.
+#'
+#' @noRd
+weights_controls <- function(method) {
+  if (is.null(method)) list() else list(method = method)
 }
 
 #' @noRd

--- a/R/pull_out.R
+++ b/R/pull_out.R
@@ -44,9 +44,15 @@ pull_out <- function(manec, model, loo_controls, ...) {
   if (length(model) > 1) {
     stop("Argument model can only take one value. See ?pull_out and ?models.")
   }
-  old_method <- attributes(manec$mod_stats$wi)$method
+  old_method <- fit_weights_method(manec)
+  # weights_controls() rather than list(method = old_method): a set that
+  # recorded no method -- one assembled by c() before #320, or one whose
+  # attribute was dropped by row-subsetting -- gave method = NULL, which
+  # loo::loo_model_weights() resolves to stacking. An unknown method is left
+  # for define_loo_controls() to fill with the documented default instead.
   if (missing(loo_controls)) {
-    loo_controls <- list(fitting = list(), weights = list(method = old_method))
+    loo_controls <- list(fitting = list(),
+                         weights = weights_controls(old_method))
   } else {
     fam_tag <- pull_brmsfit(pull_out(manec, model = names(manec$mod_fits[1])))$family$family
     loo_controls <- validate_loo_controls(loo_controls, fam_tag)
@@ -55,7 +61,7 @@ pull_out <- function(manec, model, loo_controls, ...) {
               "this is ignored in pull_out. Use function ?amend first if your",
               "intention is to modify the model averaging specs.")
     }
-    loo_controls$weights <- list(method = old_method)
+    loo_controls$weights <- weights_controls(old_method)
   }
   existing <- names(manec$mod_fits)
   msets <- names(mod_groups)

--- a/man/amend.Rd
+++ b/man/amend.Rd
@@ -37,11 +37,9 @@ containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 (via "fitting") or to \code{\link[loo]{loo_model_weights}} (via "weights").
 If no \code{method} is named in "weights", \pkg{bayesnec} sets the
 \code{method} argument of \code{\link[loo]{loo_model_weights}} to
-"pseudobma". This applies to every route that assembles a model set, not
-only to \code{\link{bnec}}: \code{\link{amend}}, \code{\link{pull_out}}
-and \code{update} preserve the method the set being operated on was built
-with, and \code{\link[base]{c}} and \code{+} inherit it where the objects
-being combined agree, falling back to "pseudobma" otherwise. See
+"pseudobma", whichever function assembles the model set. A function that
+operates on an existing set instead keeps the method that set was built
+with, unless the caller names another. See
 ?\code{\link[loo]{loo_model_weights}} for further info.}
 
 \item{x_range}{A range of predictor values over which to consider extracting

--- a/man/amend.Rd
+++ b/man/amend.Rd
@@ -38,11 +38,13 @@ containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 If no \code{method} is named in "weights", \pkg{bayesnec} sets the
 \code{method} argument of \code{\link[loo]{loo_model_weights}} to
 "pseudobma", whichever function assembles the model set.
-\code{\link{amend}}, \code{update} and \code{\link[base]{c}} operate on
-an existing set and keep the method that set was built with, unless the
-caller names another. \code{\link{pull_out}} takes no weighting method at
-all: it reports and ignores one given in "weights" and always keeps the
-set's own. See ?\code{\link[loo]{loo_model_weights}} for further info.}
+\code{\link{amend}} and \code{update} operate on an existing set and keep
+the method that set was built with, unless the caller names another.
+\code{\link{pull_out}} takes no weighting method at all: it reports and
+ignores one given in "weights" and always keeps the set's own.
+\code{\link[base]{c}} and \code{+} take no \code{loo_controls} argument;
+see \code{\link{c.bnecfit}} for how they decide the method. See
+?\code{\link[loo]{loo_model_weights}} for further info.}
 
 \item{x_range}{A range of predictor values over which to consider extracting
 ECx.}

--- a/man/amend.Rd
+++ b/man/amend.Rd
@@ -37,10 +37,12 @@ containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 (via "fitting") or to \code{\link[loo]{loo_model_weights}} (via "weights").
 If no \code{method} is named in "weights", \pkg{bayesnec} sets the
 \code{method} argument of \code{\link[loo]{loo_model_weights}} to
-"pseudobma", whichever function assembles the model set. A function that
-operates on an existing set instead keeps the method that set was built
-with, unless the caller names another. See
-?\code{\link[loo]{loo_model_weights}} for further info.}
+"pseudobma", whichever function assembles the model set.
+\code{\link{amend}}, \code{update} and \code{\link[base]{c}} operate on
+an existing set and keep the method that set was built with, unless the
+caller names another. \code{\link{pull_out}} takes no weighting method at
+all: it reports and ignores one given in "weights" and always keeps the
+set's own. See ?\code{\link[loo]{loo_model_weights}} for further info.}
 
 \item{x_range}{A range of predictor values over which to consider extracting
 ECx.}

--- a/man/amend.Rd
+++ b/man/amend.Rd
@@ -35,10 +35,14 @@ model types you which to include to the modified fit. Adding models to a
 ("fitting" and/or "weights"), each being a named \code{\link[base]{list}}
 containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 (via "fitting") or to \code{\link[loo]{loo_model_weights}} (via "weights").
-If "weights" is
-not provided by the user, \code{\link{bnec}} will set the default
-\code{method} argument in \code{\link[loo]{loo_model_weights}} to
-"pseudobma". See ?\code{\link[loo]{loo_model_weights}} for further info.}
+If no \code{method} is named in "weights", \pkg{bayesnec} sets the
+\code{method} argument of \code{\link[loo]{loo_model_weights}} to
+"pseudobma". This applies to every route that assembles a model set, not
+only to \code{\link{bnec}}: \code{\link{amend}}, \code{\link{pull_out}}
+and \code{update} preserve the method the set being operated on was built
+with, and \code{\link[base]{c}} and \code{+} inherit it where the objects
+being combined agree, falling back to "pseudobma" otherwise. See
+?\code{\link[loo]{loo_model_weights}} for further info.}
 
 \item{x_range}{A range of predictor values over which to consider extracting
 ECx.}

--- a/man/amend.bayesnechurdlefit.Rd
+++ b/man/amend.bayesnechurdlefit.Rd
@@ -37,11 +37,13 @@ containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 If no \code{method} is named in "weights", \pkg{bayesnec} sets the
 \code{method} argument of \code{\link[loo]{loo_model_weights}} to
 "pseudobma", whichever function assembles the model set.
-\code{\link{amend}}, \code{update} and \code{\link[base]{c}} operate on
-an existing set and keep the method that set was built with, unless the
-caller names another. \code{\link{pull_out}} takes no weighting method at
-all: it reports and ignores one given in "weights" and always keeps the
-set's own. See ?\code{\link[loo]{loo_model_weights}} for further info.}
+\code{\link{amend}} and \code{update} operate on an existing set and keep
+the method that set was built with, unless the caller names another.
+\code{\link{pull_out}} takes no weighting method at all: it reports and
+ignores one given in "weights" and always keeps the set's own.
+\code{\link[base]{c}} and \code{+} take no \code{loo_controls} argument;
+see \code{\link{c.bnecfit}} for how they decide the method. See
+?\code{\link[loo]{loo_model_weights}} for further info.}
 
 \item{x_range}{A range of predictor values over which to consider extracting
 ECx.}

--- a/man/amend.bayesnechurdlefit.Rd
+++ b/man/amend.bayesnechurdlefit.Rd
@@ -36,10 +36,12 @@ containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 (via "fitting") or to \code{\link[loo]{loo_model_weights}} (via "weights").
 If no \code{method} is named in "weights", \pkg{bayesnec} sets the
 \code{method} argument of \code{\link[loo]{loo_model_weights}} to
-"pseudobma", whichever function assembles the model set. A function that
-operates on an existing set instead keeps the method that set was built
-with, unless the caller names another. See
-?\code{\link[loo]{loo_model_weights}} for further info.}
+"pseudobma", whichever function assembles the model set.
+\code{\link{amend}}, \code{update} and \code{\link[base]{c}} operate on
+an existing set and keep the method that set was built with, unless the
+caller names another. \code{\link{pull_out}} takes no weighting method at
+all: it reports and ignores one given in "weights" and always keeps the
+set's own. See ?\code{\link[loo]{loo_model_weights}} for further info.}
 
 \item{x_range}{A range of predictor values over which to consider extracting
 ECx.}

--- a/man/amend.bayesnechurdlefit.Rd
+++ b/man/amend.bayesnechurdlefit.Rd
@@ -36,11 +36,9 @@ containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 (via "fitting") or to \code{\link[loo]{loo_model_weights}} (via "weights").
 If no \code{method} is named in "weights", \pkg{bayesnec} sets the
 \code{method} argument of \code{\link[loo]{loo_model_weights}} to
-"pseudobma". This applies to every route that assembles a model set, not
-only to \code{\link{bnec}}: \code{\link{amend}}, \code{\link{pull_out}}
-and \code{update} preserve the method the set being operated on was built
-with, and \code{\link[base]{c}} and \code{+} inherit it where the objects
-being combined agree, falling back to "pseudobma" otherwise. See
+"pseudobma", whichever function assembles the model set. A function that
+operates on an existing set instead keeps the method that set was built
+with, unless the caller names another. See
 ?\code{\link[loo]{loo_model_weights}} for further info.}
 
 \item{x_range}{A range of predictor values over which to consider extracting

--- a/man/amend.bayesnechurdlefit.Rd
+++ b/man/amend.bayesnechurdlefit.Rd
@@ -34,10 +34,14 @@ model types you which to include to the modified fit. Adding models to a
 ("fitting" and/or "weights"), each being a named \code{\link[base]{list}}
 containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 (via "fitting") or to \code{\link[loo]{loo_model_weights}} (via "weights").
-If "weights" is
-not provided by the user, \code{\link{bnec}} will set the default
-\code{method} argument in \code{\link[loo]{loo_model_weights}} to
-"pseudobma". See ?\code{\link[loo]{loo_model_weights}} for further info.}
+If no \code{method} is named in "weights", \pkg{bayesnec} sets the
+\code{method} argument of \code{\link[loo]{loo_model_weights}} to
+"pseudobma". This applies to every route that assembles a model set, not
+only to \code{\link{bnec}}: \code{\link{amend}}, \code{\link{pull_out}}
+and \code{update} preserve the method the set being operated on was built
+with, and \code{\link[base]{c}} and \code{+} inherit it where the objects
+being combined agree, falling back to "pseudobma" otherwise. See
+?\code{\link[loo]{loo_model_weights}} for further info.}
 
 \item{x_range}{A range of predictor values over which to consider extracting
 ECx.}

--- a/man/bnec.Rd
+++ b/man/bnec.Rd
@@ -56,11 +56,9 @@ containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 (via "fitting") or to \code{\link[loo]{loo_model_weights}} (via "weights").
 If no \code{method} is named in "weights", \pkg{bayesnec} sets the
 \code{method} argument of \code{\link[loo]{loo_model_weights}} to
-"pseudobma". This applies to every route that assembles a model set, not
-only to \code{\link{bnec}}: \code{\link{amend}}, \code{\link{pull_out}}
-and \code{update} preserve the method the set being operated on was built
-with, and \code{\link[base]{c}} and \code{+} inherit it where the objects
-being combined agree, falling back to "pseudobma" otherwise. See
+"pseudobma", whichever function assembles the model set. A function that
+operates on an existing set instead keeps the method that set was built
+with, unless the caller names another. See
 ?\code{\link[loo]{loo_model_weights}} for further info.}
 
 \item{x_var}{Removed in version 2.0. Use formula instead. Used to be a

--- a/man/bnec.Rd
+++ b/man/bnec.Rd
@@ -56,10 +56,12 @@ containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 (via "fitting") or to \code{\link[loo]{loo_model_weights}} (via "weights").
 If no \code{method} is named in "weights", \pkg{bayesnec} sets the
 \code{method} argument of \code{\link[loo]{loo_model_weights}} to
-"pseudobma", whichever function assembles the model set. A function that
-operates on an existing set instead keeps the method that set was built
-with, unless the caller names another. See
-?\code{\link[loo]{loo_model_weights}} for further info.}
+"pseudobma", whichever function assembles the model set.
+\code{\link{amend}}, \code{update} and \code{\link[base]{c}} operate on
+an existing set and keep the method that set was built with, unless the
+caller names another. \code{\link{pull_out}} takes no weighting method at
+all: it reports and ignores one given in "weights" and always keeps the
+set's own. See ?\code{\link[loo]{loo_model_weights}} for further info.}
 
 \item{x_var}{Removed in version 2.0. Use formula instead. Used to be a
 \code{\link[base]{character}} indicating the column heading

--- a/man/bnec.Rd
+++ b/man/bnec.Rd
@@ -54,10 +54,14 @@ interpolated NOEC value from smooth ECx curves.}
 ("fitting" and/or "weights"), each being a named \code{\link[base]{list}}
 containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 (via "fitting") or to \code{\link[loo]{loo_model_weights}} (via "weights").
-If "weights" is
-not provided by the user, \code{\link{bnec}} will set the default
-\code{method} argument in \code{\link[loo]{loo_model_weights}} to
-"pseudobma". See ?\code{\link[loo]{loo_model_weights}} for further info.}
+If no \code{method} is named in "weights", \pkg{bayesnec} sets the
+\code{method} argument of \code{\link[loo]{loo_model_weights}} to
+"pseudobma". This applies to every route that assembles a model set, not
+only to \code{\link{bnec}}: \code{\link{amend}}, \code{\link{pull_out}}
+and \code{update} preserve the method the set being operated on was built
+with, and \code{\link[base]{c}} and \code{+} inherit it where the objects
+being combined agree, falling back to "pseudobma" otherwise. See
+?\code{\link[loo]{loo_model_weights}} for further info.}
 
 \item{x_var}{Removed in version 2.0. Use formula instead. Used to be a
 \code{\link[base]{character}} indicating the column heading

--- a/man/bnec.Rd
+++ b/man/bnec.Rd
@@ -57,11 +57,13 @@ containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 If no \code{method} is named in "weights", \pkg{bayesnec} sets the
 \code{method} argument of \code{\link[loo]{loo_model_weights}} to
 "pseudobma", whichever function assembles the model set.
-\code{\link{amend}}, \code{update} and \code{\link[base]{c}} operate on
-an existing set and keep the method that set was built with, unless the
-caller names another. \code{\link{pull_out}} takes no weighting method at
-all: it reports and ignores one given in "weights" and always keeps the
-set's own. See ?\code{\link[loo]{loo_model_weights}} for further info.}
+\code{\link{amend}} and \code{update} operate on an existing set and keep
+the method that set was built with, unless the caller names another.
+\code{\link{pull_out}} takes no weighting method at all: it reports and
+ignores one given in "weights" and always keeps the set's own.
+\code{\link[base]{c}} and \code{+} take no \code{loo_controls} argument;
+see \code{\link{c.bnecfit}} for how they decide the method. See
+?\code{\link[loo]{loo_model_weights}} for further info.}
 
 \item{x_var}{Removed in version 2.0. Use formula instead. Used to be a
 \code{\link[base]{character}} indicating the column heading

--- a/man/c.bnecfit.Rd
+++ b/man/c.bnecfit.Rd
@@ -21,6 +21,16 @@ Concatenate multiple \code{\link{bnecfit}} objects into one single
 \code{\link{bayesmanecfit}} object containing Bayesian model averaging
 statistics.
 }
+\details{
+The combined set is weighted by the method the objects being
+combined were weighted by, where every input that records one names the same
+method. Where none records a method --- combining two
+\code{\link{bayesnecfit}} objects, for instance --- or where two inputs
+disagree, the \pkg{bayesnec} default of "pseudobma" is used and the
+disagreement is reported. \code{\link[base]{c}} takes no
+\code{loo_controls} argument; use \code{\link{amend}} to set the
+weighting method explicitly.
+}
 \examples{
 \dontrun{
 library(bayesnec)

--- a/man/c.bnecfit.Rd
+++ b/man/c.bnecfit.Rd
@@ -25,11 +25,11 @@ statistics.
 The combined set is weighted by the method the objects being
 combined were weighted by, where every input that records one names the same
 method. Where none records a method --- combining two
-\code{\link{bayesnecfit}} objects, for instance --- or where two inputs
-disagree, the \pkg{bayesnec} default of "pseudobma" is used and the
-disagreement is reported. \code{\link[base]{c}} takes no
-\code{loo_controls} argument; use \code{\link{amend}} to set the
-weighting method explicitly.
+\code{\link{bayesnecfit}} objects, for instance --- the \pkg{bayesnec}
+default of "pseudobma" is used. Where two inputs name different methods the
+default is used and a message reports the disagreement.
+\code{\link[base]{c}} takes no \code{loo_controls} argument; use
+\code{\link{amend}} to set the weighting method explicitly.
 }
 \examples{
 \dontrun{

--- a/man/expand_manec.Rd
+++ b/man/expand_manec.Rd
@@ -40,10 +40,14 @@ interpolated NOEC value from smooth ECx curves.}
 ("fitting" and/or "weights"), each being a named \code{\link[base]{list}}
 containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 (via "fitting") or to \code{\link[loo]{loo_model_weights}} (via "weights").
-If "weights" is
-not provided by the user, \code{\link{bnec}} will set the default
-\code{method} argument in \code{\link[loo]{loo_model_weights}} to
-"pseudobma". See ?\code{\link[loo]{loo_model_weights}} for further info.}
+If no \code{method} is named in "weights", \pkg{bayesnec} sets the
+\code{method} argument of \code{\link[loo]{loo_model_weights}} to
+"pseudobma". This applies to every route that assembles a model set, not
+only to \code{\link{bnec}}: \code{\link{amend}}, \code{\link{pull_out}}
+and \code{update} preserve the method the set being operated on was built
+with, and \code{\link[base]{c}} and \code{+} inherit it where the objects
+being combined agree, falling back to "pseudobma" otherwise. See
+?\code{\link[loo]{loo_model_weights}} for further info.}
 }
 \value{
 A \code{\link[base]{list}} of model statistical output derived from

--- a/man/expand_manec.Rd
+++ b/man/expand_manec.Rd
@@ -43,11 +43,13 @@ containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 If no \code{method} is named in "weights", \pkg{bayesnec} sets the
 \code{method} argument of \code{\link[loo]{loo_model_weights}} to
 "pseudobma", whichever function assembles the model set.
-\code{\link{amend}}, \code{update} and \code{\link[base]{c}} operate on
-an existing set and keep the method that set was built with, unless the
-caller names another. \code{\link{pull_out}} takes no weighting method at
-all: it reports and ignores one given in "weights" and always keeps the
-set's own. See ?\code{\link[loo]{loo_model_weights}} for further info.}
+\code{\link{amend}} and \code{update} operate on an existing set and keep
+the method that set was built with, unless the caller names another.
+\code{\link{pull_out}} takes no weighting method at all: it reports and
+ignores one given in "weights" and always keeps the set's own.
+\code{\link[base]{c}} and \code{+} take no \code{loo_controls} argument;
+see \code{\link{c.bnecfit}} for how they decide the method. See
+?\code{\link[loo]{loo_model_weights}} for further info.}
 }
 \value{
 A \code{\link[base]{list}} of model statistical output derived from

--- a/man/expand_manec.Rd
+++ b/man/expand_manec.Rd
@@ -42,10 +42,12 @@ containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 (via "fitting") or to \code{\link[loo]{loo_model_weights}} (via "weights").
 If no \code{method} is named in "weights", \pkg{bayesnec} sets the
 \code{method} argument of \code{\link[loo]{loo_model_weights}} to
-"pseudobma", whichever function assembles the model set. A function that
-operates on an existing set instead keeps the method that set was built
-with, unless the caller names another. See
-?\code{\link[loo]{loo_model_weights}} for further info.}
+"pseudobma", whichever function assembles the model set.
+\code{\link{amend}}, \code{update} and \code{\link[base]{c}} operate on
+an existing set and keep the method that set was built with, unless the
+caller names another. \code{\link{pull_out}} takes no weighting method at
+all: it reports and ignores one given in "weights" and always keeps the
+set's own. See ?\code{\link[loo]{loo_model_weights}} for further info.}
 }
 \value{
 A \code{\link[base]{list}} of model statistical output derived from

--- a/man/expand_manec.Rd
+++ b/man/expand_manec.Rd
@@ -42,11 +42,9 @@ containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 (via "fitting") or to \code{\link[loo]{loo_model_weights}} (via "weights").
 If no \code{method} is named in "weights", \pkg{bayesnec} sets the
 \code{method} argument of \code{\link[loo]{loo_model_weights}} to
-"pseudobma". This applies to every route that assembles a model set, not
-only to \code{\link{bnec}}: \code{\link{amend}}, \code{\link{pull_out}}
-and \code{update} preserve the method the set being operated on was built
-with, and \code{\link[base]{c}} and \code{+} inherit it where the objects
-being combined agree, falling back to "pseudobma" otherwise. See
+"pseudobma", whichever function assembles the model set. A function that
+operates on an existing set instead keeps the method that set was built
+with, unless the caller names another. See
 ?\code{\link[loo]{loo_model_weights}} for further info.}
 }
 \value{

--- a/man/expand_nec.Rd
+++ b/man/expand_nec.Rd
@@ -39,11 +39,9 @@ containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 (via "fitting") or to \code{\link[loo]{loo_model_weights}} (via "weights").
 If no \code{method} is named in "weights", \pkg{bayesnec} sets the
 \code{method} argument of \code{\link[loo]{loo_model_weights}} to
-"pseudobma". This applies to every route that assembles a model set, not
-only to \code{\link{bnec}}: \code{\link{amend}}, \code{\link{pull_out}}
-and \code{update} preserve the method the set being operated on was built
-with, and \code{\link[base]{c}} and \code{+} inherit it where the objects
-being combined agree, falling back to "pseudobma" otherwise. See
+"pseudobma", whichever function assembles the model set. A function that
+operates on an existing set instead keeps the method that set was built
+with, unless the caller names another. See
 ?\code{\link[loo]{loo_model_weights}} for further info.}
 
 \item{...}{Further arguments to internal function.}

--- a/man/expand_nec.Rd
+++ b/man/expand_nec.Rd
@@ -33,16 +33,10 @@ significance of the predicted posterior values against the lowest observed
 concentration (assumed to be the control), to estimate NEC as an
 interpolated NOEC value from smooth ECx curves.}
 
-\item{loo_controls}{A named \code{\link[base]{list}} of two elements
-("fitting" and/or "weights"), each being a named \code{\link[base]{list}}
-containing the desired arguments to be passed on to \code{\link[brms]{loo}}
-(via "fitting") or to \code{\link[loo]{loo_model_weights}} (via "weights").
-If no \code{method} is named in "weights", \pkg{bayesnec} sets the
-\code{method} argument of \code{\link[loo]{loo_model_weights}} to
-"pseudobma", whichever function assembles the model set. A function that
-operates on an existing set instead keeps the method that set was built
-with, unless the caller names another. See
-?\code{\link[loo]{loo_model_weights}} for further info.}
+\item{loo_controls}{A named \code{\link[base]{list}} whose "fitting"
+element holds arguments to be passed on to \code{\link[brms]{loo}}. A
+single model is not weighted, so a "weights" element is accepted and not
+read. See \code{\link{bnec}}.}
 
 \item{...}{Further arguments to internal function.}
 }

--- a/man/expand_nec.Rd
+++ b/man/expand_nec.Rd
@@ -37,10 +37,14 @@ interpolated NOEC value from smooth ECx curves.}
 ("fitting" and/or "weights"), each being a named \code{\link[base]{list}}
 containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 (via "fitting") or to \code{\link[loo]{loo_model_weights}} (via "weights").
-If "weights" is
-not provided by the user, \code{\link{bnec}} will set the default
-\code{method} argument in \code{\link[loo]{loo_model_weights}} to
-"pseudobma". See ?\code{\link[loo]{loo_model_weights}} for further info.}
+If no \code{method} is named in "weights", \pkg{bayesnec} sets the
+\code{method} argument of \code{\link[loo]{loo_model_weights}} to
+"pseudobma". This applies to every route that assembles a model set, not
+only to \code{\link{bnec}}: \code{\link{amend}}, \code{\link{pull_out}}
+and \code{update} preserve the method the set being operated on was built
+with, and \code{\link[base]{c}} and \code{+} inherit it where the objects
+being combined agree, falling back to "pseudobma" otherwise. See
+?\code{\link[loo]{loo_model_weights}} for further info.}
 
 \item{...}{Further arguments to internal function.}
 }

--- a/man/plus-.bnecfit.Rd
+++ b/man/plus-.bnecfit.Rd
@@ -21,6 +21,10 @@ An object of class \code{\link{bayesmanecfit}}.
 \code{\link{bayesmanecfit}} object containing Bayesian model averaging
 statistics.
 }
+\details{
+Shares the implementation of \code{\link[base]{c}}, including how
+the weighting method of the combined set is decided.
+}
 \examples{
 \dontrun{
 library(bayesnec)

--- a/man/pull_out.Rd
+++ b/man/pull_out.Rd
@@ -20,11 +20,13 @@ containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 If no \code{method} is named in "weights", \pkg{bayesnec} sets the
 \code{method} argument of \code{\link[loo]{loo_model_weights}} to
 "pseudobma", whichever function assembles the model set.
-\code{\link{amend}}, \code{update} and \code{\link[base]{c}} operate on
-an existing set and keep the method that set was built with, unless the
-caller names another. \code{\link{pull_out}} takes no weighting method at
-all: it reports and ignores one given in "weights" and always keeps the
-set's own. See ?\code{\link[loo]{loo_model_weights}} for further info.}
+\code{\link{amend}} and \code{update} operate on an existing set and keep
+the method that set was built with, unless the caller names another.
+\code{\link{pull_out}} takes no weighting method at all: it reports and
+ignores one given in "weights" and always keeps the set's own.
+\code{\link[base]{c}} and \code{+} take no \code{loo_controls} argument;
+see \code{\link{c.bnecfit}} for how they decide the method. See
+?\code{\link[loo]{loo_model_weights}} for further info.}
 
 \item{...}{Additional arguments to \code{\link{expand_nec}} or
 \code{\link{expand_manec}}.}

--- a/man/pull_out.Rd
+++ b/man/pull_out.Rd
@@ -17,10 +17,14 @@ which model or suite of models to pull out.}
 ("fitting" and/or "weights"), each being a named \code{\link[base]{list}}
 containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 (via "fitting") or to \code{\link[loo]{loo_model_weights}} (via "weights").
-If "weights" is
-not provided by the user, \code{\link{bnec}} will set the default
-\code{method} argument in \code{\link[loo]{loo_model_weights}} to
-"pseudobma". See ?\code{\link[loo]{loo_model_weights}} for further info.}
+If no \code{method} is named in "weights", \pkg{bayesnec} sets the
+\code{method} argument of \code{\link[loo]{loo_model_weights}} to
+"pseudobma". This applies to every route that assembles a model set, not
+only to \code{\link{bnec}}: \code{\link{amend}}, \code{\link{pull_out}}
+and \code{update} preserve the method the set being operated on was built
+with, and \code{\link[base]{c}} and \code{+} inherit it where the objects
+being combined agree, falling back to "pseudobma" otherwise. See
+?\code{\link[loo]{loo_model_weights}} for further info.}
 
 \item{...}{Additional arguments to \code{\link{expand_nec}} or
 \code{\link{expand_manec}}.}

--- a/man/pull_out.Rd
+++ b/man/pull_out.Rd
@@ -19,10 +19,12 @@ containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 (via "fitting") or to \code{\link[loo]{loo_model_weights}} (via "weights").
 If no \code{method} is named in "weights", \pkg{bayesnec} sets the
 \code{method} argument of \code{\link[loo]{loo_model_weights}} to
-"pseudobma", whichever function assembles the model set. A function that
-operates on an existing set instead keeps the method that set was built
-with, unless the caller names another. See
-?\code{\link[loo]{loo_model_weights}} for further info.}
+"pseudobma", whichever function assembles the model set.
+\code{\link{amend}}, \code{update} and \code{\link[base]{c}} operate on
+an existing set and keep the method that set was built with, unless the
+caller names another. \code{\link{pull_out}} takes no weighting method at
+all: it reports and ignores one given in "weights" and always keeps the
+set's own. See ?\code{\link[loo]{loo_model_weights}} for further info.}
 
 \item{...}{Additional arguments to \code{\link{expand_nec}} or
 \code{\link{expand_manec}}.}

--- a/man/pull_out.Rd
+++ b/man/pull_out.Rd
@@ -19,11 +19,9 @@ containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 (via "fitting") or to \code{\link[loo]{loo_model_weights}} (via "weights").
 If no \code{method} is named in "weights", \pkg{bayesnec} sets the
 \code{method} argument of \code{\link[loo]{loo_model_weights}} to
-"pseudobma". This applies to every route that assembles a model set, not
-only to \code{\link{bnec}}: \code{\link{amend}}, \code{\link{pull_out}}
-and \code{update} preserve the method the set being operated on was built
-with, and \code{\link[base]{c}} and \code{+} inherit it where the objects
-being combined agree, falling back to "pseudobma" otherwise. See
+"pseudobma", whichever function assembles the model set. A function that
+operates on an existing set instead keeps the method that set was built
+with, unless the caller names another. See
 ?\code{\link[loo]{loo_model_weights}} for further info.}
 
 \item{...}{Additional arguments to \code{\link{expand_nec}} or

--- a/man/update.bnecfit.Rd
+++ b/man/update.bnecfit.Rd
@@ -48,10 +48,12 @@ containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 (via "fitting") or to \code{\link[loo]{loo_model_weights}} (via "weights").
 If no \code{method} is named in "weights", \pkg{bayesnec} sets the
 \code{method} argument of \code{\link[loo]{loo_model_weights}} to
-"pseudobma", whichever function assembles the model set. A function that
-operates on an existing set instead keeps the method that set was built
-with, unless the caller names another. See
-?\code{\link[loo]{loo_model_weights}} for further info.}
+"pseudobma", whichever function assembles the model set.
+\code{\link{amend}}, \code{update} and \code{\link[base]{c}} operate on
+an existing set and keep the method that set was built with, unless the
+caller names another. \code{\link{pull_out}} takes no weighting method at
+all: it reports and ignores one given in "weights" and always keeps the
+set's own. See ?\code{\link[loo]{loo_model_weights}} for further info.}
 
 \item{force_fit}{Should model truly be updated in case either
 \code{newdata} of a new family is provided?}

--- a/man/update.bnecfit.Rd
+++ b/man/update.bnecfit.Rd
@@ -49,11 +49,13 @@ containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 If no \code{method} is named in "weights", \pkg{bayesnec} sets the
 \code{method} argument of \code{\link[loo]{loo_model_weights}} to
 "pseudobma", whichever function assembles the model set.
-\code{\link{amend}}, \code{update} and \code{\link[base]{c}} operate on
-an existing set and keep the method that set was built with, unless the
-caller names another. \code{\link{pull_out}} takes no weighting method at
-all: it reports and ignores one given in "weights" and always keeps the
-set's own. See ?\code{\link[loo]{loo_model_weights}} for further info.}
+\code{\link{amend}} and \code{update} operate on an existing set and keep
+the method that set was built with, unless the caller names another.
+\code{\link{pull_out}} takes no weighting method at all: it reports and
+ignores one given in "weights" and always keeps the set's own.
+\code{\link[base]{c}} and \code{+} take no \code{loo_controls} argument;
+see \code{\link{c.bnecfit}} for how they decide the method. See
+?\code{\link[loo]{loo_model_weights}} for further info.}
 
 \item{force_fit}{Should model truly be updated in case either
 \code{newdata} of a new family is provided?}

--- a/man/update.bnecfit.Rd
+++ b/man/update.bnecfit.Rd
@@ -46,10 +46,14 @@ interpolated NOEC value from smooth ECx curves.}
 ("fitting" and/or "weights"), each being a named \code{\link[base]{list}}
 containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 (via "fitting") or to \code{\link[loo]{loo_model_weights}} (via "weights").
-If "weights" is
-not provided by the user, \code{\link{bnec}} will set the default
-\code{method} argument in \code{\link[loo]{loo_model_weights}} to
-"pseudobma". See ?\code{\link[loo]{loo_model_weights}} for further info.}
+If no \code{method} is named in "weights", \pkg{bayesnec} sets the
+\code{method} argument of \code{\link[loo]{loo_model_weights}} to
+"pseudobma". This applies to every route that assembles a model set, not
+only to \code{\link{bnec}}: \code{\link{amend}}, \code{\link{pull_out}}
+and \code{update} preserve the method the set being operated on was built
+with, and \code{\link[base]{c}} and \code{+} inherit it where the objects
+being combined agree, falling back to "pseudobma" otherwise. See
+?\code{\link[loo]{loo_model_weights}} for further info.}
 
 \item{force_fit}{Should model truly be updated in case either
 \code{newdata} of a new family is provided?}

--- a/man/update.bnecfit.Rd
+++ b/man/update.bnecfit.Rd
@@ -48,11 +48,9 @@ containing the desired arguments to be passed on to \code{\link[brms]{loo}}
 (via "fitting") or to \code{\link[loo]{loo_model_weights}} (via "weights").
 If no \code{method} is named in "weights", \pkg{bayesnec} sets the
 \code{method} argument of \code{\link[loo]{loo_model_weights}} to
-"pseudobma". This applies to every route that assembles a model set, not
-only to \code{\link{bnec}}: \code{\link{amend}}, \code{\link{pull_out}}
-and \code{update} preserve the method the set being operated on was built
-with, and \code{\link[base]{c}} and \code{+} inherit it where the objects
-being combined agree, falling back to "pseudobma" otherwise. See
+"pseudobma", whichever function assembles the model set. A function that
+operates on an existing set instead keeps the method that set was built
+with, unless the caller names another. See
 ?\code{\link[loo]{loo_model_weights}} for further info.}
 
 \item{force_fit}{Should model truly be updated in case either

--- a/tests/testthat/test-amend.R
+++ b/tests/testthat/test-amend.R
@@ -90,3 +90,19 @@ test_that("amend.bayesnecfit adds models and promotes to bayesmanecfit", {
   expect_identical(fixef(added$mod_fits$nec4param$fit),
                    fixef(nec4param$fit))
 })
+
+test_that("an object that records no weighting method gets the default", {
+  if (Sys.getenv("NOT_CRAN") == "") {
+    skip_on_cran()
+  }
+  # The shape of a set assembled by c() before #320, and of any set whose
+  # attribute was dropped by row-subsetting of mod_stats. amend() preserves the
+  # method the set was built with, and an unknown method used to be preserved
+  # as NULL, which loo::loo_model_weights() resolves to stacking.
+  unrecorded <- manec_example
+  attr(unrecorded$mod_stats$wi, "method") <- NULL
+  out <- amend(unrecorded, loo_controls = list(fitting = list(reloo = FALSE))) |>
+    suppressMessages() |>
+    suppressWarnings()
+  expect_equal(attr(out$mod_stats$wi, "method"), "pseudobma")
+})

--- a/tests/testthat/test-amend.R
+++ b/tests/testthat/test-amend.R
@@ -101,8 +101,22 @@ test_that("an object that records no weighting method gets the default", {
   # as NULL, which loo::loo_model_weights() resolves to stacking.
   unrecorded <- manec_example
   attr(unrecorded$mod_stats$wi, "method") <- NULL
-  out <- amend(unrecorded, loo_controls = list(fitting = list(reloo = FALSE))) |>
+  ctrl <- list(fitting = list(reloo = FALSE))
+  out <- amend(unrecorded, loo_controls = ctrl) |>
     suppressMessages() |>
     suppressWarnings()
   expect_equal(attr(out$mod_stats$wi, "method"), "pseudobma")
+  # A method named but NULL is not a request for a method. amend_model_set()
+  # read the name alone, so this reweighted the set while
+  # define_loo_controls() two calls later read the same value as unspecified.
+  stacked <- amend(manec_example,
+                   loo_controls = list(weights = list(method = "stacking"))) |>
+    suppressMessages() |>
+    suppressWarnings()
+  kept <- amend(stacked,
+                loo_controls = list(weights = list(method = NULL),
+                                    fitting = list(reloo = FALSE))) |>
+    suppressMessages() |>
+    suppressWarnings()
+  expect_equal(attr(kept$mod_stats$wi, "method"), "stacking")
 })

--- a/tests/testthat/test-bnecfit-methods.R
+++ b/tests/testthat/test-bnecfit-methods.R
@@ -282,9 +282,10 @@ test_that("update() keeps the weighting method the set was built with", {
     suppressWarnings()
   expect_equal(attr(changed$mod_stats$wi, "method"), "pseudobma")
   # loo_controls names `fitting` and `weights` separately, so a call changing a
-  # LOO fitting argument names no method. Reading that as a request to reweight
-  # made the set stacking-weighted as a side effect of asking for something
-  # else, on the route this change is about.
+  # LOO fitting argument names no method. Reading the argument's presence as a
+  # request to reweight replaced the recorded method with the default, so this
+  # call returned a pseudo-BMA-weighted set as a side effect of asking for
+  # something else.
   fitting_only <- update(stacked, recompile = FALSE,
                          loo_controls = list(fitting = list(reloo = FALSE))) |>
     suppressMessages() |>

--- a/tests/testthat/test-bnecfit-methods.R
+++ b/tests/testthat/test-bnecfit-methods.R
@@ -193,3 +193,92 @@ test_that("update returns a bayesnecfit when only one model survives", {
   expect_equal(upd$model, names(manec_example$mod_fits)[1])
   expect_error(suppressWarnings(summary(upd)), NA)
 })
+
+# The weighting method a set is built with must not depend on which function
+# assembled it. None of these tests sample: the fits are the packaged ones and
+# only the weighting is recomputed. See #320.
+
+test_that("c() and + weight by the documented default", {
+  if (Sys.getenv("NOT_CRAN") == "") {
+    skip_on_cran()
+  }
+  combined <- c(nec4param, ecx4param) |>
+    suppressMessages() |>
+    suppressWarnings()
+  # Asserted on the method rather than on the weights, which are a Bayesian
+  # bootstrap under pseudo-BMA and so differ between calls.
+  expect_equal(attr(combined$mod_stats$wi, "method"), "pseudobma")
+  expect_equal(class(combined$mod_stats$wi), "pseudobma_bb_weights")
+  # The comparison the issue is about: the same two models fitted in one bnec()
+  # call, which is what manec_example is.
+  expect_equal(attr(combined$mod_stats$wi, "method"),
+               attr(manec_example$mod_stats$wi, "method"))
+  added <- (nec4param + ecx4param) |>
+    suppressMessages() |>
+    suppressWarnings()
+  expect_equal(attr(added$mod_stats$wi, "method"), "pseudobma")
+})
+
+test_that("c() inherits an explicit weighting method from its inputs", {
+  if (Sys.getenv("NOT_CRAN") == "") {
+    skip_on_cran()
+  }
+  stacked <- amend(manec_example,
+                   loo_controls = list(weights = list(method = "stacking"))) |>
+    suppressMessages() |>
+    suppressWarnings()
+  expect_equal(attr(stacked$mod_stats$wi, "method"), "stacking")
+  # c() takes no loo_controls, so the objects being combined are the only place
+  # an explicit request can come from. Reverting to the default here would
+  # discard it silently.
+  inherited <- c(stacked, ecx4param) |>
+    suppressMessages() |>
+    suppressWarnings()
+  expect_equal(attr(inherited$mod_stats$wi, "method"), "stacking")
+  pseudo <- amend(manec_example,
+                  loo_controls = list(weights = list(method = "pseudobma"))) |>
+    suppressMessages() |>
+    suppressWarnings()
+  # Two inputs weighted differently have no answer that is right for both, so
+  # the default is used and the disagreement reported.
+  expect_message(suppressWarnings(c(stacked, pseudo)),
+                 "weighted by different methods")
+  mixed <- c(stacked, pseudo) |>
+    suppressMessages() |>
+    suppressWarnings()
+  expect_equal(attr(mixed$mod_stats$wi, "method"), "pseudobma")
+})
+
+test_that("update() keeps the weighting method the set was built with", {
+  if (Sys.getenv("NOT_CRAN") == "") {
+    skip_on_cran()
+  }
+  # The stub returns the stored fit unchanged, so update.bnecfit() runs to
+  # completion without Stan. Everything asserted here happens after the refit
+  # loop. Registered into the S3 methods table directly, and restored from it,
+  # for the reason capture_brms_update() records above.
+  tbl <- get(".__S3MethodsTable__.", envir = asNamespace("stats"))
+  orig_method <- get("update.brmsfit", envir = tbl)
+  on.exit(assign("update.brmsfit", orig_method, envir = tbl), add = TRUE)
+  assign("update.brmsfit", function(object, ...) object, envir = tbl)
+  stacked <- amend(manec_example,
+                   loo_controls = list(weights = list(method = "stacking"))) |>
+    suppressMessages() |>
+    suppressWarnings()
+  # update() refits a set; it is not a request to reweight it.
+  kept <- update(stacked, recompile = FALSE) |>
+    suppressMessages() |>
+    suppressWarnings()
+  expect_equal(attr(kept$mod_stats$wi, "method"), "stacking")
+  defaulted <- update(manec_example, recompile = FALSE) |>
+    suppressMessages() |>
+    suppressWarnings()
+  expect_equal(attr(defaulted$mod_stats$wi, "method"), "pseudobma")
+  # An explicit request still wins over what the object records.
+  changed <- update(stacked, recompile = FALSE,
+                    loo_controls = list(weights =
+                                          list(method = "pseudobma"))) |>
+    suppressMessages() |>
+    suppressWarnings()
+  expect_equal(attr(changed$mod_stats$wi, "method"), "pseudobma")
+})

--- a/tests/testthat/test-bnecfit-methods.R
+++ b/tests/testthat/test-bnecfit-methods.R
@@ -281,4 +281,23 @@ test_that("update() keeps the weighting method the set was built with", {
     suppressMessages() |>
     suppressWarnings()
   expect_equal(attr(changed$mod_stats$wi, "method"), "pseudobma")
+  # loo_controls names `fitting` and `weights` separately, so a call changing a
+  # LOO fitting argument names no method. Reading that as a request to reweight
+  # made the set stacking-weighted as a side effect of asking for something
+  # else, on the route this change is about.
+  fitting_only <- update(stacked, recompile = FALSE,
+                         loo_controls = list(fitting = list(reloo = FALSE))) |>
+    suppressMessages() |>
+    suppressWarnings()
+  expect_equal(attr(fitting_only$mod_stats$wi, "method"), "stacking")
+  # The same call on a set that records no method takes the default rather
+  # than passing method = NULL down to loo.
+  unrecorded <- manec_example
+  attr(unrecorded$mod_stats$wi, "method") <- NULL
+  defaulted_fitting <- update(unrecorded, recompile = FALSE,
+                              loo_controls =
+                                list(fitting = list(reloo = FALSE))) |>
+    suppressMessages() |>
+    suppressWarnings()
+  expect_equal(attr(defaulted_fitting$mod_stats$wi, "method"), "pseudobma")
 })

--- a/tests/testthat/test-expand_classes.R
+++ b/tests/testthat/test-expand_classes.R
@@ -141,9 +141,23 @@ test_that("new loo_controls are incorporated", {
   if (Sys.getenv("NOT_CRAN") == "") {
     skip_on_cran()
   }
+  # The default is supplied here, not only by bnec(). Absent it, `method` went
+  # to loo::loo_model_weights() as NULL, loo applied its own default of
+  # stacking, and the attribute recorded nothing -- so the weighting method
+  # depended on which function assembled the set. See #320.
   expand_manec(tt1, formulas) |>
     get_new_method() |>
-    expect_null() |>
+    expect_equal("pseudobma") |>
+    expect_message() |>
+    suppressWarnings()
+  # Named but NULL is the shape pull_out() and update.bnecfit() pass when the
+  # object they are operating on records no method. match.arg() resolves that
+  # to stacking inside loo, so it has to be caught here rather than only in the
+  # missing-argument branch.
+  expand_manec(tt1, formulas,
+               loo_controls = list(weights = list(method = NULL))) |>
+    get_new_method() |>
+    expect_equal("pseudobma") |>
     expect_message() |>
     suppressWarnings()
   my_ctrls <- list(weights = list(method = "pseudobma"))

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -295,3 +295,58 @@ test_that("to_axis_scale carries the estimate's attributes through", {
   # An unidentified draw stays NA rather than being interpolated to an endpoint.
   expect_true(is.na(to_axis_scale(c(log(50), NA), b_log, f_log, raw)[2]))
 })
+
+test_that("define_loo_controls always names a weighting method", {
+  # The documented default is pseudo-BMA. Every route that assembles a model
+  # set passes through here, so a missing method at this point is what reaches
+  # loo::loo_model_weights(), which resolves it to stacking. See #320.
+  expect_equal(bayesnec:::define_loo_controls(family_str = "gaussian"),
+               list(fitting = list(), weights = list(method = "pseudobma")))
+  expect_equal(
+    bayesnec:::define_loo_controls(list(), "gaussian")$weights$method,
+    "pseudobma"
+  )
+  expect_equal(
+    bayesnec:::define_loo_controls(list(weights = list()),
+                                   "gaussian")$weights$method,
+    "pseudobma"
+  )
+  # Named but NULL, which is what a caller preserving an unknown method used to
+  # pass. match.arg() reads that as loo's own first choice, so it is treated as
+  # unspecified rather than passed on.
+  expect_equal(
+    bayesnec:::define_loo_controls(list(weights = list(method = NULL)),
+                                   "gaussian")$weights$method,
+    "pseudobma"
+  )
+  # An explicit request is never overridden.
+  expect_equal(
+    bayesnec:::define_loo_controls(list(weights = list(method = "stacking")),
+                                   "gaussian")$weights$method,
+    "stacking"
+  )
+  # Other elements of weights survive alongside the injected method.
+  ctrl <- bayesnec:::define_loo_controls(
+    list(fitting = list(pointwise = FALSE), weights = list(BB = FALSE)),
+    "gaussian"
+  )
+  expect_equal(ctrl$weights, list(BB = FALSE, method = "pseudobma"))
+  expect_equal(ctrl$fitting, list(pointwise = FALSE))
+})
+
+test_that("weights_controls distinguishes an unknown method from a named one", {
+  expect_equal(bayesnec:::weights_controls(NULL), list())
+  expect_equal(bayesnec:::weights_controls("stacking"),
+               list(method = "stacking"))
+})
+
+test_that("fit_weights_method reads only what a fit records", {
+  expect_equal(bayesnec:::fit_weights_method(manec_example), "pseudobma")
+  # A bayesnecfit has no weights, so it records no method. NULL means unknown,
+  # not pseudo-BMA, which is why the callers pass it through
+  # weights_controls().
+  expect_null(bayesnec:::fit_weights_method(nec4param))
+  stripped <- manec_example
+  attr(stripped$mod_stats$wi, "method") <- NULL
+  expect_null(bayesnec:::fit_weights_method(stripped))
+})


### PR DESCRIPTION
## What

The weighting method of a model-averaged set no longer depends on which
function assembled it. A set built with `c()`, `+`, `amend()` or `update()`
from fits that record no method of their own is weighted by pseudo-BMA, the
documented default, as a set fitted in one `bnec()` call already was, and
`attr(mod_stats$wi, "method")` records it. Where the set being operated on does
record a method, that method is kept.

Closes #320.

## Why it matters

Weights determine the model-averaged NEC, NSEC and ECx estimates, so two
analysts fitting the same equations to the same data got different toxicity
estimates depending on whether they called `bnec()` with a model vector or
combined single fits with `c()`. Combining single fits is a documented workflow
and is how the training material introduces model averaging.

The empty `method` attribute meant an affected result could not be identified
from the fitted object after the fact.

## Evidence

`expand_manec()` called `validate_loo_controls()`, which checks the shape of
`loo_controls` and supplies nothing. With no method named, `method` reached
`loo::loo_model_weights()` as `NULL`, `match.arg()` resolved that to `loo`'s own
first choice of `"stacking"`, and the attribute was assigned `NULL`. `bnec()`
was unaffected because it calls `define_loo_controls()` before the model loop.

Measured on the two packaged `manec_example` fits pulled out and recombined
(R 4.6.1, `loo` 2.8.0, no resampling):

| Route | `attr(wi, "method")` | weight on `nec4param` |
|---|---|---|
| `bnec()`, as recorded in `manec_example` | `pseudobma` | 0.827 |
| `c(nec4param, ecx4param)` on `dev` | *(empty)* | 0.892 |
| `c(nec4param, ecx4param)` on this branch | `pseudobma` | 0.821–0.862 |

The third row is a range over twenty repeats. Pseudo-BMA uses a Bayesian
bootstrap and is not deterministic; stacking is, which is why the second row is
a single value. The range brackets the value the `bnec()` call that fitted these
two models recorded, which is the comparison the change is for.

## User-visible changes

Three behaviours differ from `dev`, and one thing this PR deliberately does not
do.

A set assembled by `c()`, `+`, `amend()` or `update()` from fits that record no
weighting method, where the caller names none either, is weighted by pseudo-BMA
rather than stacking, so its model-averaged estimates change. Every set built
before this change is of that kind on these routes, since none of them recorded
a method. Anyone who wants the previous behaviour asks
for it: `amend(fit, loo_controls = list(weights = list(method = "stacking")))`.
A second consequence is that repeated calls no longer agree with each other
unless the session sets a seed, because pseudo-BMA draws a Bayesian bootstrap
where stacking solves a fixed optimisation.

`update()` now keeps the weighting method the set was built with, unless the
caller names another. Refitting a set is not a request to reweight it, and
neither is changing a LOO fitting argument: `loo_controls` names its `fitting`
and `weights` arguments separately, so a call that names only the first names
no method. `amend()` already behaved this way.

`c()` and `+` inherit the method where every input that records one names the
same method, and report a fallback to the default where two disagree. They take
no `loo_controls` argument, so the objects being combined are the only place an
explicit request can come from.

No migration is provided for objects already saved with stacking weights. They
keep the weights they were built with; `amend()` or `update()` on one now
reweights it by pseudo-BMA, which is the correction rather than a further
defect. Re-running such a call is how an affected result is repaired, and the
method the object now records is how it can be identified.

<details>
<summary>Implementation detail</summary>

The default is supplied at `expand_manec()`, on both branches of its
`missing(loo_controls)` test, rather than at each entry point:

```r
fam_tag <- object[[1]]$fit$family$family
loo_controls <- if (missing(loo_controls)) {
  define_loo_controls(family_str = fam_tag)
} else {
  define_loo_controls(loo_controls, fam_tag)
}
```

`expand_manec()` is the only function in the package that calls
`loo_model_weights()`, so it is where the invariant can be stated once. Fixing
the four entry points separately would require four call sites to be right, and
would leave the next one to be added unprotected.

`define_loo_controls()` now tests `is.null(loo_controls$weights$method)` rather
than whether the name is present. A name present with a `NULL` value is not
hypothetical: `pull_out()` and `update()` preserve the method they read off the
object they operate on, which is `NULL` for an object that records none, and
`match.arg()` reads that as stacking. `weights_controls()` builds an empty
`weights` list for an unknown method so the default fills it, and is used by
`amend()`, `pull_out()`, `update()` and `c()`. `amend_model_set()` was reading
the name rather than the value for the same decision and now matches.

`c.bnecfit()` reads the method off its inputs with the existing
`fit_weights_method()` helper, whose documentation in `R/bnec_group.R` is
updated to record its second set of callers. `unique()` over the inputs that
record one: length 1 inherits, length 0 defaults, length greater than 1 defaults
with a message.

`update.bnecfit()` reads the method before `recover_prebayesnecfit()` replaces
`object`, for the same reason the `bnec_record` attribute is read there.
`loo_controls` names its `fitting` and `weights` arguments separately, so the
method is filled in whenever the caller names none, not only where the argument
is absent altogether: without that, changing a LOO fitting argument reweighted
the set as a side effect of asking for something else. `amend_model_set()`
already worked this way and the two now agree.

`bnec_group()` and `bnec_hurdle()` were checked. Neither reaches
`expand_manec()` directly; both fit through `bnec()`, which supplies the
default. `bnec_group()`'s own `wt_method` already defaults to `"pseudobma"`, so
the crossed-weight identity `crossed_group_weights()` checks is unaffected.

Tests assert on the recorded method, not on the weights, which are not
deterministic under pseudo-BMA. `test-bnecfit-methods.R` covers the `c()`, `+`
and `update()` routes, the inheritance of an explicit method, the disagreement
message, and the fitting-only `loo_controls` call; its `update()` tests
substitute `update.brmsfit` with one that returns the stored fit, so they reach
the weighting code without sampling, and restore it through the S3 methods
table for the reason `capture_brms_update()` records. `test-helpers.R` covers
`define_loo_controls()`, `weights_controls()` and `fit_weights_method()`
directly, including the named-but-`NULL` case. `test-amend.R` covers a set that
records no method, which is the shape of any set assembled by `c()` before this
change, and of one whose attribute was dropped by row-subsetting of
`mod_stats`. In `test-expand_classes.R` the existing `expect_null()` on the
missing-argument branch pinned the defect and is the reason it survived; it now
asserts the default.

None of these tests sample. Run with `NOT_CRAN=true`, `test-bnecfit-methods.R`,
`test-expand_classes.R`, `test-amend.R`, `test-helpers.R` and `test-pull_out.R`
pass with no failures.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAm5fjR1ZMJ2WRnvVEuu1e
